### PR TITLE
fix: purl of components in sbom sometimes shows [Object Object]

### DIFF
--- a/src/cyclone_dx_sbom.js
+++ b/src/cyclone_dx_sbom.js
@@ -34,7 +34,7 @@ function getComponent(component,type) {
 	}
 	else
 	{
-	    componentObject = component
+		componentObject = component
 	}
 	return componentObject
 }

--- a/src/cyclone_dx_sbom.js
+++ b/src/cyclone_dx_sbom.js
@@ -1,3 +1,5 @@
+import {PackageURL} from "packageurl-js";
+
 /**
  *
  * @param component {PackageURL}
@@ -7,25 +9,32 @@
  */
 function getComponent(component,type) {
 	let componentObject;
-	if(component.namespace) {
-		componentObject = {
-			"group": component.namespace,
-			"name": component.name,
-			"version": component.version,
-			"purl": component.toString(),
-			"type": type,
-			"bom-ref": component.toString()
+	if(component instanceof PackageURL)
+	{
+		if(component.namespace) {
+			componentObject = {
+				"group": component.namespace,
+				"name": component.name,
+				"version": component.version,
+				"purl": component.toString(),
+				"type": type,
+				"bom-ref": component.toString()
+			}
+		}
+		else
+		{
+			componentObject = {
+				"name": component.name,
+				"version": component.version,
+				"purl": component.toString(),
+				"type": type,
+				"bom-ref": component.toString()
+			}
 		}
 	}
 	else
 	{
-		componentObject = {
-			"name": component.name,
-			"version": component.version,
-			"purl": component.toString(),
-			"type": type,
-			"bom-ref": component.toString()
-		}
+	    componentObject = component
 	}
 	return componentObject
 }
@@ -76,7 +85,7 @@ export default class CycloneDxSbom {
 	}
 
 	/**
-	 * @param {Component} sourceRef current target Component ( Starting from root component by clients)
+	 * @param {component} sourceRef current target Component ( Starting from root component by clients)
 	 * @param {PackageURL} targetRef current dependency to add to Dependencies list of component sourceRef
 	 * @return Sbom
 	 */
@@ -139,7 +148,7 @@ export default class CycloneDxSbom {
 
 	/**
 	 *
-	 * @param {Component} theComponent - Component Object with purl field.
+	 * @param {component} theComponent - Component Object with purl field.
 	 * @return {int} index of the found component entry, if not found returns -1.
 	 * @private
 	 */

--- a/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
@@ -1191,85 +1191,20 @@
 			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
 		},
 		{
+			"group": "github.com/kr",
 			"name": "pretty",
 			"version": "v0.2.0",
-			"purl": "[object Object]",
+			"purl": "pkg:golang/github.com/kr/pretty@v0.2.0",
 			"type": "library",
-			"bom-ref": "[object Object]"
+			"bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.0"
 		},
 		{
+			"group": "github.com/stoewer",
 			"name": "go-strcase",
 			"version": "v1.2.0",
-			"purl": "[object Object]",
+			"purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
 			"type": "library",
-			"bom-ref": "[object Object]"
-		},
-		{
-			"name": "tools",
-			"version": "v0.0.0-20190524140312-2c0ae7006135",
-			"purl": "[object Object]",
-			"type": "library",
-			"bom-ref": "[object Object]"
-		},
-		{
-			"group": "golang.org/x",
-			"name": "net",
-			"version": "v0.0.0-20190311183353-d8887717615a",
-			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
-			"type": "library",
-			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a"
-		},
-		{
-			"name": "tools",
-			"version": "v0.0.0-20190524140312-2c0ae7006135",
-			"purl": "[object Object]",
-			"type": "library",
-			"bom-ref": "[object Object]"
-		},
-		{
-			"group": "golang.org/x",
-			"name": "sync",
-			"version": "v0.0.0-20190423024810-112230192c58",
-			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
-			"type": "library",
-			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
-		},
-		{
-			"name": "genproto",
-			"version": "v0.0.0-20201019141844-1ed22bb0c154",
-			"purl": "[object Object]",
-			"type": "library",
-			"bom-ref": "[object Object]"
-		},
-		{
-			"group": "github.com/golang",
-			"name": "protobuf",
-			"version": "v1.4.1",
-			"purl": "pkg:golang/github.com/golang/protobuf@v1.4.1",
-			"type": "library",
-			"bom-ref": "pkg:golang/github.com/golang/protobuf@v1.4.1"
-		},
-		{
-			"name": "genproto",
-			"version": "v0.0.0-20201019141844-1ed22bb0c154",
-			"purl": "[object Object]",
-			"type": "library",
-			"bom-ref": "[object Object]"
-		},
-		{
-			"group": "golang.org/x",
-			"name": "lint",
-			"version": "v0.0.0-20190313153728-d0100b6bd8b3",
-			"purl": "pkg:golang/golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3",
-			"type": "library",
-			"bom-ref": "pkg:golang/golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3"
-		},
-		{
-			"name": "genproto",
-			"version": "v0.0.0-20201019141844-1ed22bb0c154",
-			"purl": "[object Object]",
-			"type": "library",
-			"bom-ref": "[object Object]"
+			"bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
 		},
 		{
 			"group": "golang.org/x",
@@ -1280,11 +1215,44 @@
 			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135"
 		},
 		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20190311183353-d8887717615a",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sync",
+			"version": "v0.0.0-20190423024810-112230192c58",
+			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
+		},
+		{
+			"group": "google.golang.org",
 			"name": "genproto",
 			"version": "v0.0.0-20201019141844-1ed22bb0c154",
-			"purl": "[object Object]",
+			"purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
 			"type": "library",
-			"bom-ref": "[object Object]"
+			"bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+		},
+		{
+			"group": "github.com/golang",
+			"name": "protobuf",
+			"version": "v1.4.1",
+			"purl": "pkg:golang/github.com/golang/protobuf@v1.4.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/golang/protobuf@v1.4.1"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "lint",
+			"version": "v0.0.0-20190313153728-d0100b6bd8b3",
+			"purl": "pkg:golang/golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3"
 		},
 		{
 			"group": "google.golang.org",
@@ -1293,13 +1261,6 @@
 			"purl": "pkg:golang/google.golang.org/grpc@v1.27.0",
 			"type": "library",
 			"bom-ref": "pkg:golang/google.golang.org/grpc@v1.27.0"
-		},
-		{
-			"name": "genproto",
-			"version": "v0.0.0-20201019141844-1ed22bb0c154",
-			"purl": "[object Object]",
-			"type": "library",
-			"bom-ref": "[object Object]"
 		},
 		{
 			"group": "google.golang.org",


### PR DESCRIPTION
## Description

fix: purl of components in sbom sometimes shows [Object Object] instead of expected package url formatted string

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.



