### PR TITLE
fix: missing common maven transitive dependencies

### DIFF
--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -159,7 +159,7 @@ function createSbomStackAnalysis(manifest, opts = {}) {
 	let tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exhort_'))
 	let tmpDepTree = path.join(tmpDir, 'mvn_deptree.txt')
 	// build initial command (dot outputType is not available for verbose mode)
-	let depTreeCmd = `${mvn} -q dependency:tree -Dverbose -DoutputType=text -DoutputFile=${tmpDepTree} -f ${manifest}`
+	let depTreeCmd = `${mvn} -q org.apache.maven.plugins:maven-dependency-plugin:3.6.0:tree -Dverbose -DoutputType=text -DoutputFile=${tmpDepTree} -f ${manifest}`
 	// exclude ignored dependencies, exclude format is groupId:artifactId:scope:version.
 	// version and scope are marked as '*' if not specified (we do not use scope yet)
 	let ignoredDeps = new Array()

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -98,6 +98,10 @@ function calculateTree(src, srcDepth, lines, sbom) {
 	if(lines.length === 0) {
 		return
 	}
+	if((lines.length === 1 && lines[0].trim() === ""))
+	{
+		return
+	}
 	let index = 0;
 	let target = lines[index];
 	let targetDepth = getDepth(target);

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -92,7 +92,8 @@ function createSbomFileFromTextFormat(dotGraphList, ignoredDeps) {
 	return sbom.filterIgnoredDepsIncludingVersion(ignoredDeps).getAsJsonString();
 }
 
-const DEP_REGEX = /(?:([-a-zA-Z0-9.]+:){4}[-a-zA-Z0-9.]+)/;
+// const DEP_REGEX = "(?:([-a-zA-Z0-9.]+:){4}[-a-zA-Z0-9.]+)"
+const DEP_REGEX = /\s*(|s{2})*[+\][-]\s[(]?(.*):(compile|runtime|provided|test|system).*/;
 
 function calculateTree(src, srcDepth, lines, sbom) {
 	if(lines.length === 0) {
@@ -128,7 +129,7 @@ function getDepth(line) {
 function parseDep(line) {
 	let match = line.match(DEP_REGEX);
 	if(match) {
-		return match[0];
+		return match[2];
 	}
 	return line;
 }

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -66,7 +66,7 @@ suite('testing the java-maven data provider', () => {
 			// read target manifest file
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
 			let manifestContent = fs.readFileSync(`test/providers/tst_manifests/maven/${testCase}/pom.xml`).toString()
-			// invoke sut stack analysis for scenario manifest
+			// invoke sut component analysis for scenario manifest
 			let providedDataForStack = await javaMvnProvider.provideComponent(manifestContent)
 			// verify returned data matches expectation
 			expect(providedDataForStack).to.deep.equal({
@@ -79,4 +79,4 @@ suite('testing the java-maven data provider', () => {
 		// these test cases takes ~1400-2000 ms each pr >10000 in CI (for the first test-case)
 
 	})
-}).beforeAll(() => clock = sinon.useFakeTimers(new Date(2023,7,7))).afterAll(()=> {clock.restore()});
+}).beforeAll(() => clock = sinon.useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(()=> {clock.restore()});

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -26,7 +26,7 @@ suite('testing the java-maven data provider', () => {
 		"pom_deps_with_no_ignore",
 		"poms_deps_with_ignore_long",
 		"poms_deps_with_no_ignore_long",
-		"poms_deps_with_no_ignore_common_paths"
+		"pom_deps_with_no_ignore_common_paths"
 	].forEach(testCase => {
 		let scenario = testCase.replace('pom_deps_', '').replaceAll('_', ' ')
 		// test(`custom adhoc test`, async () => {

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -58,7 +58,7 @@ suite('testing the java-maven data provider', () => {
 				content: expectedSbom
 			})
 		// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
-		}).timeout(process.env.GITHUB_ACTIONS ? 30000 : 5000)
+		}).timeout(process.env.GITHUB_ACTIONS ? 40000 : 10000)
 
 		test(`verify maven data provided for component analysis with scenario ${scenario}`, async () => {
 			// load the expected list for the scenario

--- a/test/providers/java_maven.test.js
+++ b/test/providers/java_maven.test.js
@@ -25,7 +25,8 @@ suite('testing the java-maven data provider', () => {
 		"pom_deps_with_ignore_on_wrong",
 		"pom_deps_with_no_ignore",
 		"poms_deps_with_ignore_long",
-		"poms_deps_with_no_ignore_long"
+		"poms_deps_with_no_ignore_long",
+		"poms_deps_with_no_ignore_common_paths"
 	].forEach(testCase => {
 		let scenario = testCase.replace('pom_deps_', '').replaceAll('_', ' ')
 		// test(`custom adhoc test`, async () => {

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/component_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/component_analysis_expected_sbom.json
@@ -3,7 +3,7 @@
 	"specVersion": "1.4",
 	"version": 1,
 	"metadata": {
-		"timestamp": "2023-09-01T15:54:21.462Z",
+		"timestamp": "2023-08-07T00:00:00.000Z",
 		"component": {
 			"group": "pom-with-deps-no-ignore",
 			"name": "pom-with-dependency-not-ignored-for-tests",

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/component_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/component_analysis_expected_sbom.json
@@ -1,0 +1,59 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.4",
+	"version": 1,
+	"metadata": {
+		"timestamp": "2023-09-01T15:54:21.462Z",
+		"component": {
+			"group": "pom-with-deps-no-ignore",
+			"name": "pom-with-dependency-not-ignored-for-tests",
+			"version": "0.0.1",
+			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"type": "application",
+			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		}
+	},
+	"components": [
+		{
+			"group": "pom-with-deps-no-ignore",
+			"name": "pom-with-dependency-not-ignored-for-tests",
+			"version": "0.0.1",
+			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"type": "application",
+			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-databind",
+			"version": "2.14.1",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1"
+		},
+		{
+			"group": "org.infinispan.protostream",
+			"name": "protostream",
+			"version": "4.6.4.Final",
+			"purl": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
+		}
+	],
+	"dependencies": [
+		{
+			"ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
+				"pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
+			"dependsOn": []
+		}
+	]
+}

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/component_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/component_analysis_expected_sbom.json
@@ -1,59 +1,124 @@
 {
-	"bomFormat": "CycloneDX",
-	"specVersion": "1.4",
-	"version": 1,
-	"metadata": {
-		"timestamp": "2023-08-07T00:00:00.000Z",
-		"component": {
-			"group": "pom-with-deps-no-ignore",
-			"name": "pom-with-dependency-not-ignored-for-tests",
-			"version": "0.0.1",
-			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-			"type": "application",
-			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
-		}
-	},
-	"components": [
-		{
-			"group": "pom-with-deps-no-ignore",
-			"name": "pom-with-dependency-not-ignored-for-tests",
-			"version": "0.0.1",
-			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-			"type": "application",
-			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.14.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1"
-		},
-		{
-			"group": "org.infinispan.protostream",
-			"name": "protostream",
-			"version": "4.6.4.Final",
-			"purl": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
-		}
-	],
-	"dependencies": [
-		{
-			"ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
-				"pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
-			"dependsOn": []
-		}
-	]
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "pom-with-deps-no-ignore",
+            "name": "pom-with-dependency-not-ignored-common-paths",
+            "version": "0.0.1",
+            "purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1",
+            "type": "application",
+            "bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1"
+        }
+    },
+    "components": [
+        {
+            "group": "pom-with-deps-no-ignore",
+            "name": "pom-with-dependency-not-ignored-common-paths",
+            "version": "0.0.1",
+            "purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1",
+            "type": "application",
+            "bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-test",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-web",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final"
+        },
+        {
+            "group": "org.keycloak",
+            "name": "keycloak-saml-core",
+            "version": "1.8.1.Final",
+            "purl": "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx-http",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-jdbc-postgresql",
+            "version": "2.13.6.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+                "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+                "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final",
+                "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+            "dependsOn": []
+        }
+    ]
 }

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/pom.xml
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/pom.xml
@@ -1,21 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.3.5.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
   <groupId>pom-with-deps-no-ignore</groupId>
-  <artifactId>pom-with-dependency-not-ignored-for-tests</artifactId>
+  <artifactId>pom-with-dependency-not-ignored-common-paths</artifactId>
   <version>0.0.1</version>
-  <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.14.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.infinispan.protostream</groupId>
-      <artifactId>protostream</artifactId>
-      <version>4.6.4.Final</version>
-    </dependency>
-  </dependencies>
+	<name>pom-with-dependency-not-ignored-common-paths</name>
+	<description>Demo project for Spring Boot</description>
+
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-resteasy</artifactId>
+			<version>2.7.7.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-saml-core</artifactId>
+			<version>1.8.1.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-vertx-http</artifactId>
+			<version>2.13.5.Final</version>
+		</dependency>
+		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-jdbc-postgresql</artifactId>
+			<version>2.13.6.Final</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/pom.xml
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>pom-with-deps-no-ignore</groupId>
+  <artifactId>pom-with-dependency-not-ignored-for-tests</artifactId>
+  <version>0.0.1</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.14.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan.protostream</groupId>
+      <artifactId>protostream</artifactId>
+      <version>4.6.4.Final</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/stack_analysis_expected_sbom.json
@@ -1,127 +1,2353 @@
 {
-	"bomFormat": "CycloneDX",
-	"specVersion": "1.4",
-	"version": 1,
-	"metadata": {
-		"timestamp": "2023-08-07T00:00:00.000Z",
-		"component": {
-			"group": "pom-with-deps-no-ignore",
-			"name": "pom-with-dependency-not-ignored-for-tests",
-			"version": "0.0.1",
-			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-			"type": "application",
-			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
-		}
-	},
-	"components": [
-		{
-			"group": "pom-with-deps-no-ignore",
-			"name": "pom-with-dependency-not-ignored-for-tests",
-			"version": "0.0.1",
-			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-			"type": "application",
-			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.14.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.14.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.14.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1"
-		},
-		{
-			"group": "org.infinispan.protostream",
-			"name": "protostream",
-			"version": "4.6.4.Final",
-			"purl": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
-		},
-		{
-			"group": "org.jboss.logging",
-			"name": "jboss-logging",
-			"version": "3.5.0.Final",
-			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final"
-		},
-		{
-			"group": "com.squareup",
-			"name": "protoparser",
-			"version": "4.0.3",
-			"purl": "pkg:maven/com.squareup/protoparser@4.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.squareup/protoparser@4.0.3"
-		},
-		{
-			"group": "org.javassist",
-			"name": "javassist",
-			"version": "3.29.1-GA",
-			"purl": "pkg:maven/org.javassist/javassist@3.29.1-GA",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.javassist/javassist@3.29.1-GA"
-		}
-	],
-	"dependencies": [
-		{
-			"ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
-				"pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
-				"pkg:maven/com.squareup/protoparser@4.0.3",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1",
-				"pkg:maven/org.javassist/javassist@3.29.1-GA"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.squareup/protoparser@4.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.javassist/javassist@3.29.1-GA",
-			"dependsOn": []
-		}
-	]
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "pom-with-deps-no-ignore",
+            "name": "pom-with-dependency-not-ignored-common-paths",
+            "version": "0.0.1",
+            "purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1",
+            "type": "application",
+            "bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1"
+        }
+    },
+    "components": [
+        {
+            "group": "pom-with-deps-no-ignore",
+            "name": "pom-with-dependency-not-ignored-common-paths",
+            "version": "0.0.1",
+            "purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1",
+            "type": "application",
+            "bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-core",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-context",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-aop",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-beans",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-expression",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-autoconfigure",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-logging",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-classic",
+            "version": "1.2.3",
+            "purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-core",
+            "version": "1.2.3",
+            "purl": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "slf4j-api",
+            "version": "1.7.30",
+            "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-to-slf4j",
+            "version": "2.13.3",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-api",
+            "version": "2.13.3",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "jul-to-slf4j",
+            "version": "1.7.30",
+            "purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
+        },
+        {
+            "group": "jakarta.annotation",
+            "name": "jakarta.annotation-api",
+            "version": "1.3.5",
+            "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-jcl",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.yaml",
+            "name": "snakeyaml",
+            "version": "1.26",
+            "purl": "pkg:maven/org.yaml/snakeyaml@1.26",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.yaml/snakeyaml@1.26"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-test",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test-autoconfigure",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE"
+        },
+        {
+            "group": "com.jayway.jsonpath",
+            "name": "json-path",
+            "version": "2.4.0",
+            "purl": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0"
+        },
+        {
+            "group": "net.minidev",
+            "name": "json-smart",
+            "version": "2.3",
+            "purl": "pkg:maven/net.minidev/json-smart@2.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/json-smart@2.3"
+        },
+        {
+            "group": "net.minidev",
+            "name": "accessors-smart",
+            "version": "1.2",
+            "purl": "pkg:maven/net.minidev/accessors-smart@1.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/accessors-smart@1.2"
+        },
+        {
+            "group": "org.ow2.asm",
+            "name": "asm",
+            "version": "5.0.4",
+            "purl": "pkg:maven/org.ow2.asm/asm@5.0.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.ow2.asm/asm@5.0.4"
+        },
+        {
+            "group": "jakarta.xml.bind",
+            "name": "jakarta.xml.bind-api",
+            "version": "2.3.3",
+            "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+        },
+        {
+            "group": "jakarta.activation",
+            "name": "jakarta.activation-api",
+            "version": "1.2.2",
+            "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+        },
+        {
+            "group": "org.assertj",
+            "name": "assertj-core",
+            "version": "3.16.1",
+            "purl": "pkg:maven/org.assertj/assertj-core@3.16.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.assertj/assertj-core@3.16.1"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest",
+            "version": "2.2",
+            "purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-api",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+        },
+        {
+            "group": "org.apiguardian",
+            "name": "apiguardian-api",
+            "version": "1.1.0",
+            "purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
+        },
+        {
+            "group": "org.opentest4j",
+            "name": "opentest4j",
+            "version": "1.2.0",
+            "purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-commons",
+            "version": "1.6.3",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-params",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-engine",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-engine",
+            "version": "1.6.3",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-core",
+            "version": "3.3.3",
+            "purl": "pkg:maven/org.mockito/mockito-core@3.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-core@3.3.3"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy",
+            "version": "1.10.17",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy-agent",
+            "version": "1.10.17",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17"
+        },
+        {
+            "group": "org.objenesis",
+            "name": "objenesis",
+            "version": "2.6",
+            "purl": "pkg:maven/org.objenesis/objenesis@2.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.objenesis/objenesis@2.6"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-junit-jupiter",
+            "version": "3.3.3",
+            "purl": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3"
+        },
+        {
+            "group": "org.skyscreamer",
+            "name": "jsonassert",
+            "version": "1.5.0",
+            "purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+        },
+        {
+            "group": "com.vaadin.external.google",
+            "name": "android-json",
+            "version": "0.0.20131108.vaadin1",
+            "purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-test",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.xmlunit",
+            "name": "xmlunit-core",
+            "version": "2.7.0",
+            "purl": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-web",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-json",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-web",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-databind",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-annotations",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-core",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jdk8",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jsr310",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.module",
+            "name": "jackson-module-parameter-names",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-tomcat",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-core",
+            "version": "9.0.39",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
+        },
+        {
+            "group": "org.glassfish",
+            "name": "jakarta.el",
+            "version": "3.0.3",
+            "purl": "pkg:maven/org.glassfish/jakarta.el@3.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.glassfish/jakarta.el@3.0.3"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-websocket",
+            "version": "9.0.39",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-webmvc",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx-http",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy-server-common",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-core",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-arc",
+            "version": "2.13.6.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy-common",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final"
+        },
+        {
+            "group": "org.jboss.resteasy",
+            "name": "resteasy-core",
+            "version": "4.7.5.Final",
+            "purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final"
+        },
+        {
+            "group": "org.jboss.logging",
+            "name": "jboss-logging",
+            "version": "3.4.1.Final",
+            "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+        },
+        {
+            "group": "org.jboss.spec.javax.annotation",
+            "name": "jboss-annotations-api_1.3_spec",
+            "version": "2.0.1.Final",
+            "purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
+        },
+        {
+            "group": "org.jboss.spec.javax.ws.rs",
+            "name": "jboss-jaxrs-api_2.1_spec",
+            "version": "2.0.1.Final",
+            "purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
+        },
+        {
+            "group": "org.jboss.spec.javax.xml.bind",
+            "name": "jboss-jaxb-api_2.3_spec",
+            "version": "2.0.0.Final",
+            "purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
+        },
+        {
+            "group": "org.jboss.resteasy",
+            "name": "resteasy-core-spi",
+            "version": "4.7.5.Final",
+            "purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final"
+        },
+        {
+            "group": "org.reactivestreams",
+            "name": "reactive-streams",
+            "version": "1.0.3",
+            "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
+        },
+        {
+            "group": "jakarta.validation",
+            "name": "jakarta.validation-api",
+            "version": "2.0.2",
+            "purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+        },
+        {
+            "group": "com.ibm.async",
+            "name": "asyncutil",
+            "version": "0.1.0",
+            "purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
+        },
+        {
+            "group": "io.smallrye.config",
+            "name": "smallrye-config",
+            "version": "2.12.0",
+            "purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
+        },
+        {
+            "group": "com.sun.activation",
+            "name": "jakarta.activation",
+            "version": "1.2.2",
+            "purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
+        },
+        {
+            "group": "org.keycloak",
+            "name": "keycloak-saml-core",
+            "version": "1.8.1.Final",
+            "purl": "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final"
+        },
+        {
+            "group": "org.apache.santuario",
+            "name": "xmlsec",
+            "version": "1.5.1",
+            "purl": "pkg:maven/org.apache.santuario/xmlsec@1.5.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.santuario/xmlsec@1.5.1"
+        },
+        {
+            "group": "commons-logging",
+            "name": "commons-logging",
+            "version": "1.1.1",
+            "purl": "pkg:maven/commons-logging/commons-logging@1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-logging/commons-logging@1.1.1"
+        },
+        {
+            "group": "jakarta.enterprise",
+            "name": "jakarta.enterprise.cdi-api",
+            "version": "2.0.2",
+            "purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
+        },
+        {
+            "group": "jakarta.el",
+            "name": "jakarta.el-api",
+            "version": "3.0.3",
+            "purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
+        },
+        {
+            "group": "jakarta.interceptor",
+            "name": "jakarta.interceptor-api",
+            "version": "1.2.5",
+            "purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
+        },
+        {
+            "group": "jakarta.ejb",
+            "name": "jakarta.ejb-api",
+            "version": "3.2.6",
+            "purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
+        },
+        {
+            "group": "jakarta.transaction",
+            "name": "jakarta.transaction-api",
+            "version": "1.3.3",
+            "purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+        },
+        {
+            "group": "jakarta.inject",
+            "name": "jakarta.inject-api",
+            "version": "1.0",
+            "purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-ide-launcher",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-development-mode-spi",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.config",
+            "name": "smallrye-config-core",
+            "version": "2.12.0",
+            "purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
+        },
+        {
+            "group": "org.eclipse.microprofile.config",
+            "name": "microprofile-config-api",
+            "version": "2.0.1",
+            "purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-annotation",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-expression",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-function",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-constraint",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-classloader",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
+        },
+        {
+            "group": "io.smallrye.config",
+            "name": "smallrye-config-common",
+            "version": "2.12.0",
+            "purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
+        },
+        {
+            "group": "org.jboss.logmanager",
+            "name": "jboss-logmanager-embedded",
+            "version": "1.0.10",
+            "purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
+        },
+        {
+            "group": "org.wildfly.common",
+            "name": "wildfly-common",
+            "version": "1.5.4.Final-format-001",
+            "purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
+        },
+        {
+            "group": "org.jboss.logging",
+            "name": "jboss-logging-annotations",
+            "version": "2.2.1.Final",
+            "purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
+        },
+        {
+            "group": "org.jboss.threads",
+            "name": "jboss-threads",
+            "version": "3.4.3.Final",
+            "purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
+        },
+        {
+            "group": "org.jboss.slf4j",
+            "name": "slf4j-jboss-logmanager",
+            "version": "1.2.0.Final",
+            "purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
+        },
+        {
+            "group": "org.graalvm.sdk",
+            "name": "graal-sdk",
+            "version": "22.3.0",
+            "purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-bootstrap-runner",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-io",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
+        },
+        {
+            "group": "io.github.crac",
+            "name": "org-crac",
+            "version": "0.1.1",
+            "purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-fs-util",
+            "version": "0.0.9",
+            "purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-security-runtime-spi",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus.security",
+            "name": "quarkus-security",
+            "version": "1.1.4.Final",
+            "purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-credentials",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus.arc",
+            "name": "arc",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "mutiny",
+            "version": "1.7.0",
+            "purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-mutiny",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-smallrye-context-propagation",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-context-propagation",
+            "version": "1.2.2",
+            "purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+        },
+        {
+            "group": "org.eclipse.microprofile.context-propagation",
+            "name": "microprofile-context-propagation-api",
+            "version": "1.2",
+            "purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-context-propagation-api",
+            "version": "1.2.2",
+            "purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-context-propagation-storage",
+            "version": "1.2.2",
+            "purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "mutiny-smallrye-context-propagation",
+            "version": "1.7.0",
+            "purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-vertx-context",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-core",
+            "version": "4.3.3",
+            "purl": "pkg:maven/io.vertx/vertx-core@4.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.3"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-common",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-common@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-common@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-buffer",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-resolver",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-handler",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-handler-proxy",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-socks",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-http",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-http2",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-resolver-dns",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-dns",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx-http-dev-console-runtime-spi",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-web",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-netty",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final"
+        },
+        {
+            "group": "com.aayushatharva.brotli4j",
+            "name": "brotli4j",
+            "version": "1.7.1",
+            "purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
+        },
+        {
+            "group": "com.aayushatharva.brotli4j",
+            "name": "native-linux-x86_64",
+            "version": "1.7.1",
+            "purl": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-haproxy",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx-latebound-mdc-provider",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-core",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-runtime",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "vertx-mutiny-generator",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-codegen",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-fault-tolerance-vertx",
+            "version": "5.5.0",
+            "purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-web",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-web-common",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-web-common",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-auth-common",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-auth-common",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-bridge-common",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-bridge-common",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-uri-template",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-uri-template",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-jdbc-postgresql",
+            "version": "2.13.6.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
+        },
+        {
+            "group": "org.postgresql",
+            "name": "postgresql",
+            "version": "42.2.18",
+            "purl": "pkg:maven/org.postgresql/postgresql@42.2.18",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.postgresql/postgresql@42.2.18"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-common-paths@0.0.1",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+                "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+                "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final",
+                "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.yaml/snakeyaml@1.26"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+                "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+                "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-core@1.2.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+                "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.yaml/snakeyaml@1.26",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+                "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+                "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+                "pkg:maven/org.assertj/assertj-core@3.16.1",
+                "pkg:maven/org.hamcrest/hamcrest@2.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+                "pkg:maven/org.mockito/mockito-core@3.3.3",
+                "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+                "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+                "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+            "dependsOn": [
+                "pkg:maven/net.minidev/json-smart@2.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/json-smart@2.3",
+            "dependsOn": [
+                "pkg:maven/net.minidev/accessors-smart@1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/accessors-smart@1.2",
+            "dependsOn": [
+                "pkg:maven/org.ow2.asm/asm@5.0.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.ow2.asm/asm@5.0.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "dependsOn": [
+                "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.assertj/assertj-core@3.16.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-core@3.3.3",
+            "dependsOn": [
+                "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+                "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+                "pkg:maven/org.objenesis/objenesis@2.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.objenesis/objenesis@2.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+            "dependsOn": [
+                "pkg:maven/org.mockito/mockito-core@3.3.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "dependsOn": [
+                "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+                "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+                "pkg:maven/org.glassfish/jakarta.el@3.0.3",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.glassfish/jakarta.el@3.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
+            "dependsOn": [
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+                "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+                "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+                "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
+                "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+                "pkg:maven/io.vertx/vertx-web@4.3.4",
+                "pkg:maven/io.github.crac/org-crac@0.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
+                "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
+                "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
+                "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+                "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
+                "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+                "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
+                "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
+                "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
+                "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+                "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+                "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+                "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+                "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+                "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+                "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+                "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.keycloak/keycloak-saml-core@1.8.1.Final",
+            "dependsOn": [
+                "pkg:maven/org.apache.santuario/xmlsec@1.5.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.santuario/xmlsec@1.5.1",
+            "dependsOn": [
+                "pkg:maven/commons-logging/commons-logging@1.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/commons-logging/commons-logging@1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+            "dependsOn": [
+                "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+                "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+                "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+            "dependsOn": [
+                "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.ow2.asm/asm@5.0.4",
+                "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+            "dependsOn": [
+                "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+                "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/io.github.crac/org-crac@0.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.github.crac/org-crac@0.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+            "dependsOn": [
+                "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+                "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+                "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+                "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+                "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3",
+                "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-core@4.3.3",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-common@4.1.53.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+                "pkg:maven/io.vertx/vertx-web@4.3.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-web@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+                "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+                "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+                "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+                "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+                "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
+            "dependsOn": [
+                "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+                "pkg:maven/io.vertx/vertx-core@4.3.3",
+                "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+                "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-web@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/org.postgresql/postgresql@42.2.18"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.postgresql/postgresql@42.2.18",
+            "dependsOn": []
+        }
+    ]
 }

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/stack_analysis_expected_sbom.json
@@ -1,0 +1,127 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.4",
+	"version": 1,
+	"metadata": {
+		"timestamp": "2023-09-01T15:54:21.462Z",
+		"component": {
+			"group": "pom-with-deps-no-ignore",
+			"name": "pom-with-dependency-not-ignored-for-tests",
+			"version": "0.0.1",
+			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"type": "application",
+			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		}
+	},
+	"components": [
+		{
+			"group": "pom-with-deps-no-ignore",
+			"name": "pom-with-dependency-not-ignored-for-tests",
+			"version": "0.0.1",
+			"purl": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"type": "application",
+			"bom-ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-databind",
+			"version": "2.14.1",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-annotations",
+			"version": "2.14.1",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-core",
+			"version": "2.14.1",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1"
+		},
+		{
+			"group": "org.infinispan.protostream",
+			"name": "protostream",
+			"version": "4.6.4.Final",
+			"purl": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
+		},
+		{
+			"group": "org.jboss.logging",
+			"name": "jboss-logging",
+			"version": "3.5.0.Final",
+			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final"
+		},
+		{
+			"group": "com.squareup",
+			"name": "protoparser",
+			"version": "4.0.3",
+			"purl": "pkg:maven/com.squareup/protoparser@4.0.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.squareup/protoparser@4.0.3"
+		},
+		{
+			"group": "org.javassist",
+			"name": "javassist",
+			"version": "3.29.1-GA",
+			"purl": "pkg:maven/org.javassist/javassist@3.29.1-GA",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.javassist/javassist@3.29.1-GA"
+		}
+	],
+	"dependencies": [
+		{
+			"ref": "pkg:maven/pom-with-deps-no-ignore/pom-with-dependency-not-ignored-for-tests@0.0.1",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
+				"pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.1",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.14.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.infinispan.protostream/protostream@4.6.4.Final",
+			"dependsOn": [
+				"pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
+				"pkg:maven/com.squareup/protoparser@4.0.3",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.14.1",
+				"pkg:maven/org.javassist/javassist@3.29.1-GA"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.jboss.logging/jboss-logging@3.5.0.Final",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.squareup/protoparser@4.0.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.javassist/javassist@3.29.1-GA",
+			"dependsOn": []
+		}
+	]
+}

--- a/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_deps_with_no_ignore_common_paths/stack_analysis_expected_sbom.json
@@ -3,7 +3,7 @@
 	"specVersion": "1.4",
 	"version": 1,
 	"metadata": {
-		"timestamp": "2023-09-01T15:54:21.462Z",
+		"timestamp": "2023-08-07T00:00:00.000Z",
 		"component": {
 			"group": "pom-with-deps-no-ignore",
 			"name": "pom-with-dependency-not-ignored-for-tests",

--- a/test/providers/tst_manifests/maven/poms_deps_with_2_ignore_long/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/poms_deps_with_2_ignore_long/stack_analysis_expected_sbom.json
@@ -32,43 +32,51 @@
 		},
 		{
 			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-test",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-web",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-resteasy",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-jdbc-postgresql",
-			"version": "2.13.6.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
-		},
-		{
-			"group": "org.springframework.boot",
 			"name": "spring-boot",
 			"version": "2.3.5.RELEASE",
 			"purl": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-core",
+			"version": "5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-context",
+			"version": "5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-aop",
+			"version": "5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-beans",
+			"version": "5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-expression",
+			"version": "5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -87,60 +95,12 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE"
 		},
 		{
-			"group": "jakarta.annotation",
-			"name": "jakarta.annotation-api",
-			"version": "1.3.5",
-			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-core",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.yaml",
-			"name": "snakeyaml",
-			"version": "1.26",
-			"purl": "pkg:maven/org.yaml/snakeyaml@1.26",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.26"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-context",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
-		},
-		{
 			"group": "ch.qos.logback",
 			"name": "logback-classic",
 			"version": "1.2.3",
 			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-to-slf4j",
-			"version": "2.13.3",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "jul-to-slf4j",
-			"version": "1.7.30",
-			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
 		},
 		{
 			"group": "ch.qos.logback",
@@ -151,6 +111,22 @@
 			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3"
 		},
 		{
+			"group": "org.slf4j",
+			"name": "slf4j-api",
+			"version": "1.7.30",
+			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+		},
+		{
+			"group": "org.apache.logging.log4j",
+			"name": "log4j-to-slf4j",
+			"version": "2.13.3",
+			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3"
+		},
+		{
 			"group": "org.apache.logging.log4j",
 			"name": "log4j-api",
 			"version": "2.13.3",
@@ -159,12 +135,44 @@
 			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
 		},
 		{
+			"group": "org.slf4j",
+			"name": "jul-to-slf4j",
+			"version": "1.7.30",
+			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
+		},
+		{
+			"group": "jakarta.annotation",
+			"name": "jakarta.annotation-api",
+			"version": "1.3.5",
+			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
+		},
+		{
 			"group": "org.springframework",
 			"name": "spring-jcl",
 			"version": "5.2.10.RELEASE",
 			"purl": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
+		},
+		{
+			"group": "org.yaml",
+			"name": "snakeyaml",
+			"version": "1.26",
+			"purl": "pkg:maven/org.yaml/snakeyaml@1.26",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.26"
+		},
+		{
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-test",
+			"version": "2.3.5.RELEASE",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -191,12 +199,44 @@
 			"bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0"
 		},
 		{
+			"group": "net.minidev",
+			"name": "json-smart",
+			"version": "2.3",
+			"purl": "pkg:maven/net.minidev/json-smart@2.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/net.minidev/json-smart@2.3"
+		},
+		{
+			"group": "net.minidev",
+			"name": "accessors-smart",
+			"version": "1.2",
+			"purl": "pkg:maven/net.minidev/accessors-smart@1.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/net.minidev/accessors-smart@1.2"
+		},
+		{
+			"group": "org.ow2.asm",
+			"name": "asm",
+			"version": "5.0.4",
+			"purl": "pkg:maven/org.ow2.asm/asm@5.0.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.ow2.asm/asm@5.0.4"
+		},
+		{
 			"group": "jakarta.xml.bind",
 			"name": "jakarta.xml.bind-api",
 			"version": "2.3.3",
 			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+		},
+		{
+			"group": "jakarta.activation",
+			"name": "jakarta.activation-api",
+			"version": "1.2.2",
+			"purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
 		},
 		{
 			"group": "org.assertj",
@@ -223,108 +263,12 @@
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3"
 		},
 		{
-			"group": "org.mockito",
-			"name": "mockito-core",
-			"version": "3.3.3",
-			"purl": "pkg:maven/org.mockito/mockito-core@3.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-core@3.3.3"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-junit-jupiter",
-			"version": "3.3.3",
-			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3"
-		},
-		{
-			"group": "org.skyscreamer",
-			"name": "jsonassert",
-			"version": "1.5.0",
-			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-test",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.xmlunit",
-			"name": "xmlunit-core",
-			"version": "2.7.0",
-			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
-		},
-		{
-			"group": "net.minidev",
-			"name": "json-smart",
-			"version": "2.3",
-			"purl": "pkg:maven/net.minidev/json-smart@2.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/json-smart@2.3"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "slf4j-api",
-			"version": "1.7.30",
-			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30"
-		},
-		{
-			"group": "net.minidev",
-			"name": "accessors-smart",
-			"version": "1.2",
-			"purl": "pkg:maven/net.minidev/accessors-smart@1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/accessors-smart@1.2"
-		},
-		{
-			"group": "org.ow2.asm",
-			"name": "asm",
-			"version": "5.0.4",
-			"purl": "pkg:maven/org.ow2.asm/asm@5.0.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.ow2.asm/asm@5.0.4"
-		},
-		{
-			"group": "jakarta.activation",
-			"name": "jakarta.activation-api",
-			"version": "1.2.2",
-			"purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-		},
-		{
 			"group": "org.junit.jupiter",
 			"name": "junit-jupiter-api",
 			"version": "5.6.3",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-params",
-			"version": "5.6.3",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-engine",
-			"version": "5.6.3",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
 		},
 		{
 			"group": "org.apiguardian",
@@ -351,12 +295,36 @@
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
 		},
 		{
+			"group": "org.junit.jupiter",
+			"name": "junit-jupiter-params",
+			"version": "5.6.3",
+			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3"
+		},
+		{
+			"group": "org.junit.jupiter",
+			"name": "junit-jupiter-engine",
+			"version": "5.6.3",
+			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
+		},
+		{
 			"group": "org.junit.platform",
 			"name": "junit-platform-engine",
 			"version": "1.6.3",
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3"
+		},
+		{
+			"group": "org.mockito",
+			"name": "mockito-core",
+			"version": "3.3.3",
+			"purl": "pkg:maven/org.mockito/mockito-core@3.3.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.mockito/mockito-core@3.3.3"
 		},
 		{
 			"group": "net.bytebuddy",
@@ -383,12 +351,52 @@
 			"bom-ref": "pkg:maven/org.objenesis/objenesis@2.6"
 		},
 		{
+			"group": "org.mockito",
+			"name": "mockito-junit-jupiter",
+			"version": "3.3.3",
+			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3"
+		},
+		{
+			"group": "org.skyscreamer",
+			"name": "jsonassert",
+			"version": "1.5.0",
+			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+		},
+		{
 			"group": "com.vaadin.external.google",
 			"name": "android-json",
 			"version": "0.0.20131108.vaadin1",
 			"purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-test",
+			"version": "5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE"
+		},
+		{
+			"group": "org.xmlunit",
+			"name": "xmlunit-core",
+			"version": "2.7.0",
+			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
+		},
+		{
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-web",
+			"version": "2.3.5.RELEASE",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -399,14 +407,6 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE"
 		},
 		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-tomcat",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE"
-		},
-		{
 			"group": "org.springframework",
 			"name": "spring-web",
 			"version": "5.2.10.RELEASE",
@@ -415,20 +415,28 @@
 			"bom-ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
 		},
 		{
-			"group": "org.springframework",
-			"name": "spring-webmvc",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
-		},
-		{
 			"group": "com.fasterxml.jackson.core",
 			"name": "jackson-databind",
 			"version": "2.11.3",
 			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-annotations",
+			"version": "2.11.3",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-core",
+			"version": "2.11.3",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
 		},
 		{
 			"group": "com.fasterxml.jackson.datatype",
@@ -455,20 +463,12 @@
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
 		},
 		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-tomcat",
+			"version": "2.3.5.RELEASE",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
 			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE"
 		},
 		{
 			"group": "org.apache.tomcat.embed",
@@ -496,27 +496,27 @@
 		},
 		{
 			"group": "org.springframework",
-			"name": "spring-beans",
+			"name": "spring-webmvc",
 			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+			"purl": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE"
+			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
 		},
 		{
-			"group": "org.springframework",
-			"name": "spring-aop",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+			"group": "io.quarkus",
+			"name": "quarkus-resteasy",
+			"version": "2.7.7.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE"
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final"
 		},
 		{
-			"group": "org.springframework",
-			"name": "spring-expression",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+			"group": "io.quarkus",
+			"name": "quarkus-vertx-http",
+			"version": "2.7.7.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final"
 		},
 		{
 			"group": "io.quarkus",
@@ -528,19 +528,27 @@
 		},
 		{
 			"group": "io.quarkus",
+			"name": "quarkus-core",
+			"version": "2.7.7.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.7.7.Final"
+		},
+		{
+			"group": "io.quarkus",
+			"name": "quarkus-arc",
+			"version": "2.7.7.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final"
+		},
+		{
+			"group": "io.quarkus",
 			"name": "quarkus-resteasy-common",
 			"version": "2.7.7.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final"
-		},
-		{
-			"group": "jakarta.validation",
-			"name": "jakarta.validation-api",
-			"version": "2.0.2",
-			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 		},
 		{
 			"group": "org.jboss.resteasy",
@@ -551,12 +559,12 @@
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final"
 		},
 		{
-			"group": "com.sun.activation",
-			"name": "jakarta.activation",
-			"version": "1.2.2",
-			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+			"group": "org.jboss.logging",
+			"name": "jboss-logging",
+			"version": "3.4.1.Final",
+			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
+			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
 		},
 		{
 			"group": "org.jboss.spec.javax.annotation",
@@ -591,12 +599,44 @@
 			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final"
 		},
 		{
+			"group": "org.reactivestreams",
+			"name": "reactive-streams",
+			"version": "1.0.3",
+			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
+		},
+		{
+			"group": "jakarta.validation",
+			"name": "jakarta.validation-api",
+			"version": "2.0.2",
+			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+		},
+		{
 			"group": "com.ibm.async",
 			"name": "asyncutil",
 			"version": "0.1.0",
 			"purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
+		},
+		{
+			"group": "io.smallrye.config",
+			"name": "smallrye-config",
+			"version": "2.3.0",
+			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.3.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.3.0"
+		},
+		{
+			"group": "com.sun.activation",
+			"name": "jakarta.activation",
+			"version": "1.2.2",
+			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
 		},
 		{
 			"group": "org.apache.santuario",
@@ -623,92 +663,44 @@
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final"
 		},
 		{
-			"group": "io.quarkus",
-			"name": "quarkus-security-runtime-spi",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-credentials",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-mutiny",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-vertx-context",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx-http-dev-console-runtime-spi",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus.security",
-			"name": "quarkus-security",
-			"version": "1.1.4.Final",
-			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-web",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-web",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
-		},
-		{
-			"group": "io.github.crac",
-			"name": "org-crac",
-			"version": "0.1.1",
-			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
-		},
-		{
 			"group": "jakarta.enterprise",
 			"name": "jakarta.enterprise.cdi-api",
 			"version": "2.0.2",
 			"purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
+		},
+		{
+			"group": "jakarta.el",
+			"name": "jakarta.el-api",
+			"version": "3.0.3",
+			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
+		},
+		{
+			"group": "jakarta.interceptor",
+			"name": "jakarta.interceptor-api",
+			"version": "1.2.5",
+			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
+		},
+		{
+			"group": "jakarta.ejb",
+			"name": "jakarta.ejb-api",
+			"version": "3.2.6",
+			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
+		},
+		{
+			"group": "jakarta.transaction",
+			"name": "jakarta.transaction-api",
+			"version": "1.3.3",
+			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
 		},
 		{
 			"group": "jakarta.inject",
@@ -743,12 +735,76 @@
 			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
 		},
 		{
-			"group": "org.jboss.logging",
-			"name": "jboss-logging",
-			"version": "3.4.1.Final",
-			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+			"group": "io.smallrye.config",
+			"name": "smallrye-config-core",
+			"version": "2.12.0",
+			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
+		},
+		{
+			"group": "org.eclipse.microprofile.config",
+			"name": "microprofile-config-api",
+			"version": "2.0.1",
+			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
+		},
+		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-annotation",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+		},
+		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-expression",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
+		},
+		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-function",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
+		},
+		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-constraint",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+		},
+		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-classloader",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
+		},
+		{
+			"group": "org.ow2.asm",
+			"name": "asm",
+			"version": "9.3",
+			"purl": "pkg:maven/org.ow2.asm/asm@9.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.3"
+		},
+		{
+			"group": "io.smallrye.config",
+			"name": "smallrye-config-common",
+			"version": "2.12.0",
+			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
 		},
 		{
 			"group": "org.jboss.logmanager",
@@ -757,6 +813,14 @@
 			"purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
+		},
+		{
+			"group": "org.wildfly.common",
+			"name": "wildfly-common",
+			"version": "1.5.0.Final-format-001",
+			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001"
 		},
 		{
 			"group": "org.jboss.logging",
@@ -773,6 +837,14 @@
 			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
+		},
+		{
+			"group": "org.wildfly.common",
+			"name": "wildfly-common",
+			"version": "1.5.0.Final",
+			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final"
 		},
 		{
 			"group": "org.jboss.slf4j",
@@ -807,6 +879,22 @@
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final"
 		},
 		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-io",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
+		},
+		{
+			"group": "io.github.crac",
+			"name": "org-crac",
+			"version": "0.1.1",
+			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
+		},
+		{
 			"group": "io.quarkus",
 			"name": "quarkus-fs-util",
 			"version": "0.0.9",
@@ -815,84 +903,28 @@
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
 		},
 		{
-			"group": "jakarta.el",
-			"name": "jakarta.el-api",
-			"version": "3.0.3",
-			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+			"group": "io.quarkus",
+			"name": "quarkus-security-runtime-spi",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
 		},
 		{
-			"group": "jakarta.interceptor",
-			"name": "jakarta.interceptor-api",
-			"version": "1.2.5",
-			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+			"group": "io.quarkus.security",
+			"name": "quarkus-security",
+			"version": "1.1.4.Final",
+			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
+			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
 		},
 		{
-			"group": "jakarta.ejb",
-			"name": "jakarta.ejb-api",
-			"version": "3.2.6",
-			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+			"group": "io.quarkus",
+			"name": "quarkus-credentials",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
-		},
-		{
-			"group": "io.smallrye.config",
-			"name": "smallrye-config-core",
-			"version": "2.12.0",
-			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
-		},
-		{
-			"group": "org.eclipse.microprofile.config",
-			"name": "microprofile-config-api",
-			"version": "2.0.1",
-			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-expression",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-classloader",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
-		},
-		{
-			"group": "io.smallrye.config",
-			"name": "smallrye-config-common",
-			"version": "2.12.0",
-			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-function",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-io",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
 		},
 		{
 			"group": "io.quarkus.arc",
@@ -903,12 +935,20 @@
 			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
 		},
 		{
-			"group": "jakarta.transaction",
-			"name": "jakarta.transaction-api",
-			"version": "1.3.3",
-			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+			"group": "io.smallrye.reactive",
+			"name": "mutiny",
+			"version": "1.6.0",
+			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.6.0",
 			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.6.0"
+		},
+		{
+			"group": "io.quarkus",
+			"name": "quarkus-mutiny",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
 		},
 		{
 			"group": "io.smallrye.reactive",
@@ -919,6 +959,14 @@
 			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
 		},
 		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-annotation",
+			"version": "1.13.0",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0"
+		},
+		{
 			"group": "io.quarkus",
 			"name": "quarkus-smallrye-context-propagation",
 			"version": "2.13.5.Final",
@@ -927,28 +975,20 @@
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final"
 		},
 		{
-			"group": "io.smallrye.reactive",
-			"name": "mutiny-smallrye-context-propagation",
-			"version": "1.7.0",
-			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
-		},
-		{
-			"group": "org.reactivestreams",
-			"name": "reactive-streams",
-			"version": "1.0.3",
-			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
-		},
-		{
 			"group": "io.smallrye",
 			"name": "smallrye-context-propagation",
 			"version": "1.2.2",
 			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+		},
+		{
+			"group": "org.eclipse.microprofile.context-propagation",
+			"name": "microprofile-context-propagation-api",
+			"version": "1.2",
+			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
 		},
 		{
 			"group": "io.smallrye",
@@ -967,20 +1007,60 @@
 			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
 		},
 		{
+			"group": "org.eclipse.microprofile.config",
+			"name": "microprofile-config-api",
+			"version": "1.4",
+			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4"
+		},
+		{
+			"group": "org.jboss.threads",
+			"name": "jboss-threads",
+			"version": "3.1.1.Final",
+			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final"
+		},
+		{
+			"group": "io.quarkus",
+			"name": "quarkus-arc",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final"
+		},
+		{
+			"group": "io.smallrye.reactive",
+			"name": "mutiny-smallrye-context-propagation",
+			"version": "1.7.0",
+			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
+		},
+		{
+			"group": "org.eclipse.microprofile.context-propagation",
+			"name": "microprofile-context-propagation-api",
+			"version": "1.3",
+			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3"
+		},
+		{
+			"group": "io.smallrye.common",
+			"name": "smallrye-common-vertx-context",
+			"version": "1.13.1",
+			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
+		},
+		{
 			"group": "io.vertx",
 			"name": "vertx-core",
 			"version": "4.3.3",
 			"purl": "pkg:maven/io.vertx/vertx-core@4.3.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.3"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-constraint",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
 		},
 		{
 			"group": "io.netty",
@@ -1008,6 +1088,14 @@
 		},
 		{
 			"group": "io.netty",
+			"name": "netty-resolver",
+			"version": "4.1.53.Final",
+			"purl": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
+		},
+		{
+			"group": "io.netty",
 			"name": "netty-handler",
 			"version": "4.1.53.Final",
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
@@ -1016,11 +1104,27 @@
 		},
 		{
 			"group": "io.netty",
+			"name": "netty-codec",
+			"version": "4.1.53.Final",
+			"purl": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+		},
+		{
+			"group": "io.netty",
 			"name": "netty-handler-proxy",
 			"version": "4.1.53.Final",
 			"purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final"
+		},
+		{
+			"group": "io.netty",
+			"name": "netty-codec-socks",
+			"version": "4.1.53.Final",
+			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final"
 		},
 		{
 			"group": "io.netty",
@@ -1040,27 +1144,11 @@
 		},
 		{
 			"group": "io.netty",
-			"name": "netty-resolver",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
 			"name": "netty-resolver-dns",
 			"version": "4.1.53.Final",
 			"purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-socks",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final"
 		},
 		{
 			"group": "io.netty",
@@ -1072,59 +1160,43 @@
 		},
 		{
 			"group": "io.quarkus",
+			"name": "quarkus-vertx-http-dev-console-runtime-spi",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
+		},
+		{
+			"group": "io.vertx",
+			"name": "vertx-web",
+			"version": "4.3.4",
+			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
+		},
+		{
+			"group": "io.smallrye.reactive",
+			"name": "mutiny",
+			"version": "0.4.3",
+			"purl": "pkg:maven/io.smallrye.reactive/mutiny@0.4.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@0.4.3"
+		},
+		{
+			"group": "io.quarkus",
+			"name": "quarkus-vertx",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
+		},
+		{
+			"group": "io.quarkus",
 			"name": "quarkus-netty",
 			"version": "2.13.5.Final",
 			"purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-haproxy",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-annotation",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx-latebound-mdc-provider",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-core",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
-		},
-		{
-			"group": "io.smallrye",
-			"name": "smallrye-fault-tolerance-vertx",
-			"version": "5.5.0",
-			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final"
 		},
 		{
 			"group": "com.aayushatharva.brotli4j",
@@ -1143,12 +1215,44 @@
 			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
 		},
 		{
+			"group": "io.netty",
+			"name": "netty-codec-haproxy",
+			"version": "4.1.53.Final",
+			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final"
+		},
+		{
+			"group": "io.quarkus",
+			"name": "quarkus-vertx-latebound-mdc-provider",
+			"version": "2.13.5.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
+		},
+		{
+			"group": "io.smallrye.reactive",
+			"name": "smallrye-mutiny-vertx-core",
+			"version": "2.27.0",
+			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+		},
+		{
 			"group": "io.smallrye.reactive",
 			"name": "smallrye-mutiny-vertx-runtime",
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
+		},
+		{
+			"group": "io.vertx",
+			"name": "vertx-core",
+			"version": "4.3.4",
+			"purl": "pkg:maven/io.vertx/vertx-core@4.3.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.4"
 		},
 		{
 			"group": "io.smallrye.reactive",
@@ -1167,12 +1271,36 @@
 			"bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
 		},
 		{
+			"group": "io.smallrye",
+			"name": "smallrye-fault-tolerance-vertx",
+			"version": "5.5.0",
+			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
+		},
+		{
+			"group": "io.smallrye.reactive",
+			"name": "smallrye-mutiny-vertx-web",
+			"version": "2.27.0",
+			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
+		},
+		{
 			"group": "io.smallrye.reactive",
 			"name": "smallrye-mutiny-vertx-web-common",
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
+		},
+		{
+			"group": "io.vertx",
+			"name": "vertx-web-common",
+			"version": "4.3.4",
+			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
 		},
 		{
 			"group": "io.smallrye.reactive",
@@ -1183,12 +1311,28 @@
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
 		},
 		{
+			"group": "io.vertx",
+			"name": "vertx-auth-common",
+			"version": "4.3.4",
+			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
+		},
+		{
 			"group": "io.smallrye.reactive",
 			"name": "smallrye-mutiny-vertx-bridge-common",
 			"version": "2.27.0",
 			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
+		},
+		{
+			"group": "io.vertx",
+			"name": "vertx-bridge-common",
+			"version": "4.3.4",
+			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
 		},
 		{
 			"group": "io.smallrye.reactive",
@@ -1207,28 +1351,12 @@
 			"bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
 		},
 		{
-			"group": "io.vertx",
-			"name": "vertx-web-common",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+			"group": "io.quarkus",
+			"name": "quarkus-jdbc-postgresql",
+			"version": "2.13.6.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
 			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-auth-common",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-bridge-common",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
 		},
 		{
 			"group": "io.quarkus",
@@ -1239,20 +1367,28 @@
 			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final"
 		},
 		{
+			"group": "io.quarkus.arc",
+			"name": "arc",
+			"version": "2.13.6.Final",
+			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.6.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.6.Final"
+		},
+		{
+			"group": "io.quarkus",
+			"name": "quarkus-core",
+			"version": "2.13.6.Final",
+			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.6.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.6.Final"
+		},
+		{
 			"group": "org.postgresql",
 			"name": "postgresql",
 			"version": "42.2.18",
 			"purl": "pkg:maven/org.postgresql/postgresql@42.2.18",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.postgresql/postgresql@42.2.18"
-		},
-		{
-			"group": "org.eclipse.microprofile.context-propagation",
-			"name": "microprofile-context-propagation-api",
-			"version": "1.2",
-			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
 		}
 	],
 	"dependencies": [
@@ -1278,53 +1414,51 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
-				"pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-				"pkg:maven/org.assertj/assertj-core@3.16.1",
-				"pkg:maven/org.hamcrest/hamcrest@2.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
-				"pkg:maven/org.mockito/mockito-core@3.3.3",
-				"pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
-				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-				"pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
-				"pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
-				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
-				"pkg:maven/org.postgresql/postgresql@42.2.18"
-			]
-		},
-		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
 			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
 				"pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
 			]
 		},
 		{
+			"ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
@@ -1335,45 +1469,39 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.yaml/snakeyaml@1.26",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
 			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-core@1.2.3"
+				"pkg:maven/ch.qos.logback/logback-core@1.2.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.30"
 			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
-			"dependsOn": [
-				"pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.30",
+				"pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.30"
+			]
+		},
+		{
+			"ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
 			"dependsOn": []
 		},
 		{
@@ -1381,12 +1509,41 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+			"ref": "pkg:maven/org.yaml/snakeyaml@1.26",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+				"pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+				"pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+				"pkg:maven/org.assertj/assertj-core@3.16.1",
+				"pkg:maven/org.hamcrest/hamcrest@2.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+				"pkg:maven/org.mockito/mockito-core@3.3.3",
+				"pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+				"pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+				"pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
@@ -1396,10 +1553,30 @@
 			]
 		},
 		{
+			"ref": "pkg:maven/net.minidev/json-smart@2.3",
+			"dependsOn": [
+				"pkg:maven/net.minidev/accessors-smart@1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/net.minidev/accessors-smart@1.2",
+			"dependsOn": [
+				"pkg:maven/org.ow2.asm/asm@5.0.4"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.ow2.asm/asm@5.0.4",
+			"dependsOn": []
+		},
+		{
 			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
 			"dependsOn": [
 				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
 			]
+		},
+		{
+			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.assertj/assertj-core@3.16.1",
@@ -1418,71 +1595,11 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/org.mockito/mockito-core@3.3.3",
-			"dependsOn": [
-				"pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
-				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
-				"pkg:maven/org.objenesis/objenesis@2.6"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"dependsOn": [
-				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/net.minidev/json-smart@2.3",
-			"dependsOn": [
-				"pkg:maven/net.minidev/accessors-smart@1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/net.minidev/accessors-smart@1.2",
-			"dependsOn": [
-				"pkg:maven/org.ow2.asm/asm@5.0.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.ow2.asm/asm@5.0.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
 			"dependsOn": [
 				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
 				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
 				"pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
-			"dependsOn": [
-				"pkg:maven/org.junit.platform/junit-platform-engine@1.6.3"
 			]
 		},
 		{
@@ -1495,11 +1612,40 @@
 		},
 		{
 			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+			"dependsOn": [
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
+			"dependsOn": [
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+				"pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
+				"pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.mockito/mockito-core@3.3.3",
+			"dependsOn": [
+				"pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+				"pkg:maven/org.objenesis/objenesis@2.6"
+			]
 		},
 		{
 			"ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
@@ -1514,12 +1660,47 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+			"dependsOn": [
+				"pkg:maven/org.mockito/mockito-core@3.3.3",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+			"dependsOn": [
+				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+			]
+		},
+		{
 			"ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
 			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
 				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
 				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
 				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
@@ -1527,24 +1708,10 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
-				"pkg:maven/org.glassfish/jakarta.el@3.0.3",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
-			]
-		},
-		{
 			"ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
 			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
 			]
 		},
 		{
@@ -1555,24 +1722,43 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+			"dependsOn": [
+				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+				"pkg:maven/org.glassfish/jakarta.el@3.0.3",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
@@ -1584,50 +1770,74 @@
 		},
 		{
 			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
+			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-			"dependsOn": []
+			"ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
+			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
-			"dependsOn": []
+			"ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final",
+				"pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
+			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+			"ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
 			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
+				"pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
 				"pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
 				"pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
 			]
 		},
 		{
+			"ref": "pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
+			"dependsOn": []
+		},
+		{
 			"ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
 			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
 				"pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+				"pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
 				"pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
 			]
 		},
 		{
-			"ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
 			"dependsOn": [
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
 				"pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
 				"pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
 				"pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
 				"pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
-				"pkg:maven/com.ibm.async/asyncutil@0.1.0"
+				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+				"pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+				"pkg:maven/com.ibm.async/asyncutil@0.1.0",
+				"pkg:maven/io.smallrye.config/smallrye-config@2.3.0"
 			]
 		},
 		{
-			"ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+			"ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
 			"dependsOn": []
 		},
 		{
@@ -1644,10 +1854,33 @@
 		},
 		{
 			"ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+			"dependsOn": [
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+				"pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+				"pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+				"pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+				"pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.config/smallrye-config@2.3.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
 			"dependsOn": []
 		},
 		{
@@ -1663,6 +1896,7 @@
 		{
 			"ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
 			"dependsOn": [
+				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
 				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 				"pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
 				"pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
@@ -1672,6 +1906,7 @@
 				"pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
 				"pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
 				"pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.30",
 				"pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
 				"pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
 				"pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
@@ -1680,76 +1915,33 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-				"pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
-				"pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-core@4.3.3",
-				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
-				"pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
-				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-				"pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-				"pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-web@4.3.4",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-web-common@4.3.4",
-				"pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-				"pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.github.crac/org-crac@0.1.1",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 			"dependsOn": [
 				"pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
-				"pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
+				"pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+				"pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
 			]
+		},
+		{
+			"ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+			"dependsOn": [
+				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
+			]
+		},
+		{
+			"ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+			"dependsOn": [
+				"pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
@@ -1766,15 +1958,74 @@
 		{
 			"ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
 			"dependsOn": [
-				"pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
+				"pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
 			]
 		},
 		{
-			"ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+			"ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+			"dependsOn": [
+				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+				"pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+				"pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+				"pkg:maven/org.ow2.asm/asm@9.3",
+				"pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+			"dependsOn": [
+				"pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+			"dependsOn": [
+				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+			"dependsOn": [
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.ow2.asm/asm@9.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
+			"dependsOn": [
+				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+				"pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+			"dependsOn": [
+				"pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001",
 			"dependsOn": []
 		},
 		{
@@ -1783,6 +2034,13 @@
 		},
 		{
 			"ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+			"dependsOn": [
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+				"pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final",
 			"dependsOn": []
 		},
 		{
@@ -1800,106 +2058,142 @@
 		{
 			"ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
 			"dependsOn": [
-				"pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
+				"pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+				"pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+				"pkg:maven/io.github.crac/org-crac@0.1.1"
 			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
-			"dependsOn": [
-				"pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
-			"dependsOn": [
-				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-				"pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+			"ref": "pkg:maven/io.github.crac/org-crac@0.1.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
 			"dependsOn": [
-				"pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+				"pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
 			]
 		},
 		{
-			"ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+			"ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
+			"dependsOn": [
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+				"pkg:maven/io.smallrye.reactive/mutiny@0.4.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
+			"dependsOn": [
+				"pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+			"dependsOn": [
+				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+				"pkg:maven/io.smallrye.reactive/mutiny@1.6.0",
+				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.reactive/mutiny@1.6.0",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+				"pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+				"pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
 			"dependsOn": [
-				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
+				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0"
 			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0",
+			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
 			"dependsOn": [
-				"pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+				"pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+				"pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final"
 			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
 			"dependsOn": [
+				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
 				"pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
-				"pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
+				"pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4",
+				"pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final"
 			]
 		},
 		{
-			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+			"ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+			"dependsOn": [
+				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
+			"dependsOn": [
+				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
+				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+				"pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-core@4.3.3",
+				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.vertx/vertx-core@4.3.3",
@@ -1912,12 +2206,9 @@
 				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
 				"pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
 				"pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-				"pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final"
+				"pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
 			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-common@4.1.53.Final",
@@ -1925,81 +2216,150 @@
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-resolver@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
 			"dependsOn": [
-				"pkg:maven/io.netty/netty-codec-socks@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-codec-dns@4.1.53.Final"
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
 			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
+				"pkg:maven/io.netty/netty-handler@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
+				"pkg:maven/io.netty/netty-handler@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+				"pkg:maven/io.netty/netty-handler@4.1.53.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.53.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+				"pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+				"pkg:maven/io.vertx/vertx-web@4.3.4"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.vertx/vertx-web@4.3.4",
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-web-common@4.3.4",
+				"pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+				"pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+				"pkg:maven/io.vertx/vertx-core@4.3.4"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.reactive/mutiny@0.4.3",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
+				"pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+				"pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+				"pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+				"pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+				"pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+				"pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
 			"dependsOn": [
 				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+				"pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
+				"pkg:maven/io.netty/netty-handler@4.1.53.Final",
+				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
 				"pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
 			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
-				"pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
@@ -2012,65 +2372,145 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
+				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+			"dependsOn": [
+				"pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+			"dependsOn": [
+				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+				"pkg:maven/io.vertx/vertx-core@4.3.4",
+				"pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
+			]
+		},
+		{
 			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+			"dependsOn": [
+				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+				"pkg:maven/io.vertx/vertx-core@4.3.4"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.vertx/vertx-core@4.3.4",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
 			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-codegen@4.3.4"
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+				"pkg:maven/io.vertx/vertx-codegen@4.3.4",
+				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0"
 			]
 		},
 		{
 			"ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-web@4.3.4",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-web-common@4.3.4",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-core@4.3.4"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-core@4.3.4"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-core@4.3.4"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
 			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-uri-template@4.3.4"
+				"pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
 			]
 		},
 		{
 			"ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.vertx/vertx-core@4.3.4"
+			]
 		},
 		{
-			"ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
-			"dependsOn": []
+			"ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+			"dependsOn": [
+				"pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+				"pkg:maven/org.postgresql/postgresql@42.2.18"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
 			"dependsOn": [
+				"pkg:maven/io.quarkus.arc/arc@2.13.6.Final",
+				"pkg:maven/io.quarkus/quarkus-core@2.13.6.Final",
 				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
 			]
 		},
 		{
-			"ref": "pkg:maven/org.postgresql/postgresql@42.2.18",
+			"ref": "pkg:maven/io.quarkus.arc/arc@2.13.6.Final",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+			"ref": "pkg:maven/io.quarkus/quarkus-core@2.13.6.Final",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.postgresql/postgresql@42.2.18",
 			"dependsOn": []
 		}
 	]

--- a/test/providers/tst_manifests/maven/poms_deps_with_2_ignore_long/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/poms_deps_with_2_ignore_long/stack_analysis_expected_sbom.json
@@ -1,2517 +1,2312 @@
 {
-	"bomFormat": "CycloneDX",
-	"specVersion": "1.4",
-	"version": 1,
-	"metadata": {
-		"timestamp": "2023-08-07T00:00:00.000Z",
-		"component": {
-			"group": "com.example",
-			"name": "demo",
-			"version": "0.0.1-SNAPSHOT",
-			"purl": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT",
-			"type": "application",
-			"bom-ref": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT"
-		}
-	},
-	"components": [
-		{
-			"group": "com.example",
-			"name": "demo",
-			"version": "0.0.1-SNAPSHOT",
-			"purl": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT",
-			"type": "application",
-			"bom-ref": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-core",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-context",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-aop",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-beans",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-expression",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-autoconfigure",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-logging",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-classic",
-			"version": "1.2.3",
-			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-core",
-			"version": "1.2.3",
-			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "slf4j-api",
-			"version": "1.7.30",
-			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-to-slf4j",
-			"version": "2.13.3",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-api",
-			"version": "2.13.3",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "jul-to-slf4j",
-			"version": "1.7.30",
-			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
-		},
-		{
-			"group": "jakarta.annotation",
-			"name": "jakarta.annotation-api",
-			"version": "1.3.5",
-			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-jcl",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.yaml",
-			"name": "snakeyaml",
-			"version": "1.26",
-			"purl": "pkg:maven/org.yaml/snakeyaml@1.26",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.26"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-test",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-test",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-test-autoconfigure",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE"
-		},
-		{
-			"group": "com.jayway.jsonpath",
-			"name": "json-path",
-			"version": "2.4.0",
-			"purl": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0"
-		},
-		{
-			"group": "net.minidev",
-			"name": "json-smart",
-			"version": "2.3",
-			"purl": "pkg:maven/net.minidev/json-smart@2.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/json-smart@2.3"
-		},
-		{
-			"group": "net.minidev",
-			"name": "accessors-smart",
-			"version": "1.2",
-			"purl": "pkg:maven/net.minidev/accessors-smart@1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/accessors-smart@1.2"
-		},
-		{
-			"group": "org.ow2.asm",
-			"name": "asm",
-			"version": "5.0.4",
-			"purl": "pkg:maven/org.ow2.asm/asm@5.0.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.ow2.asm/asm@5.0.4"
-		},
-		{
-			"group": "jakarta.xml.bind",
-			"name": "jakarta.xml.bind-api",
-			"version": "2.3.3",
-			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-		},
-		{
-			"group": "jakarta.activation",
-			"name": "jakarta.activation-api",
-			"version": "1.2.2",
-			"purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-		},
-		{
-			"group": "org.assertj",
-			"name": "assertj-core",
-			"version": "3.16.1",
-			"purl": "pkg:maven/org.assertj/assertj-core@3.16.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.16.1"
-		},
-		{
-			"group": "org.hamcrest",
-			"name": "hamcrest",
-			"version": "2.2",
-			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter",
-			"version": "5.6.3",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-api",
-			"version": "5.6.3",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
-		},
-		{
-			"group": "org.apiguardian",
-			"name": "apiguardian-api",
-			"version": "1.1.0",
-			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
-		},
-		{
-			"group": "org.opentest4j",
-			"name": "opentest4j",
-			"version": "1.2.0",
-			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-commons",
-			"version": "1.6.3",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-params",
-			"version": "5.6.3",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-engine",
-			"version": "5.6.3",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-engine",
-			"version": "1.6.3",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-core",
-			"version": "3.3.3",
-			"purl": "pkg:maven/org.mockito/mockito-core@3.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-core@3.3.3"
-		},
-		{
-			"group": "net.bytebuddy",
-			"name": "byte-buddy",
-			"version": "1.10.17",
-			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17"
-		},
-		{
-			"group": "net.bytebuddy",
-			"name": "byte-buddy-agent",
-			"version": "1.10.17",
-			"purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17"
-		},
-		{
-			"group": "org.objenesis",
-			"name": "objenesis",
-			"version": "2.6",
-			"purl": "pkg:maven/org.objenesis/objenesis@2.6",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.objenesis/objenesis@2.6"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-junit-jupiter",
-			"version": "3.3.3",
-			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3"
-		},
-		{
-			"group": "org.skyscreamer",
-			"name": "jsonassert",
-			"version": "1.5.0",
-			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
-		},
-		{
-			"group": "com.vaadin.external.google",
-			"name": "android-json",
-			"version": "0.0.20131108.vaadin1",
-			"purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-test",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE"
-		},
-		{
-			"group": "org.xmlunit",
-			"name": "xmlunit-core",
-			"version": "2.7.0",
-			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-web",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-json",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-web",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
-		},
-		{
-			"group": "com.fasterxml.jackson.datatype",
-			"name": "jackson-datatype-jdk8",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3"
-		},
-		{
-			"group": "com.fasterxml.jackson.datatype",
-			"name": "jackson-datatype-jsr310",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3"
-		},
-		{
-			"group": "com.fasterxml.jackson.module",
-			"name": "jackson-module-parameter-names",
-			"version": "2.11.3",
-			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-tomcat",
-			"version": "2.3.5.RELEASE",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-core",
-			"version": "9.0.39",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
-		},
-		{
-			"group": "org.glassfish",
-			"name": "jakarta.el",
-			"version": "3.0.3",
-			"purl": "pkg:maven/org.glassfish/jakarta.el@3.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.glassfish/jakarta.el@3.0.3"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-websocket",
-			"version": "9.0.39",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-webmvc",
-			"version": "5.2.10.RELEASE",
-			"purl": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-resteasy",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx-http",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-resteasy-server-common",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-core",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.7.7.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-arc",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-resteasy-common",
-			"version": "2.7.7.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final"
-		},
-		{
-			"group": "org.jboss.resteasy",
-			"name": "resteasy-core",
-			"version": "4.7.5.Final",
-			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final"
-		},
-		{
-			"group": "org.jboss.logging",
-			"name": "jboss-logging",
-			"version": "3.4.1.Final",
-			"purl": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
-		},
-		{
-			"group": "org.jboss.spec.javax.annotation",
-			"name": "jboss-annotations-api_1.3_spec",
-			"version": "2.0.1.Final",
-			"purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
-		},
-		{
-			"group": "org.jboss.spec.javax.ws.rs",
-			"name": "jboss-jaxrs-api_2.1_spec",
-			"version": "2.0.1.Final",
-			"purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
-		},
-		{
-			"group": "org.jboss.spec.javax.xml.bind",
-			"name": "jboss-jaxb-api_2.3_spec",
-			"version": "2.0.0.Final",
-			"purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
-		},
-		{
-			"group": "org.jboss.resteasy",
-			"name": "resteasy-core-spi",
-			"version": "4.7.5.Final",
-			"purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final"
-		},
-		{
-			"group": "org.reactivestreams",
-			"name": "reactive-streams",
-			"version": "1.0.3",
-			"purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
-		},
-		{
-			"group": "jakarta.validation",
-			"name": "jakarta.validation-api",
-			"version": "2.0.2",
-			"purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
-		},
-		{
-			"group": "com.ibm.async",
-			"name": "asyncutil",
-			"version": "0.1.0",
-			"purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
-		},
-		{
-			"group": "io.smallrye.config",
-			"name": "smallrye-config",
-			"version": "2.3.0",
-			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.3.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.3.0"
-		},
-		{
-			"group": "com.sun.activation",
-			"name": "jakarta.activation",
-			"version": "1.2.2",
-			"purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
-		},
-		{
-			"group": "org.apache.santuario",
-			"name": "xmlsec",
-			"version": "1.5.1",
-			"purl": "pkg:maven/org.apache.santuario/xmlsec@1.5.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.santuario/xmlsec@1.5.1"
-		},
-		{
-			"group": "commons-logging",
-			"name": "commons-logging",
-			"version": "1.1.1",
-			"purl": "pkg:maven/commons-logging/commons-logging@1.1.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/commons-logging/commons-logging@1.1.1"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-core",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final"
-		},
-		{
-			"group": "jakarta.enterprise",
-			"name": "jakarta.enterprise.cdi-api",
-			"version": "2.0.2",
-			"purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
-		},
-		{
-			"group": "jakarta.el",
-			"name": "jakarta.el-api",
-			"version": "3.0.3",
-			"purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
-		},
-		{
-			"group": "jakarta.interceptor",
-			"name": "jakarta.interceptor-api",
-			"version": "1.2.5",
-			"purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
-		},
-		{
-			"group": "jakarta.ejb",
-			"name": "jakarta.ejb-api",
-			"version": "3.2.6",
-			"purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
-		},
-		{
-			"group": "jakarta.transaction",
-			"name": "jakarta.transaction-api",
-			"version": "1.3.3",
-			"purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
-		},
-		{
-			"group": "jakarta.inject",
-			"name": "jakarta.inject-api",
-			"version": "1.0",
-			"purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-ide-launcher",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-development-mode-spi",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.config",
-			"name": "smallrye-config",
-			"version": "2.12.0",
-			"purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
-		},
-		{
-			"group": "io.smallrye.config",
-			"name": "smallrye-config-core",
-			"version": "2.12.0",
-			"purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
-		},
-		{
-			"group": "org.eclipse.microprofile.config",
-			"name": "microprofile-config-api",
-			"version": "2.0.1",
-			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-annotation",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-expression",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-function",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-constraint",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-classloader",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
-		},
-		{
-			"group": "org.ow2.asm",
-			"name": "asm",
-			"version": "9.3",
-			"purl": "pkg:maven/org.ow2.asm/asm@9.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.3"
-		},
-		{
-			"group": "io.smallrye.config",
-			"name": "smallrye-config-common",
-			"version": "2.12.0",
-			"purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
-		},
-		{
-			"group": "org.jboss.logmanager",
-			"name": "jboss-logmanager-embedded",
-			"version": "1.0.10",
-			"purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
-		},
-		{
-			"group": "org.wildfly.common",
-			"name": "wildfly-common",
-			"version": "1.5.0.Final-format-001",
-			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001"
-		},
-		{
-			"group": "org.jboss.logging",
-			"name": "jboss-logging-annotations",
-			"version": "2.2.1.Final",
-			"purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
-		},
-		{
-			"group": "org.jboss.threads",
-			"name": "jboss-threads",
-			"version": "3.4.3.Final",
-			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
-		},
-		{
-			"group": "org.wildfly.common",
-			"name": "wildfly-common",
-			"version": "1.5.0.Final",
-			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final"
-		},
-		{
-			"group": "org.jboss.slf4j",
-			"name": "slf4j-jboss-logmanager",
-			"version": "1.2.0.Final",
-			"purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
-		},
-		{
-			"group": "org.graalvm.sdk",
-			"name": "graal-sdk",
-			"version": "22.3.0",
-			"purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
-		},
-		{
-			"group": "org.wildfly.common",
-			"name": "wildfly-common",
-			"version": "1.5.4.Final-format-001",
-			"purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-bootstrap-runner",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-io",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
-		},
-		{
-			"group": "io.github.crac",
-			"name": "org-crac",
-			"version": "0.1.1",
-			"purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-fs-util",
-			"version": "0.0.9",
-			"purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-security-runtime-spi",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus.security",
-			"name": "quarkus-security",
-			"version": "1.1.4.Final",
-			"purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-credentials",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus.arc",
-			"name": "arc",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "mutiny",
-			"version": "1.6.0",
-			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.6.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.6.0"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-mutiny",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "mutiny",
-			"version": "1.7.0",
-			"purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-annotation",
-			"version": "1.13.0",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-smallrye-context-propagation",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye",
-			"name": "smallrye-context-propagation",
-			"version": "1.2.2",
-			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
-		},
-		{
-			"group": "org.eclipse.microprofile.context-propagation",
-			"name": "microprofile-context-propagation-api",
-			"version": "1.2",
-			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
-		},
-		{
-			"group": "io.smallrye",
-			"name": "smallrye-context-propagation-api",
-			"version": "1.2.2",
-			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
-		},
-		{
-			"group": "io.smallrye",
-			"name": "smallrye-context-propagation-storage",
-			"version": "1.2.2",
-			"purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
-		},
-		{
-			"group": "org.eclipse.microprofile.config",
-			"name": "microprofile-config-api",
-			"version": "1.4",
-			"purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4"
-		},
-		{
-			"group": "org.jboss.threads",
-			"name": "jboss-threads",
-			"version": "3.1.1.Final",
-			"purl": "pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-arc",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "mutiny-smallrye-context-propagation",
-			"version": "1.7.0",
-			"purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
-		},
-		{
-			"group": "org.eclipse.microprofile.context-propagation",
-			"name": "microprofile-context-propagation-api",
-			"version": "1.3",
-			"purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3"
-		},
-		{
-			"group": "io.smallrye.common",
-			"name": "smallrye-common-vertx-context",
-			"version": "1.13.1",
-			"purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-core",
-			"version": "4.3.3",
-			"purl": "pkg:maven/io.vertx/vertx-core@4.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.3"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-common",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-common@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-buffer",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-resolver",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-handler",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-handler-proxy",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-socks",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-http",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-http2",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-resolver-dns",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-dns",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx-http-dev-console-runtime-spi",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-web",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "mutiny",
-			"version": "0.4.3",
-			"purl": "pkg:maven/io.smallrye.reactive/mutiny@0.4.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@0.4.3"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-netty",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final"
-		},
-		{
-			"group": "com.aayushatharva.brotli4j",
-			"name": "brotli4j",
-			"version": "1.7.1",
-			"purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
-		},
-		{
-			"group": "com.aayushatharva.brotli4j",
-			"name": "native-linux-x86_64",
-			"version": "1.7.1",
-			"purl": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec-haproxy",
-			"version": "4.1.53.Final",
-			"purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-vertx-latebound-mdc-provider",
-			"version": "2.13.5.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-core",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-runtime",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-core",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-core@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.4"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "vertx-mutiny-generator",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-codegen",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
-		},
-		{
-			"group": "io.smallrye",
-			"name": "smallrye-fault-tolerance-vertx",
-			"version": "5.5.0",
-			"purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-web",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-web-common",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-web-common",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-auth-common",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-auth-common",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-bridge-common",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-bridge-common",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
-		},
-		{
-			"group": "io.smallrye.reactive",
-			"name": "smallrye-mutiny-vertx-uri-template",
-			"version": "2.27.0",
-			"purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
-		},
-		{
-			"group": "io.vertx",
-			"name": "vertx-uri-template",
-			"version": "4.3.4",
-			"purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-jdbc-postgresql",
-			"version": "2.13.6.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-arc",
-			"version": "2.13.6.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final"
-		},
-		{
-			"group": "io.quarkus.arc",
-			"name": "arc",
-			"version": "2.13.6.Final",
-			"purl": "pkg:maven/io.quarkus.arc/arc@2.13.6.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.6.Final"
-		},
-		{
-			"group": "io.quarkus",
-			"name": "quarkus-core",
-			"version": "2.13.6.Final",
-			"purl": "pkg:maven/io.quarkus/quarkus-core@2.13.6.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.6.Final"
-		},
-		{
-			"group": "org.postgresql",
-			"name": "postgresql",
-			"version": "42.2.18",
-			"purl": "pkg:maven/org.postgresql/postgresql@42.2.18",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.postgresql/postgresql@42.2.18"
-		}
-	],
-	"dependencies": [
-		{
-			"ref": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
-				"pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
-				"pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-				"pkg:maven/org.yaml/snakeyaml@1.26"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-classic@1.2.3",
-				"pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
-				"pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
-			]
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
-			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-core@1.2.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.30"
-			]
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.30",
-				"pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.30"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.yaml/snakeyaml@1.26",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
-				"pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-				"pkg:maven/org.assertj/assertj-core@3.16.1",
-				"pkg:maven/org.hamcrest/hamcrest@2.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
-				"pkg:maven/org.mockito/mockito-core@3.3.3",
-				"pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
-				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
-				"pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
-			"dependsOn": [
-				"pkg:maven/net.minidev/json-smart@2.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.30"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.minidev/json-smart@2.3",
-			"dependsOn": [
-				"pkg:maven/net.minidev/accessors-smart@1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.minidev/accessors-smart@1.2",
-			"dependsOn": [
-				"pkg:maven/org.ow2.asm/asm@5.0.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.ow2.asm/asm@5.0.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"dependsOn": [
-				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.assertj/assertj-core@3.16.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
-				"pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-core@3.3.3",
-			"dependsOn": [
-				"pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
-				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
-				"pkg:maven/org.objenesis/objenesis@2.6"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.objenesis/objenesis@2.6",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
-			"dependsOn": [
-				"pkg:maven/org.mockito/mockito-core@3.3.3",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"dependsOn": [
-				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
-				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
-				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
-			"dependsOn": [
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
-				"pkg:maven/org.glassfish/jakarta.el@3.0.3",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.glassfish/jakarta.el@3.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
-			"dependsOn": [
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
-				"pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final",
-				"pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx-http@2.7.7.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
-				"pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
-				"pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
-				"pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-core@2.7.7.Final",
-				"pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
-				"pkg:maven/io.quarkus/quarkus-arc@2.7.7.Final",
-				"pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
-				"pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
-				"pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
-				"pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
-				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-				"pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
-				"pkg:maven/com.ibm.async/asyncutil@0.1.0",
-				"pkg:maven/io.smallrye.config/smallrye-config@2.3.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
-				"pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
-				"pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
-				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-				"pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.config/smallrye-config@2.3.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.santuario/xmlsec@1.5.1",
-			"dependsOn": [
-				"pkg:maven/commons-logging/commons-logging@1.1.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/commons-logging/commons-logging@1.1.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
-				"pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
-				"pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
-				"pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
-				"pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
-				"pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
-				"pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.30",
-				"pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
-				"pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
-				"pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
-				"pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
-				"pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
-			"dependsOn": [
-				"pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
-				"pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
-				"pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
-			"dependsOn": [
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
-			"dependsOn": [
-				"pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
-			"dependsOn": [
-				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/org.ow2.asm/asm@9.3",
-				"pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.ow2.asm/asm@9.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
-			"dependsOn": [
-				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
-			"dependsOn": [
-				"pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final-format-001",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.0.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
-				"pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/io.github.crac/org-crac@0.1.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.github.crac/org-crac@0.1.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
-				"pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
-				"pkg:maven/io.smallrye.reactive/mutiny@0.4.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
-				"pkg:maven/io.smallrye.reactive/mutiny@1.6.0",
-				"pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/mutiny@1.6.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
-				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-				"pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
-				"pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-			"dependsOn": [
-				"pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
-				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
-				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
-				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
-				"pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
-			"dependsOn": [
-				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
-				"pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
-				"pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
-				"pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4",
-				"pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
-			"dependsOn": [
-				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
-				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@1.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.jboss.threads/jboss-threads@3.1.1.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
-			"dependsOn": [
-				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
-				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-				"pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-core@4.3.3",
-				"pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-core@4.3.3",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-handler@4.1.53.Final",
-				"pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-				"pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-common@4.1.53.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
-				"pkg:maven/io.netty/netty-handler@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
-				"pkg:maven/io.netty/netty-handler@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
-				"pkg:maven/io.netty/netty-handler@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.53.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
-				"pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
-				"pkg:maven/io.vertx/vertx-web@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-web@4.3.4",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-web-common@4.3.4",
-				"pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-				"pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
-				"pkg:maven/io.vertx/vertx-core@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/mutiny@0.4.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
-				"pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
-				"pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
-				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
-				"pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
-				"pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
-				"pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-				"pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
-				"pkg:maven/io.quarkus/quarkus-arc@2.13.5.Final",
-				"pkg:maven/io.netty/netty-handler@4.1.53.Final",
-				"pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
-				"pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
-			"dependsOn": [
-				"pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-buffer@4.1.53.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.53.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.53.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
-			"dependsOn": [
-				"pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
-				"pkg:maven/io.vertx/vertx-core@4.3.4",
-				"pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
-				"pkg:maven/io.vertx/vertx-core@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-core@4.3.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
-				"pkg:maven/io.vertx/vertx-codegen@4.3.4",
-				"pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-web@4.3.4",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-web-common@4.3.4",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-core@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-core@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-core@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-uri-template@4.3.4",
-				"pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
-			"dependsOn": [
-				"pkg:maven/io.vertx/vertx-core@4.3.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
-				"pkg:maven/org.postgresql/postgresql@42.2.18"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
-			"dependsOn": [
-				"pkg:maven/io.quarkus.arc/arc@2.13.6.Final",
-				"pkg:maven/io.quarkus/quarkus-core@2.13.6.Final",
-				"pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.quarkus.arc/arc@2.13.6.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.quarkus/quarkus-core@2.13.6.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.postgresql/postgresql@42.2.18",
-			"dependsOn": []
-		}
-	]
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "com.example",
+            "name": "demo",
+            "version": "0.0.1-SNAPSHOT",
+            "purl": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT",
+            "type": "application",
+            "bom-ref": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT"
+        }
+    },
+    "components": [
+        {
+            "group": "com.example",
+            "name": "demo",
+            "version": "0.0.1-SNAPSHOT",
+            "purl": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT",
+            "type": "application",
+            "bom-ref": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-core",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-context",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-aop",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-beans",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-expression",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-autoconfigure",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-logging",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-classic",
+            "version": "1.2.3",
+            "purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-core",
+            "version": "1.2.3",
+            "purl": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "slf4j-api",
+            "version": "1.7.30",
+            "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-to-slf4j",
+            "version": "2.13.3",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-api",
+            "version": "2.13.3",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "jul-to-slf4j",
+            "version": "1.7.30",
+            "purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
+        },
+        {
+            "group": "jakarta.annotation",
+            "name": "jakarta.annotation-api",
+            "version": "1.3.5",
+            "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-jcl",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.yaml",
+            "name": "snakeyaml",
+            "version": "1.26",
+            "purl": "pkg:maven/org.yaml/snakeyaml@1.26",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.yaml/snakeyaml@1.26"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-test",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test-autoconfigure",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE"
+        },
+        {
+            "group": "com.jayway.jsonpath",
+            "name": "json-path",
+            "version": "2.4.0",
+            "purl": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0"
+        },
+        {
+            "group": "net.minidev",
+            "name": "json-smart",
+            "version": "2.3",
+            "purl": "pkg:maven/net.minidev/json-smart@2.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/json-smart@2.3"
+        },
+        {
+            "group": "net.minidev",
+            "name": "accessors-smart",
+            "version": "1.2",
+            "purl": "pkg:maven/net.minidev/accessors-smart@1.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/accessors-smart@1.2"
+        },
+        {
+            "group": "org.ow2.asm",
+            "name": "asm",
+            "version": "5.0.4",
+            "purl": "pkg:maven/org.ow2.asm/asm@5.0.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.ow2.asm/asm@5.0.4"
+        },
+        {
+            "group": "jakarta.xml.bind",
+            "name": "jakarta.xml.bind-api",
+            "version": "2.3.3",
+            "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+        },
+        {
+            "group": "jakarta.activation",
+            "name": "jakarta.activation-api",
+            "version": "1.2.2",
+            "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+        },
+        {
+            "group": "org.assertj",
+            "name": "assertj-core",
+            "version": "3.16.1",
+            "purl": "pkg:maven/org.assertj/assertj-core@3.16.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.assertj/assertj-core@3.16.1"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest",
+            "version": "2.2",
+            "purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-api",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+        },
+        {
+            "group": "org.apiguardian",
+            "name": "apiguardian-api",
+            "version": "1.1.0",
+            "purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
+        },
+        {
+            "group": "org.opentest4j",
+            "name": "opentest4j",
+            "version": "1.2.0",
+            "purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-commons",
+            "version": "1.6.3",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-params",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-engine",
+            "version": "5.6.3",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-engine",
+            "version": "1.6.3",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-core",
+            "version": "3.3.3",
+            "purl": "pkg:maven/org.mockito/mockito-core@3.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-core@3.3.3"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy",
+            "version": "1.10.17",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy-agent",
+            "version": "1.10.17",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17"
+        },
+        {
+            "group": "org.objenesis",
+            "name": "objenesis",
+            "version": "2.6",
+            "purl": "pkg:maven/org.objenesis/objenesis@2.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.objenesis/objenesis@2.6"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-junit-jupiter",
+            "version": "3.3.3",
+            "purl": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3"
+        },
+        {
+            "group": "org.skyscreamer",
+            "name": "jsonassert",
+            "version": "1.5.0",
+            "purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+        },
+        {
+            "group": "com.vaadin.external.google",
+            "name": "android-json",
+            "version": "0.0.20131108.vaadin1",
+            "purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-test",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE"
+        },
+        {
+            "group": "org.xmlunit",
+            "name": "xmlunit-core",
+            "version": "2.7.0",
+            "purl": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-web",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-json",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-web",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-databind",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-annotations",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-core",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jdk8",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jsr310",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3"
+        },
+        {
+            "group": "com.fasterxml.jackson.module",
+            "name": "jackson-module-parameter-names",
+            "version": "2.11.3",
+            "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-tomcat",
+            "version": "2.3.5.RELEASE",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-core",
+            "version": "9.0.39",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
+        },
+        {
+            "group": "org.glassfish",
+            "name": "jakarta.el",
+            "version": "3.0.3",
+            "purl": "pkg:maven/org.glassfish/jakarta.el@3.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.glassfish/jakarta.el@3.0.3"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-websocket",
+            "version": "9.0.39",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-webmvc",
+            "version": "5.2.10.RELEASE",
+            "purl": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy-server-common",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-core",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-arc",
+            "version": "2.13.6.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-resteasy-common",
+            "version": "2.7.7.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final"
+        },
+        {
+            "group": "org.jboss.resteasy",
+            "name": "resteasy-core",
+            "version": "4.7.5.Final",
+            "purl": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final"
+        },
+        {
+            "group": "org.jboss.logging",
+            "name": "jboss-logging",
+            "version": "3.4.1.Final",
+            "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+        },
+        {
+            "group": "org.jboss.spec.javax.annotation",
+            "name": "jboss-annotations-api_1.3_spec",
+            "version": "2.0.1.Final",
+            "purl": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final"
+        },
+        {
+            "group": "org.jboss.spec.javax.ws.rs",
+            "name": "jboss-jaxrs-api_2.1_spec",
+            "version": "2.0.1.Final",
+            "purl": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final"
+        },
+        {
+            "group": "org.jboss.spec.javax.xml.bind",
+            "name": "jboss-jaxb-api_2.3_spec",
+            "version": "2.0.0.Final",
+            "purl": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final"
+        },
+        {
+            "group": "org.jboss.resteasy",
+            "name": "resteasy-core-spi",
+            "version": "4.7.5.Final",
+            "purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final"
+        },
+        {
+            "group": "org.reactivestreams",
+            "name": "reactive-streams",
+            "version": "1.0.3",
+            "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3"
+        },
+        {
+            "group": "jakarta.validation",
+            "name": "jakarta.validation-api",
+            "version": "2.0.2",
+            "purl": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+        },
+        {
+            "group": "com.ibm.async",
+            "name": "asyncutil",
+            "version": "0.1.0",
+            "purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0"
+        },
+        {
+            "group": "io.smallrye.config",
+            "name": "smallrye-config",
+            "version": "2.12.0",
+            "purl": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
+        },
+        {
+            "group": "com.sun.activation",
+            "name": "jakarta.activation",
+            "version": "1.2.2",
+            "purl": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
+        },
+        {
+            "group": "org.apache.santuario",
+            "name": "xmlsec",
+            "version": "1.5.1",
+            "purl": "pkg:maven/org.apache.santuario/xmlsec@1.5.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.santuario/xmlsec@1.5.1"
+        },
+        {
+            "group": "commons-logging",
+            "name": "commons-logging",
+            "version": "1.1.1",
+            "purl": "pkg:maven/commons-logging/commons-logging@1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-logging/commons-logging@1.1.1"
+        },
+        {
+            "group": "jakarta.enterprise",
+            "name": "jakarta.enterprise.cdi-api",
+            "version": "2.0.2",
+            "purl": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
+        },
+        {
+            "group": "jakarta.el",
+            "name": "jakarta.el-api",
+            "version": "3.0.3",
+            "purl": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3"
+        },
+        {
+            "group": "jakarta.interceptor",
+            "name": "jakarta.interceptor-api",
+            "version": "1.2.5",
+            "purl": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5"
+        },
+        {
+            "group": "jakarta.ejb",
+            "name": "jakarta.ejb-api",
+            "version": "3.2.6",
+            "purl": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
+        },
+        {
+            "group": "jakarta.transaction",
+            "name": "jakarta.transaction-api",
+            "version": "1.3.3",
+            "purl": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+        },
+        {
+            "group": "jakarta.inject",
+            "name": "jakarta.inject-api",
+            "version": "1.0",
+            "purl": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-ide-launcher",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-development-mode-spi",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.config",
+            "name": "smallrye-config-core",
+            "version": "2.12.0",
+            "purl": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0"
+        },
+        {
+            "group": "org.eclipse.microprofile.config",
+            "name": "microprofile-config-api",
+            "version": "2.0.1",
+            "purl": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-annotation",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-expression",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-function",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-constraint",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-classloader",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1"
+        },
+        {
+            "group": "io.smallrye.config",
+            "name": "smallrye-config-common",
+            "version": "2.12.0",
+            "purl": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
+        },
+        {
+            "group": "org.jboss.logmanager",
+            "name": "jboss-logmanager-embedded",
+            "version": "1.0.10",
+            "purl": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
+        },
+        {
+            "group": "org.wildfly.common",
+            "name": "wildfly-common",
+            "version": "1.5.4.Final-format-001",
+            "purl": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
+        },
+        {
+            "group": "org.jboss.logging",
+            "name": "jboss-logging-annotations",
+            "version": "2.2.1.Final",
+            "purl": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final"
+        },
+        {
+            "group": "org.jboss.threads",
+            "name": "jboss-threads",
+            "version": "3.4.3.Final",
+            "purl": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
+        },
+        {
+            "group": "org.jboss.slf4j",
+            "name": "slf4j-jboss-logmanager",
+            "version": "1.2.0.Final",
+            "purl": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final"
+        },
+        {
+            "group": "org.graalvm.sdk",
+            "name": "graal-sdk",
+            "version": "22.3.0",
+            "purl": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-bootstrap-runner",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-io",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1"
+        },
+        {
+            "group": "io.github.crac",
+            "name": "org-crac",
+            "version": "0.1.1",
+            "purl": "pkg:maven/io.github.crac/org-crac@0.1.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.github.crac/org-crac@0.1.1"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-fs-util",
+            "version": "0.0.9",
+            "purl": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-security-runtime-spi",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus.security",
+            "name": "quarkus-security",
+            "version": "1.1.4.Final",
+            "purl": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-credentials",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus.arc",
+            "name": "arc",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "mutiny",
+            "version": "1.7.0",
+            "purl": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-mutiny",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-smallrye-context-propagation",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-context-propagation",
+            "version": "1.2.2",
+            "purl": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+        },
+        {
+            "group": "org.eclipse.microprofile.context-propagation",
+            "name": "microprofile-context-propagation-api",
+            "version": "1.2",
+            "purl": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-context-propagation-api",
+            "version": "1.2.2",
+            "purl": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-context-propagation-storage",
+            "version": "1.2.2",
+            "purl": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "mutiny-smallrye-context-propagation",
+            "version": "1.7.0",
+            "purl": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
+        },
+        {
+            "group": "io.smallrye.common",
+            "name": "smallrye-common-vertx-context",
+            "version": "1.13.1",
+            "purl": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-core",
+            "version": "4.3.3",
+            "purl": "pkg:maven/io.vertx/vertx-core@4.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-core@4.3.3"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-common",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-common@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-common@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-buffer",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-resolver",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-handler",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-handler-proxy",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-socks",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-http",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-http2",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-resolver-dns",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-dns",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx-http-dev-console-runtime-spi",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-web",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-web@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-web@4.3.4"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-netty",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final"
+        },
+        {
+            "group": "com.aayushatharva.brotli4j",
+            "name": "brotli4j",
+            "version": "1.7.1",
+            "purl": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
+        },
+        {
+            "group": "com.aayushatharva.brotli4j",
+            "name": "native-linux-x86_64",
+            "version": "1.7.1",
+            "purl": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec-haproxy",
+            "version": "4.1.53.Final",
+            "purl": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-vertx-latebound-mdc-provider",
+            "version": "2.13.5.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-core",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-runtime",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "vertx-mutiny-generator",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-codegen",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4"
+        },
+        {
+            "group": "io.smallrye",
+            "name": "smallrye-fault-tolerance-vertx",
+            "version": "5.5.0",
+            "purl": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-web",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-web-common",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-web-common",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-auth-common",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-auth-common",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-bridge-common",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-bridge-common",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4"
+        },
+        {
+            "group": "io.smallrye.reactive",
+            "name": "smallrye-mutiny-vertx-uri-template",
+            "version": "2.27.0",
+            "purl": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
+        },
+        {
+            "group": "io.vertx",
+            "name": "vertx-uri-template",
+            "version": "4.3.4",
+            "purl": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4"
+        },
+        {
+            "group": "io.quarkus",
+            "name": "quarkus-jdbc-postgresql",
+            "version": "2.13.6.Final",
+            "purl": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
+        },
+        {
+            "group": "org.postgresql",
+            "name": "postgresql",
+            "version": "42.2.18",
+            "purl": "pkg:maven/org.postgresql/postgresql@42.2.18",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.postgresql/postgresql@42.2.18"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/com.example/demo@0.0.1-SNAPSHOT",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+                "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+                "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.yaml/snakeyaml@1.26"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+                "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+                "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-core@1.2.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.13.3",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+                "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.13.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.30",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-jcl@5.2.10.RELEASE",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.yaml/snakeyaml@1.26",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+                "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+                "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+                "pkg:maven/org.assertj/assertj-core@3.16.1",
+                "pkg:maven/org.hamcrest/hamcrest@2.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+                "pkg:maven/org.mockito/mockito-core@3.3.3",
+                "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+                "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+                "pkg:maven/org.xmlunit/xmlunit-core@2.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.3.5.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.jayway.jsonpath/json-path@2.4.0",
+            "dependsOn": [
+                "pkg:maven/net.minidev/json-smart@2.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/json-smart@2.3",
+            "dependsOn": [
+                "pkg:maven/net.minidev/accessors-smart@1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/accessors-smart@1.2",
+            "dependsOn": [
+                "pkg:maven/org.ow2.asm/asm@5.0.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.ow2.asm/asm@5.0.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "dependsOn": [
+                "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.assertj/assertj-core@3.16.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.0",
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-core@3.3.3",
+            "dependsOn": [
+                "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+                "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+                "pkg:maven/org.objenesis/objenesis@2.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy@1.10.17",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.10.17",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.objenesis/objenesis@2.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-junit-jupiter@3.3.3",
+            "dependsOn": [
+                "pkg:maven/org.mockito/mockito-core@3.3.3",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.6.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "dependsOn": [
+                "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-test@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-core@2.7.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+                "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.3.5.RELEASE",
+                "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.11.3",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.3.5.RELEASE",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+                "pkg:maven/org.glassfish/jakarta.el@3.0.3",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.glassfish/jakarta.el@3.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.39",
+            "dependsOn": [
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.39"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-webmvc@5.2.10.RELEASE",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-beans@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-context@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-core@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-expression@5.2.10.RELEASE",
+                "pkg:maven/org.springframework/spring-web@5.2.10.RELEASE"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy@2.7.7.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy-server-common@2.7.7.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
+                "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
+                "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
+                "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+                "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
+                "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.30",
+                "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
+                "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
+                "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
+                "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-resteasy-common@2.7.7.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/com.sun.activation/jakarta.activation@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.resteasy/resteasy-core@4.7.5.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+                "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+                "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+                "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+                "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+                "pkg:maven/io.smallrye.config/smallrye-config@2.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@4.7.5.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec@2.0.1.Final",
+                "pkg:maven/org.jboss.spec.javax.xml.bind/jboss-jaxb-api_2.3_spec@2.0.0.Final",
+                "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+                "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.validation/jakarta.validation-api@2.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.config/smallrye-config@2.12.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.sun.activation/jakarta.activation@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.santuario/xmlsec@1.5.1",
+            "dependsOn": [
+                "pkg:maven/commons-logging/commons-logging@1.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/commons-logging/commons-logging@1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+            "dependsOn": [
+                "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+                "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+                "pkg:maven/jakarta.inject/jakarta.inject-api@1.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.ejb/jakarta.ejb-api@3.2.6",
+            "dependsOn": [
+                "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.inject/jakarta.inject-api@1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-ide-launcher@2.13.5.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-development-mode-spi@2.13.5.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.config/smallrye-config-core@2.12.0",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.ow2.asm/asm@5.0.4",
+                "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-expression@1.13.1",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-function@1.13.1",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.config/smallrye-config-common@2.12.0",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-classloader@1.13.1",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+            "dependsOn": [
+                "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.logging/jboss-logging-annotations@2.2.1.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/org.wildfly.common/wildfly-common@1.5.4.Final-format-001"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.jboss.slf4j/slf4j-jboss-logmanager@1.2.0.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.graalvm.sdk/graal-sdk@22.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-bootstrap-runner@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+                "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/io.github.crac/org-crac@0.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-io@1.13.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.github.crac/org-crac@0.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-fs-util@0.0.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-security-runtime-spi@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus.security/quarkus-security@1.1.4.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-credentials@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus.arc/arc@2.13.5.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/jakarta.transaction/jakarta.transaction-api@1.3.3",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/org.jboss.logging/jboss-logging@3.4.1.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+            "dependsOn": [
+                "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-smallrye-context-propagation@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+                "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+                "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+                "pkg:maven/org.eclipse.microprofile.config/microprofile-config-api@2.0.1",
+                "pkg:maven/org.jboss.threads/jboss-threads@3.4.3.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-context-propagation-api@1.2.2",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-context-propagation-storage@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/mutiny-smallrye-context-propagation@1.7.0",
+            "dependsOn": [
+                "pkg:maven/org.eclipse.microprofile.context-propagation/microprofile-context-propagation-api@1.2",
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.smallrye/smallrye-context-propagation@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3",
+                "pkg:maven/io.smallrye.common/smallrye-common-constraint@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-core@4.3.3",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-common@4.1.53.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-handler-proxy@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-socks@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-dns@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.53.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx-http-dev-console-runtime-spi@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final",
+                "pkg:maven/io.quarkus.arc/arc@2.13.5.Final",
+                "pkg:maven/io.vertx/vertx-web@4.3.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-web@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+                "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+                "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+                "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1",
+                "pkg:maven/io.smallrye.common/smallrye-common-vertx-context@1.13.1",
+                "pkg:maven/io.quarkus/quarkus-mutiny@2.13.5.Final",
+                "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+                "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-netty@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec-http2@4.1.53.Final",
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/io.netty/netty-handler@4.1.53.Final",
+                "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2",
+                "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.aayushatharva.brotli4j/brotli4j@1.7.1",
+            "dependsOn": [
+                "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.aayushatharva.brotli4j/native-linux-x86_64@1.7.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec-haproxy@4.1.53.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-buffer@4.1.53.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.53.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.53.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-vertx-latebound-mdc-provider@2.13.5.Final",
+            "dependsOn": [
+                "pkg:maven/org.jboss.logmanager/jboss-logmanager-embedded@1.0.10"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+                "pkg:maven/io.vertx/vertx-core@4.3.3",
+                "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.reactive/mutiny@1.7.0",
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/vertx-mutiny-generator@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-runtime@2.27.0",
+                "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+                "pkg:maven/io.smallrye.common/smallrye-common-annotation@1.13.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-codegen@4.3.4",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.11.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye/smallrye-fault-tolerance-vertx@5.5.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-web@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-web-common@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-web-common@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-auth-common@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-auth-common@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-bridge-common@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-bridge-common@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-uri-template@2.27.0",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+                "pkg:maven/io.smallrye.reactive/smallrye-mutiny-vertx-core@2.27.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.vertx/vertx-uri-template@4.3.4",
+            "dependsOn": [
+                "pkg:maven/io.vertx/vertx-core@4.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.6.Final",
+            "dependsOn": [
+                "pkg:maven/io.quarkus/quarkus-arc@2.13.6.Final",
+                "pkg:maven/org.postgresql/postgresql@42.2.18"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.postgresql/postgresql@42.2.18",
+            "dependsOn": []
+        }
+    ]
 }

--- a/test/providers/tst_manifests/maven/poms_deps_with_ignore_long/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/poms_deps_with_ignore_long/stack_analysis_expected_sbom.json
@@ -1,1842 +1,1806 @@
 {
-	"bomFormat": "CycloneDX",
-	"specVersion": "1.4",
-	"version": 1,
-	"metadata": {
-		"timestamp": "2023-08-07T00:00:00.000Z",
-		"component": {
-			"group": "com.redhat.examples",
-			"name": "custom-metrics-demo",
-			"version": "0.0.1-SNAPSHOT",
-			"purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
-			"type": "application",
-			"bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
-		}
-	},
-	"components": [
-		{
-			"group": "com.redhat.examples",
-			"name": "custom-metrics-demo",
-			"version": "0.0.1-SNAPSHOT",
-			"purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
-			"type": "application",
-			"bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-actuator",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-core",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-context",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-context@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-logging",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-classic",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-core",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "slf4j-api",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-to-slf4j",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-api",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "jul-to-slf4j",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
-		},
-		{
-			"group": "jakarta.annotation",
-			"name": "jakarta.annotation-api",
-			"version": "1.3.5",
-			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
-		},
-		{
-			"group": "org.yaml",
-			"name": "snakeyaml",
-			"version": "1.29",
-			"purl": "pkg:maven/org.yaml/snakeyaml@1.29",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.29"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-actuator-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-actuator",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.13.2.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-		},
-		{
-			"group": "com.fasterxml.jackson.datatype",
-			"name": "jackson-datatype-jsr310",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
-		},
-		{
-			"group": "io.micrometer",
-			"name": "micrometer-core",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
-		},
-		{
-			"group": "org.hdrhistogram",
-			"name": "HdrHistogram",
-			"version": "2.1.12",
-			"purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12"
-		},
-		{
-			"group": "org.latencyutils",
-			"name": "LatencyUtils",
-			"version": "2.0.3",
-			"purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
-		},
-		{
-			"group": "io.micrometer",
-			"name": "micrometer-registry-prometheus",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_common",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_otel",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_common",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_otel_agent",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-web",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-json",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-web",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-web@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-web@5.3.19"
-		},
-		{
-			"group": "com.fasterxml.jackson.datatype",
-			"name": "jackson-datatype-jdk8",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.module",
-			"name": "jackson-module-parameter-names",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-tomcat",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-core",
-			"version": "9.0.62",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-el",
-			"version": "9.0.62",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-websocket",
-			"version": "9.0.62",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-beans",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-beans@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-beans@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-webmvc",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-aop",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-aop@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-aop@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-expression",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-expression@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-expression@5.3.19"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-clients",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1"
-		},
-		{
-			"group": "com.github.luben",
-			"name": "zstd-jni",
-			"version": "1.5.0-2",
-			"purl": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2"
-		},
-		{
-			"group": "org.lz4",
-			"name": "lz4-java",
-			"version": "1.7.1",
-			"purl": "pkg:maven/org.lz4/lz4-java@1.7.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.lz4/lz4-java@1.7.1"
-		},
-		{
-			"group": "org.xerial.snappy",
-			"name": "snappy-java",
-			"version": "1.1.8.1",
-			"purl": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
-		},
-		{
-			"group": "org.rocksdb",
-			"name": "rocksdbjni",
-			"version": "6.19.3",
-			"purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-messaging",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-messaging@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-messaging@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-tx",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-tx@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-tx@5.3.19"
-		},
-		{
-			"group": "org.springframework.retry",
-			"name": "spring-retry",
-			"version": "1.3.3",
-			"purl": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3"
-		},
-		{
-			"group": "com.google.code.findbugs",
-			"name": "jsr305",
-			"version": "3.0.2",
-			"purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-test",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-test",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-test-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7"
-		},
-		{
-			"group": "com.jayway.jsonpath",
-			"name": "json-path",
-			"version": "2.6.0",
-			"purl": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0"
-		},
-		{
-			"group": "net.minidev",
-			"name": "json-smart",
-			"version": "2.4.8",
-			"purl": "pkg:maven/net.minidev/json-smart@2.4.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/json-smart@2.4.8"
-		},
-		{
-			"group": "net.minidev",
-			"name": "accessors-smart",
-			"version": "2.4.8",
-			"purl": "pkg:maven/net.minidev/accessors-smart@2.4.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/accessors-smart@2.4.8"
-		},
-		{
-			"group": "org.ow2.asm",
-			"name": "asm",
-			"version": "9.1",
-			"purl": "pkg:maven/org.ow2.asm/asm@9.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.1"
-		},
-		{
-			"group": "jakarta.xml.bind",
-			"name": "jakarta.xml.bind-api",
-			"version": "2.3.3",
-			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-		},
-		{
-			"group": "jakarta.activation",
-			"name": "jakarta.activation-api",
-			"version": "1.2.2",
-			"purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-		},
-		{
-			"group": "org.assertj",
-			"name": "assertj-core",
-			"version": "3.21.0",
-			"purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
-		},
-		{
-			"group": "org.hamcrest",
-			"name": "hamcrest",
-			"version": "2.2",
-			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-api",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-params",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2"
-		},
-		{
-			"group": "org.apiguardian",
-			"name": "apiguardian-api",
-			"version": "1.1.2",
-			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-engine",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-engine",
-			"version": "1.8.2",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
-		},
-		{
-			"group": "org.opentest4j",
-			"name": "opentest4j",
-			"version": "1.2.0",
-			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-commons",
-			"version": "1.8.2",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-core",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
-		},
-		{
-			"group": "net.bytebuddy",
-			"name": "byte-buddy",
-			"version": "1.11.22",
-			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22"
-		},
-		{
-			"group": "net.bytebuddy",
-			"name": "byte-buddy-agent",
-			"version": "1.11.22",
-			"purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22"
-		},
-		{
-			"group": "org.objenesis",
-			"name": "objenesis",
-			"version": "3.2",
-			"purl": "pkg:maven/org.objenesis/objenesis@3.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.objenesis/objenesis@3.2"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-junit-jupiter",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
-		},
-		{
-			"group": "org.skyscreamer",
-			"name": "jsonassert",
-			"version": "1.5.0",
-			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
-		},
-		{
-			"group": "com.vaadin.external.google",
-			"name": "android-json",
-			"version": "0.0.20131108.vaadin1",
-			"purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-jcl",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-jcl@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-jcl@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-test",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
-		},
-		{
-			"group": "org.xmlunit",
-			"name": "xmlunit-core",
-			"version": "2.8.4",
-			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka-test",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
-		},
-		{
-			"group": "org.apache.zookeeper",
-			"name": "zookeeper",
-			"version": "3.6.3",
-			"purl": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3"
-		},
-		{
-			"group": "org.apache.zookeeper",
-			"name": "zookeeper-jute",
-			"version": "3.6.3",
-			"purl": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3"
-		},
-		{
-			"group": "org.apache.yetus",
-			"name": "audience-annotations",
-			"version": "0.5.0",
-			"purl": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-handler",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-common",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-common@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-resolver",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-buffer",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-native-epoll",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-native-unix-common",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-classes-epoll",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-clients",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-metadata",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-server-common",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-raft",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1"
-		},
-		{
-			"group": "com.yammer.metrics",
-			"name": "metrics-core",
-			"version": "2.2.0",
-			"purl": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams-test-utils",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-library",
-			"version": "2.13.6",
-			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.6",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.6"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-storage",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-storage-api",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
-		},
-		{
-			"group": "net.sourceforge.argparse4j",
-			"name": "argparse4j",
-			"version": "0.7.0",
-			"purl": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0"
-		},
-		{
-			"group": "com.fasterxml.jackson.module",
-			"name": "jackson-module-scala_2.13",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2"
-		},
-		{
-			"group": "com.thoughtworks.paranamer",
-			"name": "paranamer",
-			"version": "2.8",
-			"purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
-		},
-		{
-			"group": "com.fasterxml.jackson.dataformat",
-			"name": "jackson-dataformat-csv",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2"
-		},
-		{
-			"group": "net.sf.jopt-simple",
-			"name": "jopt-simple",
-			"version": "5.0.4",
-			"purl": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4"
-		},
-		{
-			"group": "org.scala-lang.modules",
-			"name": "scala-collection-compat_2.13",
-			"version": "2.4.4",
-			"purl": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-library",
-			"version": "2.13.5",
-			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.5"
-		},
-		{
-			"group": "org.scala-lang.modules",
-			"name": "scala-java8-compat_2.13",
-			"version": "1.0.0",
-			"purl": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-reflect",
-			"version": "2.13.6",
-			"purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6"
-		},
-		{
-			"group": "com.typesafe.scala-logging",
-			"name": "scala-logging_2.13",
-			"version": "3.9.3",
-			"purl": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-library",
-			"version": "2.13.4",
-			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.4"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-reflect",
-			"version": "2.13.4",
-			"purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4"
-		},
-		{
-			"group": "io.dropwizard.metrics",
-			"name": "metrics-core",
-			"version": "4.2.9",
-			"purl": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9"
-		},
-		{
-			"group": "commons-cli",
-			"name": "commons-cli",
-			"version": "1.4",
-			"purl": "pkg:maven/commons-cli/commons-cli@1.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
-		}
-	],
-	"dependencies": [
-		{
-			"ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
-				"pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-				"pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-				"pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-				"pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-				"pkg:maven/io.micrometer/micrometer-core@1.8.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.yaml/snakeyaml@1.29"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-context@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-jcl@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-context@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.3.19",
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-expression@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
-			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-classic@1.2.11",
-				"pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-				"pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
-			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-core@1.2.11",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.yaml/snakeyaml@1.29",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"dependsOn": [
-				"pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-				"pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"dependsOn": [
-				"pkg:maven/io.micrometer/micrometer-core@1.8.5",
-				"pkg:maven/io.prometheus/simpleclient_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
-				"pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-				"pkg:maven/org.springframework/spring-web@5.3.19",
-				"pkg:maven/org.springframework/spring-webmvc@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework/spring-web@5.3.19",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-web@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-			"dependsOn": [
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
-			"dependsOn": [
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-beans@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.3.19",
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-expression@5.3.19",
-				"pkg:maven/org.springframework/spring-web@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-aop@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-expression@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-			"dependsOn": [
-				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-				"pkg:maven/org.lz4/lz4-java@1.7.1",
-				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.lz4/lz4-java@1.7.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-messaging@5.3.19",
-				"pkg:maven/org.springframework/spring-tx@5.3.19",
-				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-messaging@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-tx@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-				"pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-				"pkg:maven/org.assertj/assertj-core@3.21.0",
-				"pkg:maven/org.hamcrest/hamcrest@2.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-				"pkg:maven/org.mockito/mockito-core@4.0.0",
-				"pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-test@5.3.19",
-				"pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-			"dependsOn": [
-				"pkg:maven/net.minidev/json-smart@2.4.8",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.minidev/json-smart@2.4.8",
-			"dependsOn": [
-				"pkg:maven/net.minidev/accessors-smart@2.4.8"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.minidev/accessors-smart@2.4.8",
-			"dependsOn": [
-				"pkg:maven/org.ow2.asm/asm@9.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.ow2.asm/asm@9.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"dependsOn": [
-				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
-			"dependsOn": [
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"dependsOn": [
-				"pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-				"pkg:maven/org.objenesis/objenesis@3.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.objenesis/objenesis@3.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"dependsOn": [
-				"pkg:maven/org.mockito/mockito-core@4.0.0",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"dependsOn": [
-				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-jcl@5.3.19",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"dependsOn": [
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-test@5.3.19",
-				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/org.apache.kafka/kafka-clients@test",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@test",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
-				"pkg:maven/io.netty/netty-handler@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-common@4.1.76.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"dependsOn": [
-				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-				"pkg:maven/org.lz4/lz4-java@1.7.1",
-				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/commons-cli/commons-cli@1.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.6",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.5",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.6"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.4",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.4",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/commons-cli/commons-cli@1.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/commons-cli/commons-cli@1.4"
-			]
-		}
-	]
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "com.redhat.examples",
+            "name": "custom-metrics-demo",
+            "version": "0.0.1-SNAPSHOT",
+            "purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
+            "type": "application",
+            "bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
+        }
+    },
+    "components": [
+        {
+            "group": "com.redhat.examples",
+            "name": "custom-metrics-demo",
+            "version": "0.0.1-SNAPSHOT",
+            "purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
+            "type": "application",
+            "bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-actuator",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-core",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-core@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-context",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-context@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-autoconfigure",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-logging",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-classic",
+            "version": "1.2.11",
+            "purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-core",
+            "version": "1.2.11",
+            "purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "slf4j-api",
+            "version": "1.7.36",
+            "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-to-slf4j",
+            "version": "2.17.2",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-api",
+            "version": "2.17.2",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "jul-to-slf4j",
+            "version": "1.7.36",
+            "purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+        },
+        {
+            "group": "jakarta.annotation",
+            "name": "jakarta.annotation-api",
+            "version": "1.3.5",
+            "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
+        },
+        {
+            "group": "org.yaml",
+            "name": "snakeyaml",
+            "version": "1.29",
+            "purl": "pkg:maven/org.yaml/snakeyaml@1.29",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.yaml/snakeyaml@1.29"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-actuator-autoconfigure",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-actuator",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-databind",
+            "version": "2.13.2.1",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jsr310",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-annotations",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-core",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+        },
+        {
+            "group": "io.micrometer",
+            "name": "micrometer-core",
+            "version": "1.8.5",
+            "purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
+        },
+        {
+            "group": "org.hdrhistogram",
+            "name": "HdrHistogram",
+            "version": "2.1.12",
+            "purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12"
+        },
+        {
+            "group": "org.latencyutils",
+            "name": "LatencyUtils",
+            "version": "2.0.3",
+            "purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+        },
+        {
+            "group": "io.micrometer",
+            "name": "micrometer-registry-prometheus",
+            "version": "1.8.5",
+            "purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_common",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_tracer_otel",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_tracer_common",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_tracer_otel_agent",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-web",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-json",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-web",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-web@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-web@5.3.19"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jdk8",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2"
+        },
+        {
+            "group": "com.fasterxml.jackson.module",
+            "name": "jackson-module-parameter-names",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-tomcat",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-core",
+            "version": "9.0.62",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-el",
+            "version": "9.0.62",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-websocket",
+            "version": "9.0.62",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-beans",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-beans@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-beans@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-webmvc",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-aop",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-aop@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-aop@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-expression",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-expression@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-expression@5.3.19"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-streams",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-clients",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1"
+        },
+        {
+            "group": "com.github.luben",
+            "name": "zstd-jni",
+            "version": "1.5.0-2",
+            "purl": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2"
+        },
+        {
+            "group": "org.lz4",
+            "name": "lz4-java",
+            "version": "1.7.1",
+            "purl": "pkg:maven/org.lz4/lz4-java@1.7.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.lz4/lz4-java@1.7.1"
+        },
+        {
+            "group": "org.xerial.snappy",
+            "name": "snappy-java",
+            "version": "1.1.8.1",
+            "purl": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
+        },
+        {
+            "group": "org.rocksdb",
+            "name": "rocksdbjni",
+            "version": "6.19.3",
+            "purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
+        },
+        {
+            "group": "org.springframework.kafka",
+            "name": "spring-kafka",
+            "version": "2.8.5",
+            "purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-messaging",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-messaging@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-messaging@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-tx",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-tx@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-tx@5.3.19"
+        },
+        {
+            "group": "org.springframework.retry",
+            "name": "spring-retry",
+            "version": "1.3.3",
+            "purl": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3"
+        },
+        {
+            "group": "com.google.code.findbugs",
+            "name": "jsr305",
+            "version": "3.0.2",
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-test",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test-autoconfigure",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7"
+        },
+        {
+            "group": "com.jayway.jsonpath",
+            "name": "json-path",
+            "version": "2.6.0",
+            "purl": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0"
+        },
+        {
+            "group": "net.minidev",
+            "name": "json-smart",
+            "version": "2.4.8",
+            "purl": "pkg:maven/net.minidev/json-smart@2.4.8",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/json-smart@2.4.8"
+        },
+        {
+            "group": "net.minidev",
+            "name": "accessors-smart",
+            "version": "2.4.8",
+            "purl": "pkg:maven/net.minidev/accessors-smart@2.4.8",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/accessors-smart@2.4.8"
+        },
+        {
+            "group": "org.ow2.asm",
+            "name": "asm",
+            "version": "9.1",
+            "purl": "pkg:maven/org.ow2.asm/asm@9.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.ow2.asm/asm@9.1"
+        },
+        {
+            "group": "jakarta.xml.bind",
+            "name": "jakarta.xml.bind-api",
+            "version": "2.3.3",
+            "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+        },
+        {
+            "group": "jakarta.activation",
+            "name": "jakarta.activation-api",
+            "version": "1.2.2",
+            "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+        },
+        {
+            "group": "org.assertj",
+            "name": "assertj-core",
+            "version": "3.21.0",
+            "purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest",
+            "version": "2.2",
+            "purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-api",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-params",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2"
+        },
+        {
+            "group": "org.apiguardian",
+            "name": "apiguardian-api",
+            "version": "1.1.2",
+            "purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-engine",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-engine",
+            "version": "1.8.2",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
+        },
+        {
+            "group": "org.opentest4j",
+            "name": "opentest4j",
+            "version": "1.2.0",
+            "purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-commons",
+            "version": "1.8.2",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-core",
+            "version": "4.0.0",
+            "purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy",
+            "version": "1.11.22",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy-agent",
+            "version": "1.11.22",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22"
+        },
+        {
+            "group": "org.objenesis",
+            "name": "objenesis",
+            "version": "3.2",
+            "purl": "pkg:maven/org.objenesis/objenesis@3.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.objenesis/objenesis@3.2"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-junit-jupiter",
+            "version": "4.0.0",
+            "purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
+        },
+        {
+            "group": "org.skyscreamer",
+            "name": "jsonassert",
+            "version": "1.5.0",
+            "purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+        },
+        {
+            "group": "com.vaadin.external.google",
+            "name": "android-json",
+            "version": "0.0.20131108.vaadin1",
+            "purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-jcl",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-jcl@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-jcl@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-test",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-test@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
+        },
+        {
+            "group": "org.xmlunit",
+            "name": "xmlunit-core",
+            "version": "2.8.4",
+            "purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+        },
+        {
+            "group": "org.springframework.kafka",
+            "name": "spring-kafka-test",
+            "version": "2.8.5",
+            "purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
+        },
+        {
+            "group": "org.apache.zookeeper",
+            "name": "zookeeper",
+            "version": "3.6.3",
+            "purl": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3"
+        },
+        {
+            "group": "org.apache.zookeeper",
+            "name": "zookeeper-jute",
+            "version": "3.6.3",
+            "purl": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3"
+        },
+        {
+            "group": "org.apache.yetus",
+            "name": "audience-annotations",
+            "version": "0.5.0",
+            "purl": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-handler",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-common",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-common@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-common@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-resolver",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-buffer",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport-native-epoll",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport-native-unix-common",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport-classes-epoll",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-clients",
+            "version": "test",
+            "purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-metadata",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-server-common",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-raft",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1"
+        },
+        {
+            "group": "com.yammer.metrics",
+            "name": "metrics-core",
+            "version": "2.2.0",
+            "purl": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-streams-test-utils",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka_2.13",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
+        },
+        {
+            "group": "org.scala-lang",
+            "name": "scala-library",
+            "version": "2.13.6",
+            "purl": "pkg:maven/org.scala-lang/scala-library@2.13.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.6"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-storage",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-storage-api",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
+        },
+        {
+            "group": "net.sourceforge.argparse4j",
+            "name": "argparse4j",
+            "version": "0.7.0",
+            "purl": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0"
+        },
+        {
+            "group": "com.fasterxml.jackson.module",
+            "name": "jackson-module-scala_2.13",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2"
+        },
+        {
+            "group": "com.thoughtworks.paranamer",
+            "name": "paranamer",
+            "version": "2.8",
+            "purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
+        },
+        {
+            "group": "com.fasterxml.jackson.dataformat",
+            "name": "jackson-dataformat-csv",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2"
+        },
+        {
+            "group": "net.sf.jopt-simple",
+            "name": "jopt-simple",
+            "version": "5.0.4",
+            "purl": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4"
+        },
+        {
+            "group": "org.scala-lang.modules",
+            "name": "scala-collection-compat_2.13",
+            "version": "2.4.4",
+            "purl": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4"
+        },
+        {
+            "group": "org.scala-lang.modules",
+            "name": "scala-java8-compat_2.13",
+            "version": "1.0.0",
+            "purl": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0"
+        },
+        {
+            "group": "org.scala-lang",
+            "name": "scala-reflect",
+            "version": "2.13.6",
+            "purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6"
+        },
+        {
+            "group": "com.typesafe.scala-logging",
+            "name": "scala-logging_2.13",
+            "version": "3.9.3",
+            "purl": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3"
+        },
+        {
+            "group": "io.dropwizard.metrics",
+            "name": "metrics-core",
+            "version": "4.2.9",
+            "purl": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9"
+        },
+        {
+            "group": "commons-cli",
+            "name": "commons-cli",
+            "version": "1.4",
+            "purl": "pkg:maven/commons-cli/commons-cli@1.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka_2.13",
+            "version": "test",
+            "purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
+                "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
+                "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+                "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+                "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
+                "pkg:maven/io.micrometer/micrometer-core@1.8.5"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.yaml/snakeyaml@1.29"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-context@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-core@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-jcl@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-context@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.3.19",
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-expression@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+                "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+                "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.yaml/snakeyaml@1.29",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+            "dependsOn": [
+                "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+                "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+            "dependsOn": [
+                "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+                "pkg:maven/io.prometheus/simpleclient_common@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
+                "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+                "pkg:maven/org.springframework/spring-web@5.3.19",
+                "pkg:maven/org.springframework/spring-webmvc@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework/spring-web@5.3.19",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-web@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
+            "dependsOn": [
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-beans@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.3.19",
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-context@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-expression@5.3.19",
+                "pkg:maven/org.springframework/spring-web@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-aop@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-expression@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+            "dependsOn": [
+                "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+                "pkg:maven/org.lz4/lz4-java@1.7.1",
+                "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.lz4/lz4-java@1.7.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-context@5.3.19",
+                "pkg:maven/org.springframework/spring-messaging@5.3.19",
+                "pkg:maven/org.springframework/spring-tx@5.3.19",
+                "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-messaging@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-tx@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+                "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+                "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+                "pkg:maven/org.assertj/assertj-core@3.21.0",
+                "pkg:maven/org.hamcrest/hamcrest@2.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+                "pkg:maven/org.mockito/mockito-core@4.0.0",
+                "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+                "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-test@5.3.19",
+                "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+            "dependsOn": [
+                "pkg:maven/net.minidev/json-smart@2.4.8",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/json-smart@2.4.8",
+            "dependsOn": [
+                "pkg:maven/net.minidev/accessors-smart@2.4.8"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/accessors-smart@2.4.8",
+            "dependsOn": [
+                "pkg:maven/org.ow2.asm/asm@9.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.ow2.asm/asm@9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "dependsOn": [
+                "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+            "dependsOn": [
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
+            "dependsOn": [
+                "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+                "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+                "pkg:maven/org.objenesis/objenesis@3.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.objenesis/objenesis@3.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+            "dependsOn": [
+                "pkg:maven/org.mockito/mockito-core@4.0.0",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "dependsOn": [
+                "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-jcl@5.3.19",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-test@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+            "dependsOn": [
+                "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-context@5.3.19",
+                "pkg:maven/org.springframework/spring-test@5.3.19",
+                "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+                "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+                "pkg:maven/org.apache.kafka/kafka-clients@test",
+                "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka_2.13@test",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
+                "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
+                "pkg:maven/io.netty/netty-handler@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-common@4.1.76.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
+            "dependsOn": [
+                "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+                "pkg:maven/org.lz4/lz4-java@1.7.1",
+                "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+                "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+                "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+                "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+                "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+                "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+                "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+                "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+                "pkg:maven/commons-cli/commons-cli@1.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang/scala-library@2.13.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/commons-cli/commons-cli@1.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+                "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+                "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+                "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+                "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+                "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+                "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+                "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+                "pkg:maven/commons-cli/commons-cli@1.4"
+            ]
+        }
+    ]
 }

--- a/test/providers/tst_manifests/maven/poms_deps_with_ignore_long/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/poms_deps_with_ignore_long/stack_analysis_expected_sbom.json
@@ -31,54 +31,6 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7"
 		},
 		{
-			"group": "io.micrometer",
-			"name": "micrometer-registry-prometheus",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-web",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-test",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka-test",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
-		},
-		{
 			"group": "org.springframework.boot",
 			"name": "spring-boot-starter",
 			"version": "2.6.7",
@@ -88,27 +40,27 @@
 		},
 		{
 			"group": "org.springframework.boot",
-			"name": "spring-boot-actuator-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
-		},
-		{
-			"group": "io.micrometer",
-			"name": "micrometer-core",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
-		},
-		{
-			"group": "org.springframework.boot",
 			"name": "spring-boot",
 			"version": "2.6.7",
 			"purl": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-core",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-core@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-context",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-context@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -127,6 +79,54 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7"
 		},
 		{
+			"group": "ch.qos.logback",
+			"name": "logback-classic",
+			"version": "1.2.11",
+			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"type": "library",
+			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
+		},
+		{
+			"group": "ch.qos.logback",
+			"name": "logback-core",
+			"version": "1.2.11",
+			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+			"type": "library",
+			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
+		},
+		{
+			"group": "org.slf4j",
+			"name": "slf4j-api",
+			"version": "1.7.36",
+			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+		},
+		{
+			"group": "org.apache.logging.log4j",
+			"name": "log4j-to-slf4j",
+			"version": "2.17.2",
+			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
+		},
+		{
+			"group": "org.apache.logging.log4j",
+			"name": "log4j-api",
+			"version": "2.17.2",
+			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+		},
+		{
+			"group": "org.slf4j",
+			"name": "jul-to-slf4j",
+			"version": "1.7.36",
+			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+		},
+		{
 			"group": "jakarta.annotation",
 			"name": "jakarta.annotation-api",
 			"version": "1.3.5",
@@ -143,44 +143,12 @@
 			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.29"
 		},
 		{
-			"group": "ch.qos.logback",
-			"name": "logback-classic",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"group": "org.springframework.boot",
+			"name": "spring-boot-actuator-autoconfigure",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
 			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-to-slf4j",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "jul-to-slf4j",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-core",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-api",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -191,12 +159,44 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7"
 		},
 		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-databind",
+			"version": "2.13.2.1",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+		},
+		{
 			"group": "com.fasterxml.jackson.datatype",
 			"name": "jackson-datatype-jsr310",
 			"version": "2.13.2",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-annotations",
+			"version": "2.13.2",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-core",
+			"version": "2.13.2",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+		},
+		{
+			"group": "io.micrometer",
+			"name": "micrometer-core",
+			"version": "1.8.5",
+			"purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
 		},
 		{
 			"group": "org.hdrhistogram",
@@ -213,6 +213,14 @@
 			"purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+		},
+		{
+			"group": "io.micrometer",
+			"name": "micrometer-registry-prometheus",
+			"version": "1.8.5",
+			"purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
 		},
 		{
 			"group": "io.prometheus",
@@ -240,6 +248,14 @@
 		},
 		{
 			"group": "io.prometheus",
+			"name": "simpleclient_tracer_common",
+			"version": "0.12.0",
+			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+		},
+		{
+			"group": "io.prometheus",
 			"name": "simpleclient_tracer_otel_agent",
 			"version": "0.12.0",
 			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
@@ -247,12 +263,12 @@
 			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
 		},
 		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_common",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-web",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
 			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -263,28 +279,12 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7"
 		},
 		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-tomcat",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
-		},
-		{
 			"group": "org.springframework",
 			"name": "spring-web",
 			"version": "5.3.19",
 			"purl": "pkg:maven/org.springframework/spring-web@5.3.19",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.springframework/spring-web@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-webmvc",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
 		},
 		{
 			"group": "com.fasterxml.jackson.datatype",
@@ -301,6 +301,14 @@
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+		},
+		{
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-tomcat",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
 		},
 		{
 			"group": "org.apache.tomcat.embed",
@@ -336,6 +344,14 @@
 		},
 		{
 			"group": "org.springframework",
+			"name": "spring-webmvc",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
+		},
+		{
+			"group": "org.springframework",
 			"name": "spring-aop",
 			"version": "5.3.19",
 			"purl": "pkg:maven/org.springframework/spring-aop@5.3.19",
@@ -352,43 +368,19 @@
 		},
 		{
 			"group": "org.apache.kafka",
+			"name": "kafka-streams",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
+		},
+		{
+			"group": "org.apache.kafka",
 			"name": "kafka-clients",
 			"version": "3.0.1",
 			"purl": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1"
-		},
-		{
-			"group": "org.rocksdb",
-			"name": "rocksdbjni",
-			"version": "6.19.3",
-			"purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "slf4j-api",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.13.2.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
 		},
 		{
 			"group": "com.github.luben",
@@ -415,20 +407,20 @@
 			"bom-ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
 		},
 		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"group": "org.rocksdb",
+			"name": "rocksdbjni",
+			"version": "6.19.3",
+			"purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
 			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+			"bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
 		},
 		{
-			"group": "org.springframework",
-			"name": "spring-context",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-context@5.3.19",
+			"group": "org.springframework.kafka",
+			"name": "spring-kafka",
+			"version": "2.8.5",
+			"purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
+			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
 		},
 		{
 			"group": "org.springframework",
@@ -464,6 +456,14 @@
 		},
 		{
 			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-test",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
+		},
+		{
+			"group": "org.springframework.boot",
 			"name": "spring-boot-test",
 			"version": "2.6.7",
 			"purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
@@ -485,86 +485,6 @@
 			"purl": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0"
-		},
-		{
-			"group": "jakarta.xml.bind",
-			"name": "jakarta.xml.bind-api",
-			"version": "2.3.3",
-			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-		},
-		{
-			"group": "org.assertj",
-			"name": "assertj-core",
-			"version": "3.21.0",
-			"purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
-		},
-		{
-			"group": "org.hamcrest",
-			"name": "hamcrest",
-			"version": "2.2",
-			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-core",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-junit-jupiter",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
-		},
-		{
-			"group": "org.skyscreamer",
-			"name": "jsonassert",
-			"version": "1.5.0",
-			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-core",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-test",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
-		},
-		{
-			"group": "org.xmlunit",
-			"name": "xmlunit-core",
-			"version": "2.8.4",
-			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
 		},
 		{
 			"group": "net.minidev",
@@ -591,6 +511,14 @@
 			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.1"
 		},
 		{
+			"group": "jakarta.xml.bind",
+			"name": "jakarta.xml.bind-api",
+			"version": "2.3.3",
+			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+		},
+		{
 			"group": "jakarta.activation",
 			"name": "jakarta.activation-api",
 			"version": "1.2.2",
@@ -599,12 +527,52 @@
 			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
 		},
 		{
+			"group": "org.assertj",
+			"name": "assertj-core",
+			"version": "3.21.0",
+			"purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
+		},
+		{
+			"group": "org.hamcrest",
+			"name": "hamcrest",
+			"version": "2.2",
+			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
+		},
+		{
+			"group": "org.junit.jupiter",
+			"name": "junit-jupiter",
+			"version": "5.8.2",
+			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
+		},
+		{
+			"group": "org.junit.jupiter",
+			"name": "junit-jupiter-api",
+			"version": "5.8.2",
+			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+		},
+		{
 			"group": "org.junit.jupiter",
 			"name": "junit-jupiter-params",
 			"version": "5.8.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2"
+		},
+		{
+			"group": "org.apiguardian",
+			"name": "apiguardian-api",
+			"version": "1.1.2",
+			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
 		},
 		{
 			"group": "org.junit.jupiter",
@@ -621,6 +589,30 @@
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
+		},
+		{
+			"group": "org.opentest4j",
+			"name": "opentest4j",
+			"version": "1.2.0",
+			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
+		},
+		{
+			"group": "org.junit.platform",
+			"name": "junit-platform-commons",
+			"version": "1.8.2",
+			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
+		},
+		{
+			"group": "org.mockito",
+			"name": "mockito-core",
+			"version": "4.0.0",
+			"purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
 		},
 		{
 			"group": "net.bytebuddy",
@@ -647,6 +639,22 @@
 			"bom-ref": "pkg:maven/org.objenesis/objenesis@3.2"
 		},
 		{
+			"group": "org.mockito",
+			"name": "mockito-junit-jupiter",
+			"version": "4.0.0",
+			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
+		},
+		{
+			"group": "org.skyscreamer",
+			"name": "jsonassert",
+			"version": "1.5.0",
+			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+		},
+		{
 			"group": "com.vaadin.external.google",
 			"name": "android-json",
 			"version": "0.0.20131108.vaadin1",
@@ -663,60 +671,36 @@
 			"bom-ref": "pkg:maven/org.springframework/spring-jcl@5.3.19"
 		},
 		{
+			"group": "org.springframework",
+			"name": "spring-test",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-test@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
+		},
+		{
+			"group": "org.xmlunit",
+			"name": "xmlunit-core",
+			"version": "2.8.4",
+			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+		},
+		{
+			"group": "org.springframework.kafka",
+			"name": "spring-kafka-test",
+			"version": "2.8.5",
+			"purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
+		},
+		{
 			"group": "org.apache.zookeeper",
 			"name": "zookeeper",
 			"version": "3.6.3",
 			"purl": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-clients",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-metadata",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams-test-utils",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-api",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
 		},
 		{
 			"group": "org.apache.zookeeper",
@@ -741,14 +725,6 @@
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-native-epoll",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
 		},
 		{
 			"group": "io.netty",
@@ -792,6 +768,14 @@
 		},
 		{
 			"group": "io.netty",
+			"name": "netty-transport-native-epoll",
+			"version": "4.1.76.Final",
+			"purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
+		},
+		{
+			"group": "io.netty",
 			"name": "netty-transport-native-unix-common",
 			"version": "4.1.76.Final",
 			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
@@ -805,6 +789,22 @@
 			"purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+		},
+		{
+			"group": "org.apache.kafka",
+			"name": "kafka-clients",
+			"version": "test",
+			"purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
+		},
+		{
+			"group": "org.apache.kafka",
+			"name": "kafka-metadata",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
 		},
 		{
 			"group": "org.apache.kafka",
@@ -831,6 +831,22 @@
 			"bom-ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
 		},
 		{
+			"group": "org.apache.kafka",
+			"name": "kafka-streams-test-utils",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
+		},
+		{
+			"group": "org.apache.kafka",
+			"name": "kafka_2.13",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
+		},
+		{
 			"group": "org.scala-lang",
 			"name": "scala-library",
 			"version": "2.13.6",
@@ -847,6 +863,14 @@
 			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1"
 		},
 		{
+			"group": "org.apache.kafka",
+			"name": "kafka-storage-api",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
+		},
+		{
 			"group": "net.sourceforge.argparse4j",
 			"name": "argparse4j",
 			"version": "0.7.0",
@@ -861,6 +885,14 @@
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2"
+		},
+		{
+			"group": "com.thoughtworks.paranamer",
+			"name": "paranamer",
+			"version": "2.8",
+			"purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
 		},
 		{
 			"group": "com.fasterxml.jackson.dataformat",
@@ -887,6 +919,14 @@
 			"bom-ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4"
 		},
 		{
+			"group": "org.scala-lang",
+			"name": "scala-library",
+			"version": "2.13.5",
+			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.5"
+		},
+		{
 			"group": "org.scala-lang.modules",
 			"name": "scala-java8-compat_2.13",
 			"version": "1.0.0",
@@ -911,6 +951,22 @@
 			"bom-ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3"
 		},
 		{
+			"group": "org.scala-lang",
+			"name": "scala-library",
+			"version": "2.13.4",
+			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.4"
+		},
+		{
+			"group": "org.scala-lang",
+			"name": "scala-reflect",
+			"version": "2.13.4",
+			"purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4"
+		},
+		{
 			"group": "io.dropwizard.metrics",
 			"name": "metrics-core",
 			"version": "4.2.9",
@@ -928,43 +984,11 @@
 		},
 		{
 			"group": "org.apache.kafka",
-			"name": "kafka-storage-api",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+			"name": "kafka_2.13",
+			"version": "test",
+			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
-		},
-		{
-			"group": "com.thoughtworks.paranamer",
-			"name": "paranamer",
-			"version": "2.8",
-			"purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
-		},
-		{
-			"group": "org.opentest4j",
-			"name": "opentest4j",
-			"version": "1.2.0",
-			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-commons",
-			"version": "1.8.2",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
-		},
-		{
-			"group": "org.apiguardian",
-			"name": "apiguardian-api",
-			"version": "1.1.2",
-			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
 		}
 	],
 	"dependencies": [
@@ -989,101 +1013,43 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-				"pkg:maven/org.springframework/spring-web@5.3.19",
-				"pkg:maven/org.springframework/spring-webmvc@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-messaging@5.3.19",
-				"pkg:maven/org.springframework/spring-tx@5.3.19",
-				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-				"pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-				"pkg:maven/org.assertj/assertj-core@3.21.0",
-				"pkg:maven/org.hamcrest/hamcrest@2.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-				"pkg:maven/org.mockito/mockito-core@4.0.0",
-				"pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-test@5.3.19",
-				"pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/org.apache.kafka/kafka-clients@test",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@test",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
-			]
-		},
-		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
 			"dependsOn": [
 				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
 				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
 				"pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
 				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
 				"pkg:maven/org.yaml/snakeyaml@1.29"
 			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"dependsOn": [
-				"pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-				"pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
-			]
-		},
-		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-context@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-core@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-jcl@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-context@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-aop@5.3.19",
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-expression@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
@@ -1091,6 +1057,38 @@
 				"pkg:maven/ch.qos.logback/logback-classic@1.2.11",
 				"pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
 				"pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"dependsOn": [
+				"pkg:maven/ch.qos.logback/logback-core@1.2.11",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
@@ -1102,36 +1100,50 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
 			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-core@1.2.11"
+				"pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
 			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"dependsOn": [
-				"pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+			"dependsOn": [
+				"pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+				"pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
@@ -1140,6 +1152,13 @@
 		{
 			"ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+			"dependsOn": [
+				"pkg:maven/io.micrometer/micrometer-core@1.8.5",
+				"pkg:maven/io.prometheus/simpleclient_common@0.12.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
@@ -1161,48 +1180,65 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
 			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+				"pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
 			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
 			"dependsOn": [
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+				"pkg:maven/org.springframework/spring-web@5.3.19",
+				"pkg:maven/org.springframework/spring-webmvc@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+				"pkg:maven/org.springframework/spring-web@5.3.19",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
 			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-web@5.3.19",
 			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.3.19",
-				"pkg:maven/org.springframework/spring-expression@5.3.19"
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
 			]
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+			"dependsOn": [
+				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
@@ -1214,44 +1250,57 @@
 		},
 		{
 			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-beans@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-aop@5.3.19",
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-context@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-expression@5.3.19",
+				"pkg:maven/org.springframework/spring-web@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-aop@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-expression@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
 			"dependsOn": [
 				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
 				"pkg:maven/org.lz4/lz4-java@1.7.1",
-				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
@@ -1267,20 +1316,33 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.springframework/spring-context@5.3.19",
-			"dependsOn": []
+			"ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-context@5.3.19",
+				"pkg:maven/org.springframework/spring-messaging@5.3.19",
+				"pkg:maven/org.springframework/spring-tx@5.3.19",
+				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-messaging@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-tx@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
@@ -1291,71 +1353,44 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+				"pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+				"pkg:maven/org.assertj/assertj-core@3.21.0",
+				"pkg:maven/org.hamcrest/hamcrest@2.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+				"pkg:maven/org.mockito/mockito-core@4.0.0",
+				"pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-test@5.3.19",
+				"pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
 			"dependsOn": [
-				"pkg:maven/net.minidev/json-smart@2.4.8"
+				"pkg:maven/net.minidev/json-smart@2.4.8",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"dependsOn": [
-				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"dependsOn": [
-				"pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-				"pkg:maven/org.objenesis/objenesis@3.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"dependsOn": [
-				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-jcl@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/net.minidev/json-smart@2.4.8",
@@ -1374,22 +1409,83 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+			"dependsOn": [
+				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+			]
+		},
+		{
 			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+			"dependsOn": [
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+			"dependsOn": [
+				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
+				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+			"dependsOn": [
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
 			"dependsOn": [
-				"pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
+				"pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
 			]
 		},
 		{
 			"ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+			"dependsOn": [
+				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
+				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+			"dependsOn": [
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
+			"dependsOn": [
+				"pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+				"pkg:maven/org.objenesis/objenesis@3.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
@@ -1404,6 +1500,19 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+			"dependsOn": [
+				"pkg:maven/org.mockito/mockito-core@4.0.0",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+			"dependsOn": [
+				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+			]
+		},
+		{
 			"ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
 			"dependsOn": []
 		},
@@ -1412,62 +1521,48 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.springframework/spring-test@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+			"dependsOn": [
+				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-context@5.3.19",
+				"pkg:maven/org.springframework/spring-test@5.3.19",
+				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+				"pkg:maven/org.apache.kafka/kafka-clients@test",
+				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka_2.13@test",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
 			"dependsOn": [
 				"pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
 				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
 				"pkg:maven/io.netty/netty-handler@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-				"pkg:maven/commons-cli/commons-cli@1.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+				"pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
@@ -1484,51 +1579,139 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
-			]
-		},
-		{
 			"ref": "pkg:maven/io.netty/netty-common@4.1.76.Final",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-resolver@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
+			"dependsOn": [
+				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+				"pkg:maven/org.lz4/lz4-java@1.7.1",
+				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.scala-lang/scala-library@2.13.6",
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+				"pkg:maven/commons-cli/commons-cli@1.4"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.6",
@@ -1537,7 +1720,18 @@
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
 			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
+				"pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
@@ -1547,12 +1741,24 @@
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
 			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.6",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
 				"pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
 			]
 		},
 		{
-			"ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+			"ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
@@ -1560,47 +1766,77 @@
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.5"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.5",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.5"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.6"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.4",
+				"pkg:maven/org.scala-lang/scala-reflect@2.13.4",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
 		},
 		{
 			"ref": "pkg:maven/commons-cli/commons-cli@1.4",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"dependsOn": []
+			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.scala-lang/scala-library@2.13.6",
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+				"pkg:maven/commons-cli/commons-cli@1.4"
+			]
 		}
 	]
 }

--- a/test/providers/tst_manifests/maven/poms_deps_with_no_ignore_long/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/poms_deps_with_no_ignore_long/stack_analysis_expected_sbom.json
@@ -1,1855 +1,1819 @@
 {
-	"bomFormat": "CycloneDX",
-	"specVersion": "1.4",
-	"version": 1,
-	"metadata": {
-		"timestamp": "2023-08-07T00:00:00.000Z",
-		"component": {
-			"group": "com.redhat.examples",
-			"name": "custom-metrics-demo",
-			"version": "0.0.1-SNAPSHOT",
-			"purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
-			"type": "application",
-			"bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
-		}
-	},
-	"components": [
-		{
-			"group": "com.redhat.examples",
-			"name": "custom-metrics-demo",
-			"version": "0.0.1-SNAPSHOT",
-			"purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
-			"type": "application",
-			"bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-actuator",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-core",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-context",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-context@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-logging",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-classic",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-core",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "slf4j-api",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-to-slf4j",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-api",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "jul-to-slf4j",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
-		},
-		{
-			"group": "jakarta.annotation",
-			"name": "jakarta.annotation-api",
-			"version": "1.3.5",
-			"purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
-		},
-		{
-			"group": "org.yaml",
-			"name": "snakeyaml",
-			"version": "1.29",
-			"purl": "pkg:maven/org.yaml/snakeyaml@1.29",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.29"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-actuator-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-actuator",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.13.2.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-		},
-		{
-			"group": "com.fasterxml.jackson.datatype",
-			"name": "jackson-datatype-jsr310",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
-		},
-		{
-			"group": "io.micrometer",
-			"name": "micrometer-core",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
-		},
-		{
-			"group": "org.hdrhistogram",
-			"name": "HdrHistogram",
-			"version": "2.1.12",
-			"purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12"
-		},
-		{
-			"group": "org.latencyutils",
-			"name": "LatencyUtils",
-			"version": "2.0.3",
-			"purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
-		},
-		{
-			"group": "io.micrometer",
-			"name": "micrometer-registry-prometheus",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_common",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_otel",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_common",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
-		},
-		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_otel_agent",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-web",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-json",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-web",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-web@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-web@5.3.19"
-		},
-		{
-			"group": "com.fasterxml.jackson.datatype",
-			"name": "jackson-datatype-jdk8",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.module",
-			"name": "jackson-module-parameter-names",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-tomcat",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-core",
-			"version": "9.0.62",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-el",
-			"version": "9.0.62",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62"
-		},
-		{
-			"group": "org.apache.tomcat.embed",
-			"name": "tomcat-embed-websocket",
-			"version": "9.0.62",
-			"purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-beans",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-beans@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-beans@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-webmvc",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-aop",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-aop@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-aop@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-expression",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-expression@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-expression@5.3.19"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-clients",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1"
-		},
-		{
-			"group": "com.github.luben",
-			"name": "zstd-jni",
-			"version": "1.5.0-2",
-			"purl": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2"
-		},
-		{
-			"group": "org.lz4",
-			"name": "lz4-java",
-			"version": "1.7.1",
-			"purl": "pkg:maven/org.lz4/lz4-java@1.7.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.lz4/lz4-java@1.7.1"
-		},
-		{
-			"group": "org.xerial.snappy",
-			"name": "snappy-java",
-			"version": "1.1.8.1",
-			"purl": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
-		},
-		{
-			"group": "org.rocksdb",
-			"name": "rocksdbjni",
-			"version": "6.19.3",
-			"purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-messaging",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-messaging@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-messaging@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-tx",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-tx@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-tx@5.3.19"
-		},
-		{
-			"group": "org.springframework.retry",
-			"name": "spring-retry",
-			"version": "1.3.3",
-			"purl": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3"
-		},
-		{
-			"group": "com.google.code.findbugs",
-			"name": "jsr305",
-			"version": "3.0.2",
-			"purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-		},
-		{
-			"group": "org.projectlombok",
-			"name": "lombok",
-			"version": "1.18.24",
-			"purl": "pkg:maven/org.projectlombok/lombok@1.18.24",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.projectlombok/lombok@1.18.24"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-test",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-test",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-test-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7"
-		},
-		{
-			"group": "com.jayway.jsonpath",
-			"name": "json-path",
-			"version": "2.6.0",
-			"purl": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0"
-		},
-		{
-			"group": "net.minidev",
-			"name": "json-smart",
-			"version": "2.4.8",
-			"purl": "pkg:maven/net.minidev/json-smart@2.4.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/json-smart@2.4.8"
-		},
-		{
-			"group": "net.minidev",
-			"name": "accessors-smart",
-			"version": "2.4.8",
-			"purl": "pkg:maven/net.minidev/accessors-smart@2.4.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.minidev/accessors-smart@2.4.8"
-		},
-		{
-			"group": "org.ow2.asm",
-			"name": "asm",
-			"version": "9.1",
-			"purl": "pkg:maven/org.ow2.asm/asm@9.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.1"
-		},
-		{
-			"group": "jakarta.xml.bind",
-			"name": "jakarta.xml.bind-api",
-			"version": "2.3.3",
-			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-		},
-		{
-			"group": "jakarta.activation",
-			"name": "jakarta.activation-api",
-			"version": "1.2.2",
-			"purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-		},
-		{
-			"group": "org.assertj",
-			"name": "assertj-core",
-			"version": "3.21.0",
-			"purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
-		},
-		{
-			"group": "org.hamcrest",
-			"name": "hamcrest",
-			"version": "2.2",
-			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-api",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-params",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2"
-		},
-		{
-			"group": "org.apiguardian",
-			"name": "apiguardian-api",
-			"version": "1.1.2",
-			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-engine",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-engine",
-			"version": "1.8.2",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
-		},
-		{
-			"group": "org.opentest4j",
-			"name": "opentest4j",
-			"version": "1.2.0",
-			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-commons",
-			"version": "1.8.2",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-core",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
-		},
-		{
-			"group": "net.bytebuddy",
-			"name": "byte-buddy",
-			"version": "1.11.22",
-			"purl": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22"
-		},
-		{
-			"group": "net.bytebuddy",
-			"name": "byte-buddy-agent",
-			"version": "1.11.22",
-			"purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22"
-		},
-		{
-			"group": "org.objenesis",
-			"name": "objenesis",
-			"version": "3.2",
-			"purl": "pkg:maven/org.objenesis/objenesis@3.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.objenesis/objenesis@3.2"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-junit-jupiter",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
-		},
-		{
-			"group": "org.skyscreamer",
-			"name": "jsonassert",
-			"version": "1.5.0",
-			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
-		},
-		{
-			"group": "com.vaadin.external.google",
-			"name": "android-json",
-			"version": "0.0.20131108.vaadin1",
-			"purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-jcl",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-jcl@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-jcl@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-test",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
-		},
-		{
-			"group": "org.xmlunit",
-			"name": "xmlunit-core",
-			"version": "2.8.4",
-			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka-test",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
-		},
-		{
-			"group": "org.apache.zookeeper",
-			"name": "zookeeper",
-			"version": "3.6.3",
-			"purl": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3"
-		},
-		{
-			"group": "org.apache.zookeeper",
-			"name": "zookeeper-jute",
-			"version": "3.6.3",
-			"purl": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3"
-		},
-		{
-			"group": "org.apache.yetus",
-			"name": "audience-annotations",
-			"version": "0.5.0",
-			"purl": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-handler",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-common",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-common@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-common@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-resolver",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-buffer",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-codec",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-native-epoll",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-native-unix-common",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-classes-epoll",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-clients",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-metadata",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-server-common",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-raft",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1"
-		},
-		{
-			"group": "com.yammer.metrics",
-			"name": "metrics-core",
-			"version": "2.2.0",
-			"purl": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams-test-utils",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-library",
-			"version": "2.13.6",
-			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.6",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.6"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-storage",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-storage-api",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
-		},
-		{
-			"group": "net.sourceforge.argparse4j",
-			"name": "argparse4j",
-			"version": "0.7.0",
-			"purl": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0"
-		},
-		{
-			"group": "com.fasterxml.jackson.module",
-			"name": "jackson-module-scala_2.13",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2"
-		},
-		{
-			"group": "com.thoughtworks.paranamer",
-			"name": "paranamer",
-			"version": "2.8",
-			"purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
-		},
-		{
-			"group": "com.fasterxml.jackson.dataformat",
-			"name": "jackson-dataformat-csv",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2"
-		},
-		{
-			"group": "net.sf.jopt-simple",
-			"name": "jopt-simple",
-			"version": "5.0.4",
-			"purl": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4"
-		},
-		{
-			"group": "org.scala-lang.modules",
-			"name": "scala-collection-compat_2.13",
-			"version": "2.4.4",
-			"purl": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-library",
-			"version": "2.13.5",
-			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.5"
-		},
-		{
-			"group": "org.scala-lang.modules",
-			"name": "scala-java8-compat_2.13",
-			"version": "1.0.0",
-			"purl": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-reflect",
-			"version": "2.13.6",
-			"purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6"
-		},
-		{
-			"group": "com.typesafe.scala-logging",
-			"name": "scala-logging_2.13",
-			"version": "3.9.3",
-			"purl": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-library",
-			"version": "2.13.4",
-			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.4"
-		},
-		{
-			"group": "org.scala-lang",
-			"name": "scala-reflect",
-			"version": "2.13.4",
-			"purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4"
-		},
-		{
-			"group": "io.dropwizard.metrics",
-			"name": "metrics-core",
-			"version": "4.2.9",
-			"purl": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9"
-		},
-		{
-			"group": "commons-cli",
-			"name": "commons-cli",
-			"version": "1.4",
-			"purl": "pkg:maven/commons-cli/commons-cli@1.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
-		}
-	],
-	"dependencies": [
-		{
-			"ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
-				"pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-				"pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-				"pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-				"pkg:maven/org.projectlombok/lombok@1.18.24",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-				"pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-				"pkg:maven/io.micrometer/micrometer-core@1.8.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.yaml/snakeyaml@1.29"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-context@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-jcl@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-context@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.3.19",
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-expression@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
-			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-classic@1.2.11",
-				"pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-				"pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
-			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-core@1.2.11",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.yaml/snakeyaml@1.29",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"dependsOn": [
-				"pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-				"pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"dependsOn": [
-				"pkg:maven/io.micrometer/micrometer-core@1.8.5",
-				"pkg:maven/io.prometheus/simpleclient_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
-				"pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-				"pkg:maven/org.springframework/spring-web@5.3.19",
-				"pkg:maven/org.springframework/spring-webmvc@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework/spring-web@5.3.19",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-web@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-			"dependsOn": [
-				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
-			"dependsOn": [
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-beans@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.3.19",
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-expression@5.3.19",
-				"pkg:maven/org.springframework/spring-web@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-aop@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-expression@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-			"dependsOn": [
-				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-				"pkg:maven/org.lz4/lz4-java@1.7.1",
-				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.lz4/lz4-java@1.7.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-messaging@5.3.19",
-				"pkg:maven/org.springframework/spring-tx@5.3.19",
-				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-messaging@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-tx@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19",
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.projectlombok/lombok@1.18.24",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-				"pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-				"pkg:maven/org.assertj/assertj-core@3.21.0",
-				"pkg:maven/org.hamcrest/hamcrest@2.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-				"pkg:maven/org.mockito/mockito-core@4.0.0",
-				"pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-test@5.3.19",
-				"pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-			"dependsOn": [
-				"pkg:maven/net.minidev/json-smart@2.4.8",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.minidev/json-smart@2.4.8",
-			"dependsOn": [
-				"pkg:maven/net.minidev/accessors-smart@2.4.8"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.minidev/accessors-smart@2.4.8",
-			"dependsOn": [
-				"pkg:maven/org.ow2.asm/asm@9.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.ow2.asm/asm@9.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"dependsOn": [
-				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
-			"dependsOn": [
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"dependsOn": [
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"dependsOn": [
-				"pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-				"pkg:maven/org.objenesis/objenesis@3.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.objenesis/objenesis@3.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"dependsOn": [
-				"pkg:maven/org.mockito/mockito-core@4.0.0",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"dependsOn": [
-				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-jcl@5.3.19",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-core@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"dependsOn": [
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-test@5.3.19",
-				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/org.apache.kafka/kafka-clients@test",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@test",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
-				"pkg:maven/io.netty/netty-handler@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-			"dependsOn": [
-				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
-				"pkg:maven/io.netty/netty-codec@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-common@4.1.76.Final",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-resolver@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"dependsOn": [
-				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
-				"pkg:maven/org.lz4/lz4-java@1.7.1",
-				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/commons-cli/commons-cli@1.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.6",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.5",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.5"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.6"
-			]
-		},
-		{
-			"ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.4",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.4",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-			"dependsOn": [
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
-			]
-		},
-		{
-			"ref": "pkg:maven/commons-cli/commons-cli@1.4",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/commons-cli/commons-cli@1.4"
-			]
-		}
-	]
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "group": "com.redhat.examples",
+            "name": "custom-metrics-demo",
+            "version": "0.0.1-SNAPSHOT",
+            "purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
+            "type": "application",
+            "bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
+        }
+    },
+    "components": [
+        {
+            "group": "com.redhat.examples",
+            "name": "custom-metrics-demo",
+            "version": "0.0.1-SNAPSHOT",
+            "purl": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
+            "type": "application",
+            "bom-ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-actuator",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-core",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-core@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-context",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-context@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-autoconfigure",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-logging",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-classic",
+            "version": "1.2.11",
+            "purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
+        },
+        {
+            "group": "ch.qos.logback",
+            "name": "logback-core",
+            "version": "1.2.11",
+            "purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+            "type": "library",
+            "bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "slf4j-api",
+            "version": "1.7.36",
+            "purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-to-slf4j",
+            "version": "2.17.2",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
+        },
+        {
+            "group": "org.apache.logging.log4j",
+            "name": "log4j-api",
+            "version": "2.17.2",
+            "purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+        },
+        {
+            "group": "org.slf4j",
+            "name": "jul-to-slf4j",
+            "version": "1.7.36",
+            "purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+        },
+        {
+            "group": "jakarta.annotation",
+            "name": "jakarta.annotation-api",
+            "version": "1.3.5",
+            "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5"
+        },
+        {
+            "group": "org.yaml",
+            "name": "snakeyaml",
+            "version": "1.29",
+            "purl": "pkg:maven/org.yaml/snakeyaml@1.29",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.yaml/snakeyaml@1.29"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-actuator-autoconfigure",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-actuator",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-databind",
+            "version": "2.13.2.1",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jsr310",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-annotations",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
+        },
+        {
+            "group": "com.fasterxml.jackson.core",
+            "name": "jackson-core",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+        },
+        {
+            "group": "io.micrometer",
+            "name": "micrometer-core",
+            "version": "1.8.5",
+            "purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
+        },
+        {
+            "group": "org.hdrhistogram",
+            "name": "HdrHistogram",
+            "version": "2.1.12",
+            "purl": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12"
+        },
+        {
+            "group": "org.latencyutils",
+            "name": "LatencyUtils",
+            "version": "2.0.3",
+            "purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+        },
+        {
+            "group": "io.micrometer",
+            "name": "micrometer-registry-prometheus",
+            "version": "1.8.5",
+            "purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_common",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_tracer_otel",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_tracer_common",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+        },
+        {
+            "group": "io.prometheus",
+            "name": "simpleclient_tracer_otel_agent",
+            "version": "0.12.0",
+            "purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-web",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-json",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-web",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-web@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-web@5.3.19"
+        },
+        {
+            "group": "com.fasterxml.jackson.datatype",
+            "name": "jackson-datatype-jdk8",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2"
+        },
+        {
+            "group": "com.fasterxml.jackson.module",
+            "name": "jackson-module-parameter-names",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-tomcat",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-core",
+            "version": "9.0.62",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-el",
+            "version": "9.0.62",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62"
+        },
+        {
+            "group": "org.apache.tomcat.embed",
+            "name": "tomcat-embed-websocket",
+            "version": "9.0.62",
+            "purl": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-beans",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-beans@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-beans@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-webmvc",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-aop",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-aop@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-aop@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-expression",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-expression@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-expression@5.3.19"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-streams",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-clients",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1"
+        },
+        {
+            "group": "com.github.luben",
+            "name": "zstd-jni",
+            "version": "1.5.0-2",
+            "purl": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2"
+        },
+        {
+            "group": "org.lz4",
+            "name": "lz4-java",
+            "version": "1.7.1",
+            "purl": "pkg:maven/org.lz4/lz4-java@1.7.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.lz4/lz4-java@1.7.1"
+        },
+        {
+            "group": "org.xerial.snappy",
+            "name": "snappy-java",
+            "version": "1.1.8.1",
+            "purl": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
+        },
+        {
+            "group": "org.rocksdb",
+            "name": "rocksdbjni",
+            "version": "6.19.3",
+            "purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
+        },
+        {
+            "group": "org.springframework.kafka",
+            "name": "spring-kafka",
+            "version": "2.8.5",
+            "purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-messaging",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-messaging@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-messaging@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-tx",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-tx@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-tx@5.3.19"
+        },
+        {
+            "group": "org.springframework.retry",
+            "name": "spring-retry",
+            "version": "1.3.3",
+            "purl": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3"
+        },
+        {
+            "group": "com.google.code.findbugs",
+            "name": "jsr305",
+            "version": "3.0.2",
+            "purl": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+        },
+        {
+            "group": "org.projectlombok",
+            "name": "lombok",
+            "version": "1.18.24",
+            "purl": "pkg:maven/org.projectlombok/lombok@1.18.24",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.projectlombok/lombok@1.18.24"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-starter-test",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7"
+        },
+        {
+            "group": "org.springframework.boot",
+            "name": "spring-boot-test-autoconfigure",
+            "version": "2.6.7",
+            "purl": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7"
+        },
+        {
+            "group": "com.jayway.jsonpath",
+            "name": "json-path",
+            "version": "2.6.0",
+            "purl": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0"
+        },
+        {
+            "group": "net.minidev",
+            "name": "json-smart",
+            "version": "2.4.8",
+            "purl": "pkg:maven/net.minidev/json-smart@2.4.8",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/json-smart@2.4.8"
+        },
+        {
+            "group": "net.minidev",
+            "name": "accessors-smart",
+            "version": "2.4.8",
+            "purl": "pkg:maven/net.minidev/accessors-smart@2.4.8",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.minidev/accessors-smart@2.4.8"
+        },
+        {
+            "group": "org.ow2.asm",
+            "name": "asm",
+            "version": "9.1",
+            "purl": "pkg:maven/org.ow2.asm/asm@9.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.ow2.asm/asm@9.1"
+        },
+        {
+            "group": "jakarta.xml.bind",
+            "name": "jakarta.xml.bind-api",
+            "version": "2.3.3",
+            "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+        },
+        {
+            "group": "jakarta.activation",
+            "name": "jakarta.activation-api",
+            "version": "1.2.2",
+            "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+        },
+        {
+            "group": "org.assertj",
+            "name": "assertj-core",
+            "version": "3.21.0",
+            "purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
+        },
+        {
+            "group": "org.hamcrest",
+            "name": "hamcrest",
+            "version": "2.2",
+            "purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-api",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-params",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2"
+        },
+        {
+            "group": "org.apiguardian",
+            "name": "apiguardian-api",
+            "version": "1.1.2",
+            "purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+        },
+        {
+            "group": "org.junit.jupiter",
+            "name": "junit-jupiter-engine",
+            "version": "5.8.2",
+            "purl": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-engine",
+            "version": "1.8.2",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
+        },
+        {
+            "group": "org.opentest4j",
+            "name": "opentest4j",
+            "version": "1.2.0",
+            "purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
+        },
+        {
+            "group": "org.junit.platform",
+            "name": "junit-platform-commons",
+            "version": "1.8.2",
+            "purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-core",
+            "version": "4.0.0",
+            "purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy",
+            "version": "1.11.22",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22"
+        },
+        {
+            "group": "net.bytebuddy",
+            "name": "byte-buddy-agent",
+            "version": "1.11.22",
+            "purl": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22"
+        },
+        {
+            "group": "org.objenesis",
+            "name": "objenesis",
+            "version": "3.2",
+            "purl": "pkg:maven/org.objenesis/objenesis@3.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.objenesis/objenesis@3.2"
+        },
+        {
+            "group": "org.mockito",
+            "name": "mockito-junit-jupiter",
+            "version": "4.0.0",
+            "purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
+        },
+        {
+            "group": "org.skyscreamer",
+            "name": "jsonassert",
+            "version": "1.5.0",
+            "purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+        },
+        {
+            "group": "com.vaadin.external.google",
+            "name": "android-json",
+            "version": "0.0.20131108.vaadin1",
+            "purl": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-jcl",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-jcl@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-jcl@5.3.19"
+        },
+        {
+            "group": "org.springframework",
+            "name": "spring-test",
+            "version": "5.3.19",
+            "purl": "pkg:maven/org.springframework/spring-test@5.3.19",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
+        },
+        {
+            "group": "org.xmlunit",
+            "name": "xmlunit-core",
+            "version": "2.8.4",
+            "purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+        },
+        {
+            "group": "org.springframework.kafka",
+            "name": "spring-kafka-test",
+            "version": "2.8.5",
+            "purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
+        },
+        {
+            "group": "org.apache.zookeeper",
+            "name": "zookeeper",
+            "version": "3.6.3",
+            "purl": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3"
+        },
+        {
+            "group": "org.apache.zookeeper",
+            "name": "zookeeper-jute",
+            "version": "3.6.3",
+            "purl": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3"
+        },
+        {
+            "group": "org.apache.yetus",
+            "name": "audience-annotations",
+            "version": "0.5.0",
+            "purl": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-handler",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-common",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-common@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-common@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-resolver",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-buffer",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-codec",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport-native-epoll",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport-native-unix-common",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
+        },
+        {
+            "group": "io.netty",
+            "name": "netty-transport-classes-epoll",
+            "version": "4.1.76.Final",
+            "purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-clients",
+            "version": "test",
+            "purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-metadata",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-server-common",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-raft",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1"
+        },
+        {
+            "group": "com.yammer.metrics",
+            "name": "metrics-core",
+            "version": "2.2.0",
+            "purl": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-streams-test-utils",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka_2.13",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
+        },
+        {
+            "group": "org.scala-lang",
+            "name": "scala-library",
+            "version": "2.13.6",
+            "purl": "pkg:maven/org.scala-lang/scala-library@2.13.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.6"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-storage",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka-storage-api",
+            "version": "3.0.1",
+            "purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
+        },
+        {
+            "group": "net.sourceforge.argparse4j",
+            "name": "argparse4j",
+            "version": "0.7.0",
+            "purl": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0"
+        },
+        {
+            "group": "com.fasterxml.jackson.module",
+            "name": "jackson-module-scala_2.13",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2"
+        },
+        {
+            "group": "com.thoughtworks.paranamer",
+            "name": "paranamer",
+            "version": "2.8",
+            "purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
+        },
+        {
+            "group": "com.fasterxml.jackson.dataformat",
+            "name": "jackson-dataformat-csv",
+            "version": "2.13.2",
+            "purl": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2"
+        },
+        {
+            "group": "net.sf.jopt-simple",
+            "name": "jopt-simple",
+            "version": "5.0.4",
+            "purl": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4"
+        },
+        {
+            "group": "org.scala-lang.modules",
+            "name": "scala-collection-compat_2.13",
+            "version": "2.4.4",
+            "purl": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4"
+        },
+        {
+            "group": "org.scala-lang.modules",
+            "name": "scala-java8-compat_2.13",
+            "version": "1.0.0",
+            "purl": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0"
+        },
+        {
+            "group": "org.scala-lang",
+            "name": "scala-reflect",
+            "version": "2.13.6",
+            "purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6"
+        },
+        {
+            "group": "com.typesafe.scala-logging",
+            "name": "scala-logging_2.13",
+            "version": "3.9.3",
+            "purl": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+            "type": "library",
+            "bom-ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3"
+        },
+        {
+            "group": "io.dropwizard.metrics",
+            "name": "metrics-core",
+            "version": "4.2.9",
+            "purl": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+            "type": "library",
+            "bom-ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9"
+        },
+        {
+            "group": "commons-cli",
+            "name": "commons-cli",
+            "version": "1.4",
+            "purl": "pkg:maven/commons-cli/commons-cli@1.4",
+            "type": "library",
+            "bom-ref": "pkg:maven/commons-cli/commons-cli@1.4"
+        },
+        {
+            "group": "org.apache.kafka",
+            "name": "kafka_2.13",
+            "version": "test",
+            "purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
+            "type": "library",
+            "bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/com.redhat.examples/custom-metrics-demo@0.0.1-SNAPSHOT",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
+                "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
+                "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+                "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+                "pkg:maven/org.projectlombok/lombok@1.18.24",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+                "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
+                "pkg:maven/io.micrometer/micrometer-core@1.8.5"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.yaml/snakeyaml@1.29"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-context@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-core@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-jcl@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-context@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.3.19",
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-expression@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+                "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+                "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+            "dependsOn": [
+                "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.yaml/snakeyaml@1.29",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+            "dependsOn": [
+                "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+                "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+            "dependsOn": [
+                "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+                "pkg:maven/io.prometheus/simpleclient_common@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
+                "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
+            "dependsOn": [
+                "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+                "pkg:maven/org.springframework/spring-web@5.3.19",
+                "pkg:maven/org.springframework/spring-webmvc@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework/spring-web@5.3.19",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-web@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+            "dependsOn": [
+                "pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
+            "dependsOn": [
+                "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-beans@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-aop@5.3.19",
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-context@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-expression@5.3.19",
+                "pkg:maven/org.springframework/spring-web@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-aop@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-expression@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+            "dependsOn": [
+                "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+                "pkg:maven/org.lz4/lz4-java@1.7.1",
+                "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.lz4/lz4-java@1.7.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-context@5.3.19",
+                "pkg:maven/org.springframework/spring-messaging@5.3.19",
+                "pkg:maven/org.springframework/spring-tx@5.3.19",
+                "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-messaging@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-tx@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-beans@5.3.19",
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.projectlombok/lombok@1.18.24",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+                "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+                "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+                "pkg:maven/org.assertj/assertj-core@3.21.0",
+                "pkg:maven/org.hamcrest/hamcrest@2.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+                "pkg:maven/org.mockito/mockito-core@4.0.0",
+                "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+                "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+                "pkg:maven/org.springframework/spring-core@5.3.19",
+                "pkg:maven/org.springframework/spring-test@5.3.19",
+                "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+            "dependsOn": [
+                "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+                "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+            "dependsOn": [
+                "pkg:maven/net.minidev/json-smart@2.4.8",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/json-smart@2.4.8",
+            "dependsOn": [
+                "pkg:maven/net.minidev/accessors-smart@2.4.8"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.minidev/accessors-smart@2.4.8",
+            "dependsOn": [
+                "pkg:maven/org.ow2.asm/asm@9.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.ow2.asm/asm@9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+            "dependsOn": [
+                "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
+            "dependsOn": [
+                "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+            "dependsOn": [
+                "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+                "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+            "dependsOn": [
+                "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
+            "dependsOn": [
+                "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+                "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+                "pkg:maven/org.objenesis/objenesis@3.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.objenesis/objenesis@3.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+            "dependsOn": [
+                "pkg:maven/org.mockito/mockito-core@4.0.0",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+            "dependsOn": [
+                "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-jcl@5.3.19",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.springframework/spring-test@5.3.19",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-core@5.3.19"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+            "dependsOn": [
+                "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+            "dependsOn": [
+                "pkg:maven/org.springframework/spring-context@5.3.19",
+                "pkg:maven/org.springframework/spring-test@5.3.19",
+                "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+                "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+                "pkg:maven/org.apache.kafka/kafka-clients@test",
+                "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka_2.13@test",
+                "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+                "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
+                "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
+                "pkg:maven/io.netty/netty-handler@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
+            "dependsOn": [
+                "pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+                "pkg:maven/io.netty/netty-codec@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-common@4.1.76.Final",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-resolver@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
+            "dependsOn": [
+                "pkg:maven/io.netty/netty-common@4.1.76.Final",
+                "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport@4.1.76.Final",
+                "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
+            "dependsOn": [
+                "pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+                "pkg:maven/org.lz4/lz4-java@1.7.1",
+                "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+                "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+                "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+                "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+                "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+                "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+                "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+                "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+                "pkg:maven/commons-cli/commons-cli@1.4"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang/scala-library@2.13.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+            "dependsOn": [
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+            ]
+        },
+        {
+            "ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6"
+            ]
+        },
+        {
+            "ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+            "dependsOn": [
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+            "dependsOn": [
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+            ]
+        },
+        {
+            "ref": "pkg:maven/commons-cli/commons-cli@1.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
+            "dependsOn": [
+                "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+                "pkg:maven/org.scala-lang/scala-library@2.13.6",
+                "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+                "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+                "pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+                "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+                "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+                "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+                "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+                "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+                "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+                "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+                "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+                "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+                "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+                "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+                "pkg:maven/commons-cli/commons-cli@1.4"
+            ]
+        }
+    ]
 }

--- a/test/providers/tst_manifests/maven/poms_deps_with_no_ignore_long/stack_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/poms_deps_with_no_ignore_long/stack_analysis_expected_sbom.json
@@ -31,62 +31,6 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-actuator@2.6.7"
 		},
 		{
-			"group": "io.micrometer",
-			"name": "micrometer-registry-prometheus",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-web",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
-		},
-		{
-			"group": "org.projectlombok",
-			"name": "lombok",
-			"version": "1.18.24",
-			"purl": "pkg:maven/org.projectlombok/lombok@1.18.24",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.projectlombok/lombok@1.18.24"
-		},
-		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-test",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
-		},
-		{
-			"group": "org.springframework.kafka",
-			"name": "spring-kafka-test",
-			"version": "2.8.5",
-			"purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
-		},
-		{
 			"group": "org.springframework.boot",
 			"name": "spring-boot-starter",
 			"version": "2.6.7",
@@ -96,27 +40,27 @@
 		},
 		{
 			"group": "org.springframework.boot",
-			"name": "spring-boot-actuator-autoconfigure",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
-		},
-		{
-			"group": "io.micrometer",
-			"name": "micrometer-core",
-			"version": "1.8.5",
-			"purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
-		},
-		{
-			"group": "org.springframework.boot",
 			"name": "spring-boot",
 			"version": "2.6.7",
 			"purl": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-core",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-core@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
+		},
+		{
+			"group": "org.springframework",
+			"name": "spring-context",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-context@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -135,6 +79,54 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7"
 		},
 		{
+			"group": "ch.qos.logback",
+			"name": "logback-classic",
+			"version": "1.2.11",
+			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"type": "library",
+			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
+		},
+		{
+			"group": "ch.qos.logback",
+			"name": "logback-core",
+			"version": "1.2.11",
+			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+			"type": "library",
+			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
+		},
+		{
+			"group": "org.slf4j",
+			"name": "slf4j-api",
+			"version": "1.7.36",
+			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
+		},
+		{
+			"group": "org.apache.logging.log4j",
+			"name": "log4j-to-slf4j",
+			"version": "2.17.2",
+			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
+		},
+		{
+			"group": "org.apache.logging.log4j",
+			"name": "log4j-api",
+			"version": "2.17.2",
+			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+		},
+		{
+			"group": "org.slf4j",
+			"name": "jul-to-slf4j",
+			"version": "1.7.36",
+			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+		},
+		{
 			"group": "jakarta.annotation",
 			"name": "jakarta.annotation-api",
 			"version": "1.3.5",
@@ -151,44 +143,12 @@
 			"bom-ref": "pkg:maven/org.yaml/snakeyaml@1.29"
 		},
 		{
-			"group": "ch.qos.logback",
-			"name": "logback-classic",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"group": "org.springframework.boot",
+			"name": "spring-boot-actuator-autoconfigure",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
 			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-to-slf4j",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "jul-to-slf4j",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
-		},
-		{
-			"group": "ch.qos.logback",
-			"name": "logback-core",
-			"version": "1.2.11",
-			"purl": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"type": "library",
-			"bom-ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11"
-		},
-		{
-			"group": "org.apache.logging.log4j",
-			"name": "log4j-api",
-			"version": "2.17.2",
-			"purl": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -199,12 +159,44 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7"
 		},
 		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-databind",
+			"version": "2.13.2.1",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+		},
+		{
 			"group": "com.fasterxml.jackson.datatype",
 			"name": "jackson-datatype-jsr310",
 			"version": "2.13.2",
 			"purl": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-annotations",
+			"version": "2.13.2",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
+		},
+		{
+			"group": "com.fasterxml.jackson.core",
+			"name": "jackson-core",
+			"version": "2.13.2",
+			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+		},
+		{
+			"group": "io.micrometer",
+			"name": "micrometer-core",
+			"version": "1.8.5",
+			"purl": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5"
 		},
 		{
 			"group": "org.hdrhistogram",
@@ -221,6 +213,14 @@
 			"purl": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+		},
+		{
+			"group": "io.micrometer",
+			"name": "micrometer-registry-prometheus",
+			"version": "1.8.5",
+			"purl": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5"
 		},
 		{
 			"group": "io.prometheus",
@@ -248,6 +248,14 @@
 		},
 		{
 			"group": "io.prometheus",
+			"name": "simpleclient_tracer_common",
+			"version": "0.12.0",
+			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+		},
+		{
+			"group": "io.prometheus",
 			"name": "simpleclient_tracer_otel_agent",
 			"version": "0.12.0",
 			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
@@ -255,12 +263,12 @@
 			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0"
 		},
 		{
-			"group": "io.prometheus",
-			"name": "simpleclient_tracer_common",
-			"version": "0.12.0",
-			"purl": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-web",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
 			"type": "library",
-			"bom-ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7"
 		},
 		{
 			"group": "org.springframework.boot",
@@ -271,28 +279,12 @@
 			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7"
 		},
 		{
-			"group": "org.springframework.boot",
-			"name": "spring-boot-starter-tomcat",
-			"version": "2.6.7",
-			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
-		},
-		{
 			"group": "org.springframework",
 			"name": "spring-web",
 			"version": "5.3.19",
 			"purl": "pkg:maven/org.springframework/spring-web@5.3.19",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.springframework/spring-web@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-webmvc",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
 		},
 		{
 			"group": "com.fasterxml.jackson.datatype",
@@ -309,6 +301,14 @@
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+		},
+		{
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-tomcat",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7"
 		},
 		{
 			"group": "org.apache.tomcat.embed",
@@ -344,6 +344,14 @@
 		},
 		{
 			"group": "org.springframework",
+			"name": "spring-webmvc",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19"
+		},
+		{
+			"group": "org.springframework",
 			"name": "spring-aop",
 			"version": "5.3.19",
 			"purl": "pkg:maven/org.springframework/spring-aop@5.3.19",
@@ -360,43 +368,19 @@
 		},
 		{
 			"group": "org.apache.kafka",
+			"name": "kafka-streams",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1"
+		},
+		{
+			"group": "org.apache.kafka",
 			"name": "kafka-clients",
 			"version": "3.0.1",
 			"purl": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1"
-		},
-		{
-			"group": "org.rocksdb",
-			"name": "rocksdbjni",
-			"version": "6.19.3",
-			"purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
-		},
-		{
-			"group": "org.slf4j",
-			"name": "slf4j-api",
-			"version": "1.7.36",
-			"purl": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-annotations",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2"
-		},
-		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-databind",
-			"version": "2.13.2.1",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
 		},
 		{
 			"group": "com.github.luben",
@@ -423,20 +407,20 @@
 			"bom-ref": "pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
 		},
 		{
-			"group": "com.fasterxml.jackson.core",
-			"name": "jackson-core",
-			"version": "2.13.2",
-			"purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"group": "org.rocksdb",
+			"name": "rocksdbjni",
+			"version": "6.19.3",
+			"purl": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
 			"type": "library",
-			"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+			"bom-ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3"
 		},
 		{
-			"group": "org.springframework",
-			"name": "spring-context",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-context@5.3.19",
+			"group": "org.springframework.kafka",
+			"name": "spring-kafka",
+			"version": "2.8.5",
+			"purl": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-context@5.3.19"
+			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5"
 		},
 		{
 			"group": "org.springframework",
@@ -471,6 +455,22 @@
 			"bom-ref": "pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
 		},
 		{
+			"group": "org.projectlombok",
+			"name": "lombok",
+			"version": "1.18.24",
+			"purl": "pkg:maven/org.projectlombok/lombok@1.18.24",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.projectlombok/lombok@1.18.24"
+		},
+		{
+			"group": "org.springframework.boot",
+			"name": "spring-boot-starter-test",
+			"version": "2.6.7",
+			"purl": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7"
+		},
+		{
 			"group": "org.springframework.boot",
 			"name": "spring-boot-test",
 			"version": "2.6.7",
@@ -493,86 +493,6 @@
 			"purl": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0"
-		},
-		{
-			"group": "jakarta.xml.bind",
-			"name": "jakarta.xml.bind-api",
-			"version": "2.3.3",
-			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"type": "library",
-			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
-		},
-		{
-			"group": "org.assertj",
-			"name": "assertj-core",
-			"version": "3.21.0",
-			"purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
-		},
-		{
-			"group": "org.hamcrest",
-			"name": "hamcrest",
-			"version": "2.2",
-			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-core",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
-		},
-		{
-			"group": "org.mockito",
-			"name": "mockito-junit-jupiter",
-			"version": "4.0.0",
-			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
-		},
-		{
-			"group": "org.skyscreamer",
-			"name": "jsonassert",
-			"version": "1.5.0",
-			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-core",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-core@5.3.19"
-		},
-		{
-			"group": "org.springframework",
-			"name": "spring-test",
-			"version": "5.3.19",
-			"purl": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
-		},
-		{
-			"group": "org.xmlunit",
-			"name": "xmlunit-core",
-			"version": "2.8.4",
-			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
 		},
 		{
 			"group": "net.minidev",
@@ -599,6 +519,14 @@
 			"bom-ref": "pkg:maven/org.ow2.asm/asm@9.1"
 		},
 		{
+			"group": "jakarta.xml.bind",
+			"name": "jakarta.xml.bind-api",
+			"version": "2.3.3",
+			"purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+			"type": "library",
+			"bom-ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+		},
+		{
 			"group": "jakarta.activation",
 			"name": "jakarta.activation-api",
 			"version": "1.2.2",
@@ -607,12 +535,52 @@
 			"bom-ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
 		},
 		{
+			"group": "org.assertj",
+			"name": "assertj-core",
+			"version": "3.21.0",
+			"purl": "pkg:maven/org.assertj/assertj-core@3.21.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.assertj/assertj-core@3.21.0"
+		},
+		{
+			"group": "org.hamcrest",
+			"name": "hamcrest",
+			"version": "2.2",
+			"purl": "pkg:maven/org.hamcrest/hamcrest@2.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.hamcrest/hamcrest@2.2"
+		},
+		{
+			"group": "org.junit.jupiter",
+			"name": "junit-jupiter",
+			"version": "5.8.2",
+			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2"
+		},
+		{
+			"group": "org.junit.jupiter",
+			"name": "junit-jupiter-api",
+			"version": "5.8.2",
+			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+		},
+		{
 			"group": "org.junit.jupiter",
 			"name": "junit-jupiter-params",
 			"version": "5.8.2",
 			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2"
+		},
+		{
+			"group": "org.apiguardian",
+			"name": "apiguardian-api",
+			"version": "1.1.2",
+			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
 		},
 		{
 			"group": "org.junit.jupiter",
@@ -629,6 +597,30 @@
 			"purl": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
+		},
+		{
+			"group": "org.opentest4j",
+			"name": "opentest4j",
+			"version": "1.2.0",
+			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
+		},
+		{
+			"group": "org.junit.platform",
+			"name": "junit-platform-commons",
+			"version": "1.8.2",
+			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
+		},
+		{
+			"group": "org.mockito",
+			"name": "mockito-core",
+			"version": "4.0.0",
+			"purl": "pkg:maven/org.mockito/mockito-core@4.0.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.mockito/mockito-core@4.0.0"
 		},
 		{
 			"group": "net.bytebuddy",
@@ -655,6 +647,22 @@
 			"bom-ref": "pkg:maven/org.objenesis/objenesis@3.2"
 		},
 		{
+			"group": "org.mockito",
+			"name": "mockito-junit-jupiter",
+			"version": "4.0.0",
+			"purl": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0"
+		},
+		{
+			"group": "org.skyscreamer",
+			"name": "jsonassert",
+			"version": "1.5.0",
+			"purl": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0"
+		},
+		{
 			"group": "com.vaadin.external.google",
 			"name": "android-json",
 			"version": "0.0.20131108.vaadin1",
@@ -671,60 +679,36 @@
 			"bom-ref": "pkg:maven/org.springframework/spring-jcl@5.3.19"
 		},
 		{
+			"group": "org.springframework",
+			"name": "spring-test",
+			"version": "5.3.19",
+			"purl": "pkg:maven/org.springframework/spring-test@5.3.19",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework/spring-test@5.3.19"
+		},
+		{
+			"group": "org.xmlunit",
+			"name": "xmlunit-core",
+			"version": "2.8.4",
+			"purl": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+		},
+		{
+			"group": "org.springframework.kafka",
+			"name": "spring-kafka-test",
+			"version": "2.8.5",
+			"purl": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5"
+		},
+		{
 			"group": "org.apache.zookeeper",
 			"name": "zookeeper",
 			"version": "3.6.3",
 			"purl": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
 			"type": "library",
 			"bom-ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-clients",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-metadata",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka-streams-test-utils",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
-		},
-		{
-			"group": "org.apache.kafka",
-			"name": "kafka_2.13",
-			"version": "test",
-			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
-		},
-		{
-			"group": "org.junit.jupiter",
-			"name": "junit-jupiter-api",
-			"version": "5.8.2",
-			"purl": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
 		},
 		{
 			"group": "org.apache.zookeeper",
@@ -749,14 +733,6 @@
 			"purl": "pkg:maven/io.netty/netty-handler@4.1.76.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.netty/netty-handler@4.1.76.Final"
-		},
-		{
-			"group": "io.netty",
-			"name": "netty-transport-native-epoll",
-			"version": "4.1.76.Final",
-			"purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"type": "library",
-			"bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
 		},
 		{
 			"group": "io.netty",
@@ -800,6 +776,14 @@
 		},
 		{
 			"group": "io.netty",
+			"name": "netty-transport-native-epoll",
+			"version": "4.1.76.Final",
+			"purl": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+			"type": "library",
+			"bom-ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
+		},
+		{
+			"group": "io.netty",
 			"name": "netty-transport-native-unix-common",
 			"version": "4.1.76.Final",
 			"purl": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
@@ -813,6 +797,22 @@
 			"purl": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
 			"type": "library",
 			"bom-ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+		},
+		{
+			"group": "org.apache.kafka",
+			"name": "kafka-clients",
+			"version": "test",
+			"purl": "pkg:maven/org.apache.kafka/kafka-clients@test",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-clients@test"
+		},
+		{
+			"group": "org.apache.kafka",
+			"name": "kafka-metadata",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1"
 		},
 		{
 			"group": "org.apache.kafka",
@@ -839,6 +839,22 @@
 			"bom-ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
 		},
 		{
+			"group": "org.apache.kafka",
+			"name": "kafka-streams-test-utils",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1"
+		},
+		{
+			"group": "org.apache.kafka",
+			"name": "kafka_2.13",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1"
+		},
+		{
 			"group": "org.scala-lang",
 			"name": "scala-library",
 			"version": "2.13.6",
@@ -855,6 +871,14 @@
 			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1"
 		},
 		{
+			"group": "org.apache.kafka",
+			"name": "kafka-storage-api",
+			"version": "3.0.1",
+			"purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
+		},
+		{
 			"group": "net.sourceforge.argparse4j",
 			"name": "argparse4j",
 			"version": "0.7.0",
@@ -869,6 +893,14 @@
 			"purl": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
 			"type": "library",
 			"bom-ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2"
+		},
+		{
+			"group": "com.thoughtworks.paranamer",
+			"name": "paranamer",
+			"version": "2.8",
+			"purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
+			"type": "library",
+			"bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
 		},
 		{
 			"group": "com.fasterxml.jackson.dataformat",
@@ -895,6 +927,14 @@
 			"bom-ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4"
 		},
 		{
+			"group": "org.scala-lang",
+			"name": "scala-library",
+			"version": "2.13.5",
+			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.5",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.5"
+		},
+		{
 			"group": "org.scala-lang.modules",
 			"name": "scala-java8-compat_2.13",
 			"version": "1.0.0",
@@ -919,6 +959,22 @@
 			"bom-ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3"
 		},
 		{
+			"group": "org.scala-lang",
+			"name": "scala-library",
+			"version": "2.13.4",
+			"purl": "pkg:maven/org.scala-lang/scala-library@2.13.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.scala-lang/scala-library@2.13.4"
+		},
+		{
+			"group": "org.scala-lang",
+			"name": "scala-reflect",
+			"version": "2.13.4",
+			"purl": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
+			"type": "library",
+			"bom-ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4"
+		},
+		{
 			"group": "io.dropwizard.metrics",
 			"name": "metrics-core",
 			"version": "4.2.9",
@@ -936,43 +992,11 @@
 		},
 		{
 			"group": "org.apache.kafka",
-			"name": "kafka-storage-api",
-			"version": "3.0.1",
-			"purl": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+			"name": "kafka_2.13",
+			"version": "test",
+			"purl": "pkg:maven/org.apache.kafka/kafka_2.13@test",
 			"type": "library",
-			"bom-ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
-		},
-		{
-			"group": "com.thoughtworks.paranamer",
-			"name": "paranamer",
-			"version": "2.8",
-			"purl": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"type": "library",
-			"bom-ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
-		},
-		{
-			"group": "org.opentest4j",
-			"name": "opentest4j",
-			"version": "1.2.0",
-			"purl": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0"
-		},
-		{
-			"group": "org.junit.platform",
-			"name": "junit-platform-commons",
-			"version": "1.8.2",
-			"purl": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2"
-		},
-		{
-			"group": "org.apiguardian",
-			"name": "apiguardian-api",
-			"version": "1.1.2",
-			"purl": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"type": "library",
-			"bom-ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			"bom-ref": "pkg:maven/org.apache.kafka/kafka_2.13@test"
 		}
 	],
 	"dependencies": [
@@ -998,105 +1022,43 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
-			"dependsOn": [
-				"pkg:maven/io.prometheus/simpleclient_common@0.12.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
-				"pkg:maven/org.springframework/spring-web@5.3.19",
-				"pkg:maven/org.springframework/spring-webmvc@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
-				"pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-context@5.3.19",
-				"pkg:maven/org.springframework/spring-messaging@5.3.19",
-				"pkg:maven/org.springframework/spring-tx@5.3.19",
-				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
-				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.projectlombok/lombok@1.18.24",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
-				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-				"pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
-				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-				"pkg:maven/org.assertj/assertj-core@3.21.0",
-				"pkg:maven/org.hamcrest/hamcrest@2.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-				"pkg:maven/org.mockito/mockito-core@4.0.0",
-				"pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-				"pkg:maven/org.springframework/spring-core@5.3.19",
-				"pkg:maven/org.springframework/spring-test@5.3.19",
-				"pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
-			"dependsOn": [
-				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
-				"pkg:maven/org.apache.kafka/kafka-clients@test",
-				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka_2.13@test",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
-			]
-		},
-		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
 			"dependsOn": [
 				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
 				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
 				"pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
 				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
 				"pkg:maven/org.yaml/snakeyaml@1.29"
 			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
-			"dependsOn": [
-				"pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
-			"dependsOn": [
-				"pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
-				"pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
-			]
-		},
-		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-context@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-core@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-jcl@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-context@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-aop@5.3.19",
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-expression@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.6.7",
@@ -1104,6 +1066,38 @@
 				"pkg:maven/ch.qos.logback/logback-classic@1.2.11",
 				"pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
 				"pkg:maven/org.slf4j/jul-to-slf4j@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"dependsOn": [
+				"pkg:maven/ch.qos.logback/logback-core@1.2.11",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
@@ -1115,36 +1109,50 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.11",
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator-autoconfigure@2.6.7",
 			"dependsOn": [
-				"pkg:maven/ch.qos.logback/logback-core@1.2.11"
+				"pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2"
 			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.17.2",
-			"dependsOn": [
-				"pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/jul-to-slf4j@1.7.36",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.11",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.logging.log4j/log4j-api@2.17.2",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-actuator@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.micrometer/micrometer-core@1.8.5",
+			"dependsOn": [
+				"pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
+				"pkg:maven/org.latencyutils/LatencyUtils@2.0.3"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.hdrhistogram/HdrHistogram@2.1.12",
@@ -1153,6 +1161,13 @@
 		{
 			"ref": "pkg:maven/org.latencyutils/LatencyUtils@2.0.3",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/io.micrometer/micrometer-registry-prometheus@1.8.5",
+			"dependsOn": [
+				"pkg:maven/io.micrometer/micrometer-core@1.8.5",
+				"pkg:maven/io.prometheus/simpleclient_common@0.12.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.prometheus/simpleclient_common@0.12.0",
@@ -1174,48 +1189,65 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+			"ref": "pkg:maven/io.prometheus/simpleclient_tracer_otel_agent@0.12.0",
 			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
+				"pkg:maven/io.prometheus/simpleclient_tracer_common@0.12.0"
 			]
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-web@2.6.7",
 			"dependsOn": [
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
-				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+				"pkg:maven/org.springframework/spring-web@5.3.19",
+				"pkg:maven/org.springframework/spring-webmvc@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-json@2.6.7",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+				"pkg:maven/org.springframework/spring-web@5.3.19",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jsr310@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2"
 			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-web@5.3.19",
 			"dependsOn": [
-				"pkg:maven/org.springframework/spring-beans@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-aop@5.3.19",
-				"pkg:maven/org.springframework/spring-expression@5.3.19"
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
 			]
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-parameter-names@2.13.2",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-tomcat@2.6.7",
+			"dependsOn": [
+				"pkg:maven/jakarta.annotation/jakarta.annotation-api@1.3.5",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-el@9.0.62",
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62",
@@ -1227,44 +1259,57 @@
 		},
 		{
 			"ref": "pkg:maven/org.apache.tomcat.embed/tomcat-embed-websocket@9.0.62",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@9.0.62"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-beans@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework/spring-webmvc@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-aop@5.3.19",
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-context@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-expression@5.3.19",
+				"pkg:maven/org.springframework/spring-web@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-aop@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-expression@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
 			"dependsOn": [
 				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
 				"pkg:maven/org.lz4/lz4-java@1.7.1",
-				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.36",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
-			"dependsOn": [
-				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
@@ -1280,20 +1325,33 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+			"ref": "pkg:maven/org.rocksdb/rocksdbjni@6.19.3",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.springframework/spring-context@5.3.19",
-			"dependsOn": []
+			"ref": "pkg:maven/org.springframework.kafka/spring-kafka@2.8.5",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-context@5.3.19",
+				"pkg:maven/org.springframework/spring-messaging@5.3.19",
+				"pkg:maven/org.springframework/spring-tx@5.3.19",
+				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-messaging@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework/spring-tx@5.3.19",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-beans@5.3.19",
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.springframework.retry/spring-retry@1.3.3",
@@ -1304,71 +1362,48 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+			"ref": "pkg:maven/org.projectlombok/lombok@1.18.24",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.6.7",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot-starter@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
+				"pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
+				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+				"pkg:maven/org.assertj/assertj-core@3.21.0",
+				"pkg:maven/org.hamcrest/hamcrest@2.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+				"pkg:maven/org.mockito/mockito-core@4.0.0",
+				"pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+				"pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+				"pkg:maven/org.springframework/spring-core@5.3.19",
+				"pkg:maven/org.springframework/spring-test@5.3.19",
+				"pkg:maven/org.xmlunit/xmlunit-core@2.8.4"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.springframework.boot/spring-boot-test-autoconfigure@2.6.7",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.springframework.boot/spring-boot@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-test@2.6.7",
+				"pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.6.7"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.jayway.jsonpath/json-path@2.6.0",
 			"dependsOn": [
-				"pkg:maven/net.minidev/json-smart@2.4.8"
+				"pkg:maven/net.minidev/json-smart@2.4.8",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
-		},
-		{
-			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
-			"dependsOn": [
-				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
-				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
-			"dependsOn": [
-				"pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
-				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
-				"pkg:maven/org.objenesis/objenesis@3.2"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
-			"dependsOn": [
-				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-core@5.3.19",
-			"dependsOn": [
-				"pkg:maven/org.springframework/spring-jcl@5.3.19"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.springframework/spring-test@5.3.19",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
-			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/net.minidev/json-smart@2.4.8",
@@ -1387,22 +1422,83 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3",
+			"dependsOn": [
+				"pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2"
+			]
+		},
+		{
 			"ref": "pkg:maven/jakarta.activation/jakarta.activation-api@1.2.2",
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.assertj/assertj-core@3.21.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.hamcrest/hamcrest@2.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter@5.8.2",
+			"dependsOn": [
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+			"dependsOn": [
+				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
+				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-params@5.8.2",
+			"dependsOn": [
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-engine@5.8.2",
 			"dependsOn": [
-				"pkg:maven/org.junit.platform/junit-platform-engine@1.8.2"
+				"pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
 			]
 		},
 		{
 			"ref": "pkg:maven/org.junit.platform/junit-platform-engine@1.8.2",
+			"dependsOn": [
+				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
+				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
+			"dependsOn": [
+				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.mockito/mockito-core@4.0.0",
+			"dependsOn": [
+				"pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
+				"pkg:maven/net.bytebuddy/byte-buddy-agent@1.11.22",
+				"pkg:maven/org.objenesis/objenesis@3.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/net.bytebuddy/byte-buddy@1.11.22",
@@ -1417,6 +1513,19 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.mockito/mockito-junit-jupiter@4.0.0",
+			"dependsOn": [
+				"pkg:maven/org.mockito/mockito-core@4.0.0",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.skyscreamer/jsonassert@1.5.0",
+			"dependsOn": [
+				"pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1"
+			]
+		},
+		{
 			"ref": "pkg:maven/com.vaadin.external.google/android-json@0.0.20131108.vaadin1",
 			"dependsOn": []
 		},
@@ -1425,62 +1534,48 @@
 			"dependsOn": []
 		},
 		{
+			"ref": "pkg:maven/org.springframework/spring-test@5.3.19",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-core@5.3.19"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.xmlunit/xmlunit-core@2.8.4",
+			"dependsOn": [
+				"pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@2.3.3"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.springframework.kafka/spring-kafka-test@2.8.5",
+			"dependsOn": [
+				"pkg:maven/org.springframework/spring-context@5.3.19",
+				"pkg:maven/org.springframework/spring-test@5.3.19",
+				"pkg:maven/org.springframework.retry/spring-retry@1.3.3",
+				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+				"pkg:maven/org.apache.kafka/kafka-clients@test",
+				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka_2.13@test",
+				"pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
+				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2"
+			]
+		},
+		{
 			"ref": "pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
 			"dependsOn": [
 				"pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
 				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
 				"pkg:maven/io.netty/netty-handler@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
-			"dependsOn": [
-				"pkg:maven/org.scala-lang/scala-library@2.13.6",
-				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
-				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
-				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
-				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
-				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
-				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
-				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
-				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-				"pkg:maven/commons-cli/commons-cli@1.4"
-			]
-		},
-		{
-			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.jupiter/junit-jupiter-api@5.8.2",
-			"dependsOn": [
-				"pkg:maven/org.opentest4j/opentest4j@1.2.0",
-				"pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-				"pkg:maven/org.apiguardian/apiguardian-api@1.1.2"
+				"pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.zookeeper/zookeeper-jute@3.6.3",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.yetus/audience-annotations@0.5.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.yetus/audience-annotations@0.5.0",
@@ -1497,51 +1592,139 @@
 			]
 		},
 		{
-			"ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
-			"dependsOn": [
-				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-				"pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
-			]
-		},
-		{
 			"ref": "pkg:maven/io.netty/netty-common@4.1.76.Final",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-resolver@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-buffer@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-resolver@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-codec@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/io.netty/netty-transport-native-epoll@4.1.76.Final",
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final"
+			]
 		},
 		{
 			"ref": "pkg:maven/io.netty/netty-transport-classes-epoll@4.1.76.Final",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/io.netty/netty-common@4.1.76.Final",
+				"pkg:maven/io.netty/netty-buffer@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport@4.1.76.Final",
+				"pkg:maven/io.netty/netty-transport-native-unix-common@4.1.76.Final"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-clients@test",
+			"dependsOn": [
+				"pkg:maven/com.github.luben/zstd-jni@1.5.0-2",
+				"pkg:maven/org.lz4/lz4-java@1.7.1",
+				"pkg:maven/org.xerial.snappy/snappy-java@1.1.8.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-streams-test-utils@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-streams@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.scala-lang/scala-library@2.13.6",
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+				"pkg:maven/commons-cli/commons-cli@1.4"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.6",
@@ -1550,7 +1733,18 @@
 		{
 			"ref": "pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
 			"dependsOn": [
-				"pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1"
+				"pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
 			]
 		},
 		{
@@ -1560,12 +1754,24 @@
 		{
 			"ref": "pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
 			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.6",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
 				"pkg:maven/com.thoughtworks.paranamer/paranamer@2.8"
 			]
 		},
 		{
-			"ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+			"ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
 			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+			"dependsOn": [
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-core@2.13.2"
+			]
 		},
 		{
 			"ref": "pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
@@ -1573,47 +1779,77 @@
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.5"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.5",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.5"
+			]
 		},
 		{
 			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.6",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.6"
+			]
 		},
 		{
 			"ref": "pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+			"dependsOn": [
+				"pkg:maven/org.scala-lang/scala-library@2.13.4",
+				"pkg:maven/org.scala-lang/scala-reflect@2.13.4",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
+		},
+		{
+			"ref": "pkg:maven/org.scala-lang/scala-library@2.13.4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:maven/org.scala-lang/scala-reflect@2.13.4",
 			"dependsOn": []
 		},
 		{
 			"ref": "pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
-			"dependsOn": []
+			"dependsOn": [
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36"
+			]
 		},
 		{
 			"ref": "pkg:maven/commons-cli/commons-cli@1.4",
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/org.apache.kafka/kafka-storage-api@3.0.1",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/com.thoughtworks.paranamer/paranamer@2.8",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.opentest4j/opentest4j@1.2.0",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.junit.platform/junit-platform-commons@1.8.2",
-			"dependsOn": []
-		},
-		{
-			"ref": "pkg:maven/org.apiguardian/apiguardian-api@1.1.2",
-			"dependsOn": []
+			"ref": "pkg:maven/org.apache.kafka/kafka_2.13@test",
+			"dependsOn": [
+				"pkg:maven/org.apache.kafka/kafka-clients@3.0.1",
+				"pkg:maven/org.scala-lang/scala-library@2.13.6",
+				"pkg:maven/org.apache.kafka/kafka-server-common@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-metadata@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-raft@3.0.1",
+				"pkg:maven/org.apache.kafka/kafka-storage@3.0.1",
+				"pkg:maven/net.sourceforge.argparse4j/argparse4j@0.7.0",
+				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.2.1",
+				"pkg:maven/com.fasterxml.jackson.module/jackson-module-scala_2.13@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.dataformat/jackson-dataformat-csv@2.13.2",
+				"pkg:maven/com.fasterxml.jackson.datatype/jackson-datatype-jdk8@2.13.2",
+				"pkg:maven/net.sf.jopt-simple/jopt-simple@5.0.4",
+				"pkg:maven/com.yammer.metrics/metrics-core@2.2.0",
+				"pkg:maven/org.scala-lang.modules/scala-collection-compat_2.13@2.4.4",
+				"pkg:maven/org.scala-lang.modules/scala-java8-compat_2.13@1.0.0",
+				"pkg:maven/org.scala-lang/scala-reflect@2.13.6",
+				"pkg:maven/com.typesafe.scala-logging/scala-logging_2.13@3.9.3",
+				"pkg:maven/org.slf4j/slf4j-api@1.7.36",
+				"pkg:maven/io.dropwizard.metrics/metrics-core@4.2.9",
+				"pkg:maven/org.apache.zookeeper/zookeeper@3.6.3",
+				"pkg:maven/commons-cli/commons-cli@1.4"
+			]
 		}
 	]
 }


### PR DESCRIPTION
## Description

The `dependency:tree` plugin omits duplicates but when using the `verbose` flag the omitted are shown. However the plugin only yields the `text` type in that case.

I have added the `verbose` flag to the `mvn dependency:tree` command and changed how the text file is processed with the `text` format.

**Related issue (if any):** 
fixes #44 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

Related to https://github.com/RHEcosystemAppEng/exhort/pull/135