### PR TITLE
feat: add new function validateToken to check providers tokens

### DIFF
--- a/src/analysis.js
+++ b/src/analysis.js
@@ -1,6 +1,6 @@
 import {getCustom} from "./tools.js";
 
-export default { requestComponent, requestStack }
+export default { requestComponent, requestStack, validateToken }
 
 /**
  * Send a stack analysis request and get the report as 'text/html' or 'application/json'.
@@ -45,6 +45,23 @@ async function requestComponent(provider, data, url, opts = {}) {
 		body: provided.content
 	})
 	return resp.json()
+}
+
+/**
+ *
+ * @param url the backend url to send the request to
+ * @param {{}} [opts={}] - optional various options to pass headers for t he validateToken Request
+ * @return {Promise<number>} return the HTTP status Code of the response from the validate token request.
+ */
+async function validateToken(url, opts = {}) {
+	let resp = await fetch(`${url}/api/v3/token`, {
+		method: 'GET',
+		headers: {
+			// 'Accept': 'text/plain',
+			...getTokenHeaders(opts),
+		}
+	})
+	return resp.status
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import analysis from './analysis.js'
 import fs from 'node:fs'
 import {getCustom} from "./tools.js";
 
-export default { AnalysisReport, componentAnalysis, stackAnalysis }
+export default { AnalysisReport, componentAnalysis, stackAnalysis, validateToken }
 
 /**
  * @type {string} backend url to send requests to
@@ -41,4 +41,8 @@ async function stackAnalysis(manifest, html = false, opts = {}) {
 async function componentAnalysis(manifestType, data, opts = {}) {
 	let provider = match(manifestType, availableProviders) // throws error if no matching provider
 	return await analysis.requestComponent(provider, data, url, opts) // throws error request sending failed
+}
+
+async function validateToken(opts = {}) {
+	return await analysis.validateToken(url, opts) // throws error request sending failed
 }

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -265,7 +265,7 @@ function getDependencies(manifest) {
 		ignored.push({
 			groupId: dep['groupId'],
 			artifactId: dep['artifactId'],
-			version: dep['version'] ? dep['version'] : '*',
+			version: dep['version'] ? dep['version'].toString() : '*',
 			scope: '*',
 			ignore: ignore
 		})

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import fs from 'fs'
 import sinon from "sinon";
+// import exhort from "../../src/index.js"
 
 
 
@@ -27,6 +28,19 @@ suite('testing the java-maven data provider', () => {
 		"poms_deps_with_no_ignore_long"
 	].forEach(testCase => {
 		let scenario = testCase.replace('pom_deps_', '').replaceAll('_', ' ')
+		// test(`custom adhoc test`, async () => {
+		//
+		// 	let options = {
+		// 		'EXHORT_SNYK_TOKEN': 'insert-token'
+		// 	}
+		// 	let httpStatus = await exhort.validateToken(options);
+		//
+		// 	let pom = fs.readFileSync(`/tmp/exhort-maven/pom.xml`,).toString().trim()
+		// 	let analysisReport = await exhort.componentAnalysis("pom.xml", pom);
+		// 	console.log(analysisReport)
+		// 	analysisReport = await exhort.stackAnalysis(`/tmp/exhort-maven/pom.xml`,true);
+		// 	console.log(analysisReport)
+		// }).timeout(process.env.GITHUB_ACTIONS ? 30000 : 5000)
 
 		test(`verify maven data provided for stack analysis with scenario ${scenario}`, async () => {
 			// load the expected graph for the scenario


### PR DESCRIPTION
fix: fix maven artifacts' versions sometimes interpreted as integer instead of string

## Description

-  Add new function validateToken to let clients check providers' tokens , instead of calling backend directly
- Fix bug of sometimes maven artifacts' version are interpreted as numbers/integers instead of  string.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
