### PR TITLE
fix: argument list too long error when writing json report to file

### DIFF
--- a/docker-image/scripts/exhort.sh
+++ b/docker-image/scripts/exhort.sh
@@ -45,7 +45,7 @@ else
 
   # Save report along with exit code into output file.
   jq -n {} | \
-  jq --argjson report "$report" '. + {report: $report}' | \
+  jq --slurpfile report <(echo "$report") '. + {report: $report[0]}' | \
   jq --arg exit_code "$exit_code" '. + {exit_code: $exit_code}' > \
   $output_file_path
 


### PR DESCRIPTION
## Description

substituted --argjson with --slurpfile in order to deal with large Json objects and overcome the "Argument list too long" error when writing report result to file.

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

