### PR TITLE
fix: always re-create package-lock.json

### DIFF
--- a/src/providers/javascript_npm.js
+++ b/src/providers/javascript_npm.js
@@ -90,14 +90,11 @@ function getSBOM(manifest, opts = {}, includeTransitive) {
 		}
 	})
 	let manifestDir = path.dirname(manifest)
-	if(!fs.existsSync(path.join(manifestDir,"package-lock.json"))) {
-
-		execSync(`${npm} i --package-lock-only --prefix ${manifestDir}`, err => {
-			if (err) {
-				throw new Error('failed to create npmOutput list')
-			}
-		})
-	}
+	execSync(`${npm} i --package-lock-only --prefix ${manifestDir}`, err => {
+		if (err) {
+			throw new Error('failed to create npmOutput list')
+		}
+	})
 	let allFilter = includeTransitive? " --all" : ""
 	let npmListing = getNpmListing(npm, allFilter, manifestDir)
 	let npmOutput = execSync(npmListing, err => {


### PR DESCRIPTION
## Description

Always re-create the package-lock.json because after the user updates the package.json file, the extension will run another analysis and it will fail because the package-lock.json is not synchronized.

**Related issue (if any):** fixes #issue_number_goes_here
- [TC-529](https://issues.redhat.com/browse/TC-529)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
