### PR TITLE
fix: drop bundled config file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,8 @@
-import {rootPath} from "get-root-path";
 import { availableProviders, match } from './provider.js'
 import {AnalysisReport} from '../generated/backend/AnalysisReport.js'
 import analysis from './analysis.js'
 import fs from 'node:fs'
 import {getCustom} from "./tools.js";
-import path from 'node:path'
-
-import PropertiesReader from 'properties-reader'
 
 export default { AnalysisReport, componentAnalysis, stackAnalysis, validateToken }
 
@@ -24,22 +20,14 @@ export const exhortDefaultUrl = "https://rhda.rhcloud.com";
  * EXHORT_DEV_MODE evaluated in the following order and selected when it finds it first:
  * 1. Environment Variable
  * 2. (key,value) from opts object
- * 3. Bundled value in configuration.properties file inside the package
+ * 3. Default False ( points to production URL )
  * @param {{}} [opts={}] - optional various options to override default EXHORT_DEV_MODE and DEV_EXHORT_BACKEND_URL.
  * @return {string} - The selected exhort backend
  * @private
  */
 function selectExhortBackend(opts= {}) {
 	let result
-	// fs.existsSync()
-
-
-	// console.log(path.resolve(rootPath,"config","config.properties"))
-
-	let properties = PropertiesReader(path.join(rootPath,"config","config.properties"));
-	// let error={}
-	// console.log(error)
-	let exhortDevModeBundled = properties.get("EXHORT_DEV_MODE").toString()
+	let exhortDevModeBundled = "false"
 	let exhortDevMode = getCustom("EXHORT_DEV_MODE",exhortDevModeBundled,opts)
 	if(exhortDevMode !== null && exhortDevMode.toString() === "true") {
 		result = getCustom('DEV_EXHORT_BACKEND_URL',exhortDevDefaultUrl,opts);

--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -60,4 +60,4 @@ suite('testing the golang-go-modules data provider', () => {
 	})
 
 
-}).beforeAll(() => clock = sinon.useFakeTimers(new Date(2023,7,7))).afterAll(()=> clock.restore());
+}).beforeAll(() => clock = sinon.useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(()=> clock.restore());


### PR DESCRIPTION
## Description

This is very useful feature but a package ( get-root-path ) that it's relying on doing some problems for what concerns dependency management and resolution on client Vscode Extension at build time  , probably because it's pretty old dependency.

So i'm dropping this nice to have feature.


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

