### PR TITLE
fix: couple of related problems with exhortignore in go.mod

### DIFF
--- a/src/cyclone_dx_sbom.js
+++ b/src/cyclone_dx_sbom.js
@@ -227,5 +227,30 @@ export default class CycloneDxSbom {
 		return this
 	}
 
+	/** This method gets a component object, and a string name, and checks if the name is a substring of the component' purl.
+	 * @param {} component to search in its dependencies
+	 * @param {String} name to be checked.
+	 *
+	 * @return {boolean}
+	 */
+	checkIfPackageInsideDependsOnList(component, name)
+	{
+
+		let dependencyIndex = this.getDependencyIndex(component.purl)
+		if(dependencyIndex < 0)
+		{
+			return false
+		}
+
+		//Only if the dependency doesn't exists on the dependency list of dependency, then add it to this list.
+		if(this.dependencies[dependencyIndex].dependsOn.findIndex(dep => dep.includes(name) ) >= 0)
+		{
+			return true;
+		}
+		else {
+			return false
+		}
+	}
+
 
 }

--- a/src/sbom.js
+++ b/src/sbom.js
@@ -62,6 +62,17 @@ export default class Sbom {
 	purlToComponent(purl){
 		return this.sbomModel.purlToComponent(purl)
 	}
+
+	/** This method gets a component object, and a string name, and checks if the name is a substring of the component' purl.
+	 * @param {} component to search in its dependencies
+	 * @param {String} name to be checked.
+	 *
+	 * @return {boolean}
+	 */
+	checkIfPackageInsideDependsOnList(component, name)
+	{
+		return this.sbomModel.checkIfPackageInsideDependsOnList(component,name)
+	}
 }
 
 

--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -20,7 +20,8 @@ suite('testing the golang-go-modules data provider', () => {
 		"go_mod_light_no_ignore",
 		"go_mod_no_ignore",
 		"go_mod_with_ignore",
-		"go_mod_test_ignore"
+		"go_mod_test_ignore",
+		"go_mod_with_all_ignore"
 	].forEach(testCase => {
 		let scenario = testCase.replace('go_mod_', '').replaceAll('_', ' ')
 		test(`verify go.mod sbom provided for stack analysis with scenario ${scenario}`, async () => {

--- a/test/providers/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_component_analysis.json
@@ -1,0 +1,32 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.4",
+	"version": 1,
+	"metadata": {
+		"timestamp": "2023-08-07T00:00:00.000Z",
+		"component": {
+			"group": "github.com/devfile-samples",
+			"name": "devfile-sample-go-basic",
+			"version": "v0.0.0",
+			"purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+			"type": "application",
+			"bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+		}
+	},
+	"components": [
+		{
+			"group": "github.com/devfile-samples",
+			"name": "devfile-sample-go-basic",
+			"version": "v0.0.0",
+			"purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+			"type": "application",
+			"bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+		}
+	],
+	"dependencies": [
+		{
+			"ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+			"dependsOn": []
+		}
+	]
+}

--- a/test/providers/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_with_all_ignore/expected_sbom_stack_analysis.json
@@ -1,0 +1,4654 @@
+{
+	"bomFormat": "CycloneDX",
+	"specVersion": "1.4",
+	"version": 1,
+	"metadata": {
+		"timestamp": "2023-08-07T00:00:00.000Z",
+		"component": {
+			"group": "github.com/devfile-samples",
+			"name": "devfile-sample-go-basic",
+			"version": "v0.0.0",
+			"purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+			"type": "application",
+			"bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+		}
+	},
+	"components": [
+		{
+			"group": "github.com/devfile-samples",
+			"name": "devfile-sample-go-basic",
+			"version": "v0.0.0",
+			"purl": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+			"type": "application",
+			"bom-ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0"
+		},
+		{
+			"group": "github.com/gin-contrib",
+			"name": "sse",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0"
+		},
+		{
+			"group": "github.com/go-playground/validator",
+			"name": "v10",
+			"version": "v10.2.0",
+			"purl": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0"
+		},
+		{
+			"group": "github.com/golang",
+			"name": "protobuf",
+			"version": "v1.3.3",
+			"purl": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.3"
+		},
+		{
+			"group": "github.com/json-iterator",
+			"name": "go",
+			"version": "v1.1.9",
+			"purl": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.9"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-isatty",
+			"version": "v0.0.12",
+			"purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12"
+		},
+		{
+			"group": "github.com/stretchr",
+			"name": "testify",
+			"version": "v1.4.0",
+			"purl": "pkg:golang/github.com/stretchr/testify@v1.4.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/stretchr/testify@v1.4.0"
+		},
+		{
+			"group": "github.com/ugorji/go",
+			"name": "codec",
+			"version": "v1.1.7",
+			"purl": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "yaml.v2",
+			"version": "v2.2.8",
+			"purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-block-format",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-cid",
+			"version": "v0.0.7",
+			"purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipld-cbor",
+			"version": "v0.0.5",
+			"purl": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipld-format",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-merkledag",
+			"version": "v0.3.2",
+			"purl": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2"
+		},
+		{
+			"group": "github.com/ipld",
+			"name": "go-codec-dagpb",
+			"version": "v1.2.0",
+			"purl": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0"
+		},
+		{
+			"group": "github.com/ipld",
+			"name": "go-ipld-prime",
+			"version": "v0.9.0",
+			"purl": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multihash",
+			"version": "v0.0.15",
+			"purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15"
+		},
+		{
+			"group": "github.com/stretchr",
+			"name": "testify",
+			"version": "v1.7.0",
+			"purl": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/stretchr/testify@v1.7.0"
+		},
+		{
+			"group": "github.com/dgrijalva",
+			"name": "jwt-go",
+			"version": "v3.2.0+incompatible",
+			"purl": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible"
+		},
+		{
+			"group": "github.com/labstack",
+			"name": "gommon",
+			"version": "v0.3.0",
+			"purl": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/labstack/gommon@v0.3.0"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-colorable",
+			"version": "v0.1.7",
+			"purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7"
+		},
+		{
+			"group": "github.com/valyala",
+			"name": "fasttemplate",
+			"version": "v1.2.1",
+			"purl": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20200820211705-5c72a883971a",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20200820211705-5c72a883971a",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200820211705-5c72a883971a"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20200822124328-c89045814202",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20200826173525-f9321e4c35a6",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200826173525-f9321e4c35a6",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200826173525-f9321e4c35a6"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "text",
+			"version": "v0.3.3",
+			"purl": "pkg:golang/golang.org/x/text@v0.3.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/text@v0.3.3"
+		},
+		{
+			"group": "github.com/beevik",
+			"name": "etree",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/github.com/beevik/etree@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/beevik/etree@v1.1.0"
+		},
+		{
+			"group": "github.com/jonboulle",
+			"name": "clockwork",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0"
+		},
+		{
+			"group": "github.com/stretchr",
+			"name": "testify",
+			"version": "v1.6.1",
+			"purl": "pkg:golang/github.com/stretchr/testify@v1.6.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/stretchr/testify@v1.6.1"
+		},
+		{
+			"group": "github.com/armon",
+			"name": "go-radix",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/armon/go-radix@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/armon/go-radix@v1.0.0"
+		},
+		{
+			"group": "github.com/cucumber",
+			"name": "godog",
+			"version": "v0.8.1",
+			"purl": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/cucumber/godog@v0.8.1"
+		},
+		{
+			"group": "github.com/davecgh",
+			"name": "go-spew",
+			"version": "v1.1.1",
+			"purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+		},
+		{
+			"group": "github.com/elastic",
+			"name": "go-sysinfo",
+			"version": "v1.1.1",
+			"purl": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1"
+		},
+		{
+			"group": "github.com/google",
+			"name": "go-cmp",
+			"version": "v0.3.1",
+			"purl": "pkg:golang/github.com/google/go-cmp@v0.3.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/google/go-cmp@v0.3.1"
+		},
+		{
+			"group": "github.com/pkg",
+			"name": "errors",
+			"version": "v0.8.1",
+			"purl": "pkg:golang/github.com/pkg/errors@v0.8.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/pkg/errors@v0.8.1"
+		},
+		{
+			"group": "github.com/prometheus",
+			"name": "procfs",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3"
+		},
+		{
+			"group": "github.com/santhosh-tekuri",
+			"name": "jsonschema",
+			"version": "v1.2.4",
+			"purl": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4"
+		},
+		{
+			"group": "go.elastic.co",
+			"name": "fastjson",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20191204072324-ce4227a45e2e",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20191204072324-ce4227a45e2e",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191204072324-ce4227a45e2e"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "check.v1",
+			"version": "v0.0.0-20161208181325-20d25e280405",
+			"purl": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+		},
+		{
+			"group": "github.com/stretchr",
+			"name": "testify",
+			"version": "v1.3.0",
+			"purl": "pkg:golang/github.com/stretchr/testify@v1.3.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/stretchr/testify@v1.3.0"
+		},
+		{
+			"group": "github.com/go-playground/assert",
+			"name": "v2",
+			"version": "v2.0.1",
+			"purl": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1"
+		},
+		{
+			"group": "github.com/go-playground",
+			"name": "locales",
+			"version": "v0.13.0",
+			"purl": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/go-playground/locales@v0.13.0"
+		},
+		{
+			"group": "github.com/go-playground",
+			"name": "universal-translator",
+			"version": "v0.17.0",
+			"purl": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0"
+		},
+		{
+			"group": "github.com/leodido",
+			"name": "go-urn",
+			"version": "v1.2.0",
+			"purl": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0"
+		},
+		{
+			"group": "github.com/google",
+			"name": "gofuzz",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/google/gofuzz@v1.0.0"
+		},
+		{
+			"group": "github.com/modern-go",
+			"name": "concurrent",
+			"version": "v0.0.0-20180228061459-e0a39a4cb421",
+			"purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421"
+		},
+		{
+			"group": "github.com/modern-go",
+			"name": "reflect2",
+			"version": "v0.0.0-20180701023420-4b7aa43c6742",
+			"purl": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20200116001909-b77594299b42",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+		},
+		{
+			"group": "github.com/davecgh",
+			"name": "go-spew",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.0"
+		},
+		{
+			"group": "github.com/pmezard",
+			"name": "go-difflib",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0"
+		},
+		{
+			"group": "github.com/stretchr",
+			"name": "objx",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/stretchr/objx@v0.1.0"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "yaml.v2",
+			"version": "v2.2.2",
+			"purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+		},
+		{
+			"group": "github.com/ugorji",
+			"name": "go",
+			"version": "v1.1.7",
+			"purl": "pkg:golang/github.com/ugorji/go@v1.1.7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ugorji/go@v1.1.7"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-util",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multihash",
+			"version": "v0.0.14",
+			"purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.14",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.14"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multibase",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multihash",
+			"version": "v0.0.13",
+			"purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.13",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.13"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-varint",
+			"version": "v0.0.5",
+			"purl": "pkg:golang/github.com/multiformats/go-varint@v0.0.5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.5"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-block-format",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.2"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-cid",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.3"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-util",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipld-format",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.0.1"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multihash",
+			"version": "v0.0.10",
+			"purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.10",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.10"
+		},
+		{
+			"group": "github.com/polydawn",
+			"name": "refmt",
+			"version": "v0.0.0-20190221155625-df39d6c2d992",
+			"purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20190221155625-df39d6c2d992",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20190221155625-df39d6c2d992"
+		},
+		{
+			"group": "github.com/smartystreets",
+			"name": "goconvey",
+			"version": "v0.0.0-20190222223459-a17d461953aa",
+			"purl": "pkg:golang/github.com/smartystreets/goconvey@v0.0.0-20190222223459-a17d461953aa",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v0.0.0-20190222223459-a17d461953aa"
+		},
+		{
+			"group": "github.com/warpfork",
+			"name": "go-wish",
+			"version": "v0.0.0-20180510122957-5ad1f5abf436",
+			"purl": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20180510122957-5ad1f5abf436",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20180510122957-5ad1f5abf436"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "cbor-gen",
+			"version": "v0.0.0-20200123233031-1cdf64d27158",
+			"purl": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-cid",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.2"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-buffer-pool",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multihash",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+		},
+		{
+			"group": "github.com/gogo",
+			"name": "protobuf",
+			"version": "v1.3.1",
+			"purl": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-blockservice",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-datastore",
+			"version": "v0.3.1",
+			"purl": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-blockstore",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-exchange-offline",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipld-cbor",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.3"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipld-format",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/ipfs/go-ipld-format@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.0.2"
+		},
+		{
+			"group": "github.com/mr-tron",
+			"name": "base58",
+			"version": "v1.2.0",
+			"purl": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-varint",
+			"version": "v0.0.6",
+			"purl": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6"
+		},
+		{
+			"group": "github.com/polydawn",
+			"name": "refmt",
+			"version": "v0.0.0-20201211092308-30ac6d18308e",
+			"purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "xerrors",
+			"version": "v0.0.0-20200804184101-5ec99f83aff1",
+			"purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+		},
+		{
+			"group": "github.com/frankban",
+			"name": "quicktest",
+			"version": "v1.11.3",
+			"purl": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-cid",
+			"version": "v0.0.4",
+			"purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.4"
+		},
+		{
+			"group": "github.com/polydawn",
+			"name": "refmt",
+			"version": "v0.0.0-20190807091052-3d65705ee9f1",
+			"purl": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20190807091052-3d65705ee9f1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20190807091052-3d65705ee9f1"
+		},
+		{
+			"group": "github.com/smartystreets",
+			"name": "goconvey",
+			"version": "v1.6.4",
+			"purl": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4"
+		},
+		{
+			"group": "github.com/warpfork",
+			"name": "go-wish",
+			"version": "v0.0.0-20200122115046-b9ea61034e4a",
+			"purl": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+		},
+		{
+			"group": "github.com/minio",
+			"name": "blake2b-simd",
+			"version": "v0.0.0-20160723061019-3f5f724cb5b1",
+			"purl": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1"
+		},
+		{
+			"group": "github.com/minio",
+			"name": "sha256-simd",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20210220033148-5ea612d1eb83",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20210309074719-68d13333faf2",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "yaml.v3",
+			"version": "v3.0.0-20200313102051-9f266ea9e77c",
+			"purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-colorable",
+			"version": "v0.1.2",
+			"purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.2"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-isatty",
+			"version": "v0.0.9",
+			"purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.9",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.9"
+		},
+		{
+			"group": "github.com/valyala",
+			"name": "fasttemplate",
+			"version": "v1.0.1",
+			"purl": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20200223170610-d5e6a3e2c0ae",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200223170610-d5e6a3e2c0ae",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200223170610-d5e6a3e2c0ae"
+		},
+		{
+			"group": "github.com/valyala",
+			"name": "bytebufferpool",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20190404232315-eb5bcb51f2a3",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190412213103-97732733099d",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20200622213623-75b288015ac9",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20200323222414-85ca7c5b95cd",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "text",
+			"version": "v0.3.0",
+			"purl": "pkg:golang/golang.org/x/text@v0.3.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/text@v0.3.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20180917221912-90fa682c2a6e",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+		},
+		{
+			"group": "github.com/elastic",
+			"name": "go-windows",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0"
+		},
+		{
+			"group": "github.com/joeshaw",
+			"name": "multierror",
+			"version": "v0.0.0-20140124173710-69b34d4ec901",
+			"purl": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901"
+		},
+		{
+			"group": "github.com/prometheus",
+			"name": "procfs",
+			"version": "v0.0.0-20190425082905-87a4384529e0",
+			"purl": "pkg:golang/github.com/prometheus/procfs@v0.0.0-20190425082905-87a4384529e0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/prometheus/procfs@v0.0.0-20190425082905-87a4384529e0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20191025021431-6c3a3bfe00ae",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20191025021431-6c3a3bfe00ae",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191025021431-6c3a3bfe00ae"
+		},
+		{
+			"group": "howett.net",
+			"name": "plist",
+			"version": "v0.0.0-20181124034731-591f970eefbb",
+			"purl": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+			"type": "library",
+			"bom-ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+		},
+		{
+			"group": "github.com/google",
+			"name": "go-cmp",
+			"version": "v0.3.0",
+			"purl": "pkg:golang/github.com/google/go-cmp@v0.3.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/google/go-cmp@v0.3.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sync",
+			"version": "v0.0.0-20181221193216-37e7f081c4d4",
+			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4"
+		},
+		{
+			"group": "github.com/pkg",
+			"name": "errors",
+			"version": "v0.8.0",
+			"purl": "pkg:golang/github.com/pkg/errors@v0.8.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/pkg/errors@v0.8.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20200509030707-2212a7e161a5",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "text",
+			"version": "v0.3.2",
+			"purl": "pkg:golang/golang.org/x/text@v0.3.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/text@v0.3.2"
+		},
+		{
+			"group": "github.com/mr-tron",
+			"name": "base58",
+			"version": "v1.1.3",
+			"purl": "pkg:golang/github.com/mr-tron/base58@v1.1.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.1.3"
+		},
+		{
+			"group": "github.com/minio",
+			"name": "sha256-simd",
+			"version": "v0.1.1-0.20190913151208-6de447530771",
+			"purl": "pkg:golang/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771"
+		},
+		{
+			"group": "github.com/spaolacci",
+			"name": "murmur3",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20190611184440-5c40567a22f8",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8"
+		},
+		{
+			"group": "github.com/mr-tron",
+			"name": "base58",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/github.com/mr-tron/base58@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.1.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-base32",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-base36",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-cid",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.1"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multibase",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/multiformats/go-multibase@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.1"
+		},
+		{
+			"group": "github.com/mr-tron",
+			"name": "base58",
+			"version": "v1.1.2",
+			"purl": "pkg:golang/github.com/mr-tron/base58@v1.1.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.1.2"
+		},
+		{
+			"group": "github.com/gopherjs",
+			"name": "gopherjs",
+			"version": "v0.0.0-20181017120253-0766667cb4d1",
+			"purl": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1"
+		},
+		{
+			"group": "github.com/jtolds",
+			"name": "gls",
+			"version": "v4.2.1+incompatible",
+			"purl": "pkg:golang/github.com/jtolds/gls@v4.2.1%2Bincompatible",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jtolds/gls@v4.2.1%2Bincompatible"
+		},
+		{
+			"group": "github.com/smartystreets",
+			"name": "assertions",
+			"version": "v0.0.0-20180927180507-b2de0cb4f26d",
+			"purl": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+		},
+		{
+			"group": "github.com/google",
+			"name": "go-cmp",
+			"version": "v0.4.0",
+			"purl": "pkg:golang/github.com/google/go-cmp@v0.4.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/google/go-cmp@v0.4.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "xerrors",
+			"version": "v0.0.0-20191204190536-9bdfabe68543",
+			"purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+		},
+		{
+			"group": "github.com/gxed/hashland",
+			"name": "keccakpg",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1"
+		},
+		{
+			"group": "github.com/gxed/hashland",
+			"name": "murmur3",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1"
+		},
+		{
+			"group": "github.com/minio",
+			"name": "sha256-simd",
+			"version": "v0.0.0-20190131020904-2d45a736cd16",
+			"purl": "pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190131020904-2d45a736cd16",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190131020904-2d45a736cd16"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20190211182817-74369b46fc67",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20190211182817-74369b46fc67",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190211182817-74369b46fc67"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190219092855-153ac476189d",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190219092855-153ac476189d",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190219092855-153ac476189d"
+		},
+		{
+			"group": "github.com/kisielk",
+			"name": "errcheck",
+			"version": "v1.2.0",
+			"purl": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0"
+		},
+		{
+			"group": "github.com/kisielk",
+			"name": "gotool",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-bitswap",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-datastore",
+			"version": "v0.0.5",
+			"purl": "pkg:golang/github.com/ipfs/go-datastore@v0.0.5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.0.5"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-blockstore",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-blocksutil",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-delay",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-exchange-interface",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-routing",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-log",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-verifcid",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+		},
+		{
+			"group": "github.com/go-check",
+			"name": "check",
+			"version": "v0.0.0-20180628173108-788fd7840127",
+			"purl": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127"
+		},
+		{
+			"group": "github.com/google",
+			"name": "uuid",
+			"version": "v1.1.1",
+			"purl": "pkg:golang/github.com/google/uuid@v1.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/google/uuid@v1.1.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-delay",
+			"version": "v0.0.0-20181109222059-70721b86a9a8",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8"
+		},
+		{
+			"group": "github.com/jbenet",
+			"name": "goprocess",
+			"version": "v0.0.0-20160826012719-b497e2f366b8",
+			"purl": "pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8"
+		},
+		{
+			"group": "github.com/kr",
+			"name": "pretty",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/kr/pretty@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kr/pretty@v0.1.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "xerrors",
+			"version": "v0.0.0-20190717185122-a985d3407aa7",
+			"purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20190717185122-a985d3407aa7",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20190717185122-a985d3407aa7"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "check.v1",
+			"version": "v1.0.0-20180628173108-788fd7840127",
+			"purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+		},
+		{
+			"group": "github.com/hashicorp",
+			"name": "golang-lru",
+			"version": "v0.5.1",
+			"purl": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "bbloom",
+			"version": "v0.0.4",
+			"purl": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-block-format",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-block-format@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-datastore",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/ipfs/go-datastore@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-ds-help",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-metrics-interface",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-datastore",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-datastore@v0.0.1"
+		},
+		{
+			"group": "github.com/google",
+			"name": "go-cmp",
+			"version": "v0.5.4",
+			"purl": "pkg:golang/github.com/google/go-cmp@v0.5.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.4"
+		},
+		{
+			"group": "github.com/kr",
+			"name": "pretty",
+			"version": "v0.2.1",
+			"purl": "pkg:golang/github.com/kr/pretty@v0.2.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.1"
+		},
+		{
+			"group": "github.com/jtolds",
+			"name": "gls",
+			"version": "v4.20.0+incompatible",
+			"purl": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20190328211700-ab21143f2384",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20190328211700-ab21143f2384",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190328211700-ab21143f2384"
+		},
+		{
+			"group": "github.com/klauspost/cpuid",
+			"name": "v2",
+			"version": "v2.0.4",
+			"purl": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20191026070338-33540a1f6037",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "term",
+			"version": "v0.0.0-20201117132131-f5c789dd3221",
+			"purl": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-isatty",
+			"version": "v0.0.8",
+			"purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.8",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.8"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190813064441-fde4db37ae7a",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190813064441-fde4db37ae7a",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190813064441-fde4db37ae7a"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20190308221718-c2843e01d9a2",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2"
+		},
+		{
+			"group": "github.com/jessevdk",
+			"name": "go-flags",
+			"version": "v1.4.0",
+			"purl": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "yaml.v2",
+			"version": "v2.2.1",
+			"purl": "pkg:golang/gopkg.in/yaml.v2@v2.2.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.1"
+		},
+		{
+			"group": "github.com/yuin",
+			"name": "goldmark",
+			"version": "v1.1.27",
+			"purl": "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/yuin/goldmark@v1.1.27"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "mod",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/golang.org/x/mod@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/mod@v0.2.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20200226121028-0de0cce0169b",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20200226121028-0de0cce0169b",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20200226121028-0de0cce0169b"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sync",
+			"version": "v0.0.0-20190911185100-cd5d95a43a6e",
+			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20181030221726-6c7e314b6563",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20181030221726-6c7e314b6563",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20181030221726-6c7e314b6563"
+		},
+		{
+			"group": "github.com/cskr",
+			"name": "pubsub",
+			"version": "v1.0.2",
+			"purl": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2"
+		},
+		{
+			"group": "github.com/gogo",
+			"name": "protobuf",
+			"version": "v1.2.1",
+			"purl": "pkg:golang/github.com/gogo/protobuf@v1.2.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.2.1"
+		},
+		{
+			"group": "github.com/golang",
+			"name": "protobuf",
+			"version": "v1.3.1",
+			"purl": "pkg:golang/github.com/golang/protobuf@v1.3.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-detect-race",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-peertaskqueue",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0"
+		},
+		{
+			"group": "github.com/jbenet",
+			"name": "goprocess",
+			"version": "v0.1.3",
+			"purl": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-core",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-loggables",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-netutil",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-testing",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-testutil",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr",
+			"version": "v0.0.4",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+		},
+		{
+			"group": "github.com/opentracing",
+			"name": "opentracing-go",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20190522155817-f3200d17e092",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190522155817-f3200d17e092",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190522155817-f3200d17e092"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190524122548-abf6ff778158",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190524122548-abf6ff778158",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190524122548-abf6ff778158"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "bbloom",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/bbloom@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-record",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multihash",
+			"version": "v0.0.5",
+			"purl": "pkg:golang/github.com/multiformats/go-multihash@v0.0.5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.5"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-colorable",
+			"version": "v0.1.1",
+			"purl": "pkg:golang/github.com/mattn/go-colorable@v0.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.1"
+		},
+		{
+			"group": "github.com/opentracing",
+			"name": "opentracing-go",
+			"version": "v1.0.2",
+			"purl": "pkg:golang/github.com/opentracing/opentracing-go@v1.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.0.2"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "go-logging",
+			"version": "v0.0.0-20170515211332-0457bb6b88fc",
+			"purl": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20190227160552-c95aed5357e7",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190227160552-c95aed5357e7",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190227160552-c95aed5357e7"
+		},
+		{
+			"group": "github.com/kr",
+			"name": "text",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/kr/text@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kr/text@v0.1.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20190311183353-d8887717615a",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190222072716-a9d3bda3a223",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190215142949-d0b11bdaac8a",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20191011191535-87dc89f01550",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20191119224855-298f0cb1881e",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20191119224855-298f0cb1881e",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20191119224855-298f0cb1881e"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "xerrors",
+			"version": "v0.0.0-20191011141410-1b5146add898",
+			"purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191011141410-1b5146add898",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191011141410-1b5146add898"
+		},
+		{
+			"group": "github.com/kisielk",
+			"name": "errcheck",
+			"version": "v1.1.0",
+			"purl": "pkg:golang/github.com/kisielk/errcheck@v1.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kisielk/errcheck@v1.1.0"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ipfs-pq",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-core",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1"
+		},
+		{
+			"group": "github.com/jbenet",
+			"name": "go-cienv",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-conn-security-multistream",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-autonat",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-blankhost",
+			"version": "v0.1.1",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-circuit",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-discovery",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-mplex",
+			"version": "v0.2.1",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-nat",
+			"version": "v0.0.4",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-peerstore",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-secio",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-swarm",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-transport-upgrader",
+			"version": "v0.1.1",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-yamux",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-maddr-filter",
+			"version": "v0.0.4",
+			"purl": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-stream-muxer-multistream",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-tcp-transport",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-ws-transport",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr-dns",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr-net",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multistream",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "mdns",
+			"version": "v0.0.0-20180901202407-ef14215e6b30",
+			"purl": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "btcd",
+			"version": "v0.0.0-20190523000118-16327141da8c",
+			"purl": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c"
+		},
+		{
+			"group": "github.com/coreos",
+			"name": "go-semver",
+			"version": "v0.3.0",
+			"purl": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-flow-metrics",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1"
+		},
+		{
+			"group": "github.com/minio",
+			"name": "sha256-simd",
+			"version": "v0.0.0-20190328051042-05b4dd3047e5",
+			"purl": "pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190328051042-05b4dd3047e5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190328051042-05b4dd3047e5"
+		},
+		{
+			"group": "github.com/spacemonkeygo",
+			"name": "openssl",
+			"version": "v0.0.0-20181017203307-c2dcc5cca94a",
+			"purl": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20190513172903-22d7a77e9e5f",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20190513172903-22d7a77e9e5f",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190513172903-22d7a77e9e5f"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-testing",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.2"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20190426145343-a29dc8fdc734",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20190426145343-a29dc8fdc734",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190426145343-a29dc8fdc734"
+		},
+		{
+			"group": "github.com/mattn",
+			"name": "go-isatty",
+			"version": "v0.0.5",
+			"purl": "pkg:golang/github.com/mattn/go-isatty@v0.0.5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.5"
+		},
+		{
+			"group": "github.com/kr",
+			"name": "pty",
+			"version": "v1.1.1",
+			"purl": "pkg:golang/github.com/kr/pty@v1.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kr/pty@v1.1.1"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20190620200207-3b0461eec859",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20190620200207-3b0461eec859",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20190620200207-3b0461eec859"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sync",
+			"version": "v0.0.0-20190423024810-112230192c58",
+			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20180221164845-07fd8470d635",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20180221164845-07fd8470d635",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180221164845-07fd8470d635"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "btcd",
+			"version": "v0.0.0-20190213025234-306aecffea32",
+			"purl": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190213025234-306aecffea32",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190213025234-306aecffea32"
+		},
+		{
+			"group": "github.com/mr-tron",
+			"name": "base58",
+			"version": "v1.1.1",
+			"purl": "pkg:golang/github.com/mr-tron/base58@v1.1.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/mr-tron/base58@v1.1.1"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20190225124518-7f87c0fbb88b",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20190225124518-7f87c0fbb88b",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190225124518-7f87c0fbb88b"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-mplex",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+		},
+		{
+			"group": "github.com/jbenet",
+			"name": "go-cienv",
+			"version": "v0.0.0-20150120210510-1bb1476777ec",
+			"purl": "pkg:golang/github.com/jbenet/go-cienv@v0.0.0-20150120210510-1bb1476777ec",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jbenet/go-cienv@v0.0.0-20150120210510-1bb1476777ec"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-nat",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "go-notifier",
+			"version": "v0.0.0-20170827234753-097c5d47330f",
+			"purl": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ds-badger",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2"
+		},
+		{
+			"group": "github.com/ipfs",
+			"name": "go-ds-leveldb",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-buffer-pool",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-crypto",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-peer",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "go-keyspace",
+			"version": "v0.0.0-20160322163242-5b898ac5add1",
+			"purl": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "mafmt",
+			"version": "v1.2.8",
+			"purl": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-msgio",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2"
+		},
+		{
+			"group": "github.com/minio",
+			"name": "sha256-simd",
+			"version": "v0.1.0",
+			"purl": "pkg:golang/github.com/minio/sha256-simd@v0.1.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/minio/sha256-simd@v0.1.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-addr-util",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1"
+		},
+		{
+			"group": "github.com/whyrusleeping",
+			"name": "multiaddr-filter",
+			"version": "v0.0.0-20160516205228-e903e4adabd7",
+			"purl": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+		},
+		{
+			"group": "github.com/jbenet",
+			"name": "go-temp-err-catcher",
+			"version": "v0.0.0-20150120210811-aac704a3f4f2",
+			"purl": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-libp2p-mplex",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.0"
+		},
+		{
+			"group": "github.com/onsi",
+			"name": "ginkgo",
+			"version": "v1.8.0",
+			"purl": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0"
+		},
+		{
+			"group": "github.com/onsi",
+			"name": "gomega",
+			"version": "v1.5.0",
+			"purl": "pkg:golang/github.com/onsi/gomega@v1.5.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/onsi/gomega@v1.5.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-yamux",
+			"version": "v1.2.2",
+			"purl": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-reuseport",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-reuseport-transport",
+			"version": "v0.0.2",
+			"purl": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr-fmt",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1"
+		},
+		{
+			"group": "github.com/gorilla",
+			"name": "websocket",
+			"version": "v1.4.0",
+			"purl": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0"
+		},
+		{
+			"group": "github.com/multiformats",
+			"name": "go-multiaddr-dns",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.1"
+		},
+		{
+			"group": "github.com/aead",
+			"name": "siphash",
+			"version": "v1.0.1",
+			"purl": "pkg:golang/github.com/aead/siphash@v1.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/aead/siphash@v1.0.1"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "btclog",
+			"version": "v0.0.0-20170628155309-84c8d2346e9f",
+			"purl": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "btcutil",
+			"version": "v0.0.0-20190425235716-9e5f4b9a998d",
+			"purl": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "go-socks",
+			"version": "v0.0.0-20170105172521-4720035b7bfd",
+			"purl": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "goleveldb",
+			"version": "v0.0.0-20160330041536-7834afc9e8cd",
+			"purl": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "snappy-go",
+			"version": "v0.0.0-20151229074030-0bdef8d06723",
+			"purl": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "websocket",
+			"version": "v0.0.0-20150119174127-31079b680792",
+			"purl": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "winsvc",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0"
+		},
+		{
+			"group": "github.com/davecgh",
+			"name": "go-spew",
+			"version": "v0.0.0-20171005155431-ecdeabc65495",
+			"purl": "pkg:golang/github.com/davecgh/go-spew@v0.0.0-20171005155431-ecdeabc65495",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/davecgh/go-spew@v0.0.0-20171005155431-ecdeabc65495"
+		},
+		{
+			"group": "github.com/jessevdk",
+			"name": "go-flags",
+			"version": "v0.0.0-20141203071132-1679536dcc89",
+			"purl": "pkg:golang/github.com/jessevdk/go-flags@v0.0.0-20141203071132-1679536dcc89",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v0.0.0-20141203071132-1679536dcc89"
+		},
+		{
+			"group": "github.com/jrick",
+			"name": "logrotate",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0"
+		},
+		{
+			"group": "github.com/kkdai",
+			"name": "bstream",
+			"version": "v0.0.0-20161212061736-f391b8402d23",
+			"purl": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23"
+		},
+		{
+			"group": "github.com/onsi",
+			"name": "ginkgo",
+			"version": "v1.7.0",
+			"purl": "pkg:golang/github.com/onsi/ginkgo@v1.7.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.7.0"
+		},
+		{
+			"group": "github.com/onsi",
+			"name": "gomega",
+			"version": "v1.4.3",
+			"purl": "pkg:golang/github.com/onsi/gomega@v1.4.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/onsi/gomega@v1.4.3"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "crypto",
+			"version": "v0.0.0-20170930174604-9419663f5a44",
+			"purl": "pkg:golang/golang.org/x/crypto@v0.0.0-20170930174604-9419663f5a44",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20170930174604-9419663f5a44"
+		},
+		{
+			"group": "github.com/spacemonkeygo",
+			"name": "spacelog",
+			"version": "v0.0.0-20180420211403-2296661a0572",
+			"purl": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+		},
+		{
+			"group": "github.com/btcsuite",
+			"name": "btcutil",
+			"version": "v0.0.0-20190207003914-4c204d697803",
+			"purl": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190207003914-4c204d697803",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190207003914-4c204d697803"
+		},
+		{
+			"group": "github.com/huin",
+			"name": "goupnp",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/huin/goupnp@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/huin/goupnp@v1.0.0"
+		},
+		{
+			"group": "github.com/jackpal",
+			"name": "gateway",
+			"version": "v1.0.5",
+			"purl": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5"
+		},
+		{
+			"group": "github.com/jackpal",
+			"name": "go-nat-pmp",
+			"version": "v1.0.1",
+			"purl": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1"
+		},
+		{
+			"group": "github.com/koron",
+			"name": "go-ssdp",
+			"version": "v0.0.0-20180514024734-4a0ed625a78b",
+			"purl": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+		},
+		{
+			"group": "github.com/AndreasBriese",
+			"name": "bbloom",
+			"version": "v0.0.0-20180913140656-343706a395b7",
+			"purl": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20180913140656-343706a395b7"
+		},
+		{
+			"group": "github.com/Kubuxu",
+			"name": "go-os-helper",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/Kubuxu/go-os-helper@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/Kubuxu/go-os-helper@v0.0.1"
+		},
+		{
+			"group": "github.com/dgraph-io",
+			"name": "badger",
+			"version": "v1.5.5-0.20190226225317-8115aed38f8f",
+			"purl": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f"
+		},
+		{
+			"group": "github.com/dgryski",
+			"name": "go-farm",
+			"version": "v0.0.0-20190104051053-3adb47b1fb0f",
+			"purl": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f"
+		},
+		{
+			"group": "github.com/dustin",
+			"name": "go-humanize",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0"
+		},
+		{
+			"group": "github.com/golang",
+			"name": "protobuf",
+			"version": "v1.3.0",
+			"purl": "pkg:golang/github.com/golang/protobuf@v1.3.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/golang/protobuf@v1.3.0"
+		},
+		{
+			"group": "github.com/syndtr",
+			"name": "goleveldb",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-mplex",
+			"version": "v0.0.3",
+			"purl": "pkg:golang/github.com/libp2p/go-mplex@v0.0.3",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-mplex@v0.0.3"
+		},
+		{
+			"group": "github.com/fsnotify",
+			"name": "fsnotify",
+			"version": "v1.4.7",
+			"purl": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7"
+		},
+		{
+			"group": "github.com/golang",
+			"name": "protobuf",
+			"version": "v1.2.0",
+			"purl": "pkg:golang/github.com/golang/protobuf@v1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/golang/protobuf@v1.2.0"
+		},
+		{
+			"group": "github.com/hpcloud",
+			"name": "tail",
+			"version": "v1.0.0",
+			"purl": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0"
+		},
+		{
+			"group": "github.com/onsi",
+			"name": "ginkgo",
+			"version": "v1.6.0",
+			"purl": "pkg:golang/github.com/onsi/ginkgo@v1.6.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/onsi/ginkgo@v1.6.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20180906233101-161cd47e91fd",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20180906233101-161cd47e91fd",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20180906233101-161cd47e91fd"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sync",
+			"version": "v0.0.0-20180314180146-1d60e4601c6f",
+			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20180909124046-d0be0721c37e",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20180909124046-d0be0721c37e",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20180909124046-d0be0721c37e"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "fsnotify.v1",
+			"version": "v1.4.7",
+			"purl": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "tomb.v1",
+			"version": "v1.0.0-20141024135613-dd632973f1e7",
+			"purl": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20190228124157-a34e9553db1e",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20190228124157-a34e9553db1e",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190228124157-a34e9553db1e"
+		},
+		{
+			"group": "github.com/huin",
+			"name": "goutil",
+			"version": "v0.0.0-20170803182201-1ca381bf3150",
+			"purl": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "net",
+			"version": "v0.0.0-20181011144130-49bb7cea24b1",
+			"purl": "pkg:golang/golang.org/x/net@v0.0.0-20181011144130-49bb7cea24b1",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20181011144130-49bb7cea24b1"
+		},
+		{
+			"group": "google.golang.org",
+			"name": "genproto",
+			"version": "v0.0.0-20180831171423-11092d34479b",
+			"purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+			"type": "library",
+			"bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+		},
+		{
+			"group": "github.com/golang",
+			"name": "snappy",
+			"version": "v0.0.0-20180518054509-2e65f85255db",
+			"purl": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db"
+		},
+		{
+			"group": "github.com/libp2p",
+			"name": "go-stream-muxer",
+			"version": "v0.0.1",
+			"purl": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+		}
+	],
+	"dependencies": [
+		{
+			"ref": "pkg:golang/github.com/devfile-samples/devfile-sample-go-basic@v0.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/stretchr/testify@v1.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/go-playground/validator/v10@v10.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+				"pkg:golang/github.com/go-playground/locales@v0.13.0",
+				"pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+				"pkg:golang/github.com/leodido/go-urn@v1.2.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/golang/protobuf@v1.3.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/json-iterator/go@v1.1.9",
+			"dependsOn": [
+				"pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+				"pkg:golang/github.com/google/gofuzz@v1.0.0",
+				"pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+				"pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+				"pkg:golang/github.com/stretchr/testify@v1.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/stretchr/testify@v1.4.0",
+			"dependsOn": [
+				"pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+				"pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+				"pkg:golang/github.com/stretchr/objx@v0.1.0",
+				"pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ugorji/go/codec@v1.1.7",
+			"dependsOn": [
+				"pkg:golang/github.com/ugorji/go@v1.1.7"
+			]
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
+			"dependsOn": [
+				"pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.14"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.13",
+				"pkg:golang/github.com/multiformats/go-varint@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.5",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.3",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipld-format@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.10",
+				"pkg:golang/github.com/polydawn/refmt@v0.0.0-20190221155625-df39d6c2d992",
+				"pkg:golang/github.com/smartystreets/goconvey@v0.0.0-20190222223459-a17d461953aa",
+				"pkg:golang/github.com/warpfork/go-wish@v0.0.0-20180510122957-5ad1f5abf436",
+				"pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-merkledag@v0.3.2",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.3.1",
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.3",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+				"pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.3",
+				"pkg:golang/github.com/ipfs/go-ipld-format@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.10"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipld/go-codec-dagpb@v1.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.7",
+				"pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+				"pkg:golang/github.com/mr-tron/base58@v1.2.0",
+				"pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+				"pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipld/go-ipld-prime@v0.9.0",
+			"dependsOn": [
+				"pkg:golang/github.com/frankban/quicktest@v1.11.3",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+				"pkg:golang/github.com/polydawn/refmt@v0.0.0-20190807091052-3d65705ee9f1",
+				"pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+				"pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.15",
+			"dependsOn": [
+				"pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+				"pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+				"pkg:golang/github.com/mr-tron/base58@v1.2.0",
+				"pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/stretchr/testify@v1.7.0",
+			"dependsOn": [
+				"pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+				"pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+				"pkg:golang/github.com/stretchr/objx@v0.1.0",
+				"pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/dgrijalva/jwt-go@v3.2.0%2Bincompatible",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/labstack/gommon@v0.3.0",
+			"dependsOn": [
+				"pkg:golang/github.com/mattn/go-colorable@v0.1.2",
+				"pkg:golang/github.com/mattn/go-isatty@v0.0.9",
+				"pkg:golang/github.com/stretchr/testify@v1.4.0",
+				"pkg:golang/github.com/valyala/fasttemplate@v1.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.7",
+			"dependsOn": [
+				"pkg:golang/github.com/mattn/go-isatty@v0.0.12",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20200223170610-d5e6a3e2c0ae"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/valyala/fasttemplate@v1.2.1",
+			"dependsOn": [
+				"pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200820211705-5c72a883971a",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20200822124328-c89045814202",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200826173525-f9321e4c35a6",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/text@v0.3.3",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/beevik/etree@v1.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jonboulle/clockwork@v0.2.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/stretchr/testify@v1.6.1",
+			"dependsOn": [
+				"pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+				"pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+				"pkg:golang/github.com/stretchr/objx@v0.1.0",
+				"pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/armon/go-radix@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/cucumber/godog@v0.8.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/elastic/go-sysinfo@v1.1.1",
+			"dependsOn": [
+				"pkg:golang/github.com/elastic/go-windows@v1.0.0",
+				"pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+				"pkg:golang/github.com/pkg/errors@v0.8.1",
+				"pkg:golang/github.com/prometheus/procfs@v0.0.0-20190425082905-87a4384529e0",
+				"pkg:golang/github.com/stretchr/testify@v1.3.0",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20191025021431-6c3a3bfe00ae",
+				"pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/google/go-cmp@v0.3.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/pkg/errors@v0.8.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/prometheus/procfs@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/google/go-cmp@v0.3.0",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/santhosh-tekuri/jsonschema@v1.2.4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/go.elastic.co/fastjson@v1.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/pkg/errors@v0.8.0",
+				"pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191204072324-ce4227a45e2e",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/stretchr/testify@v1.3.0",
+			"dependsOn": [
+				"pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+				"pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+				"pkg:golang/github.com/stretchr/objx@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/go-playground/assert/v2@v2.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/go-playground/locales@v0.13.0",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/text@v0.3.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/go-playground/universal-translator@v0.17.0",
+			"dependsOn": [
+				"pkg:golang/github.com/go-playground/locales@v0.13.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/leodido/go-urn@v1.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/stretchr/testify@v1.4.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180228061459-e0a39a4cb421",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/modern-go/reflect2@v0.0.0-20180701023420-4b7aa43c6742",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200116001909-b77594299b42",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/stretchr/objx@v0.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.2",
+			"dependsOn": [
+				"pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ugorji/go@v1.1.7",
+			"dependsOn": [
+				"pkg:golang/github.com/ugorji/go/codec@v1.1.7"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/mr-tron/base58@v1.1.3",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.13"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.14",
+			"dependsOn": [
+				"pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.3",
+				"pkg:golang/github.com/multiformats/go-varint@v0.0.5",
+				"pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/mr-tron/base58@v1.1.0",
+				"pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+				"pkg:golang/github.com/multiformats/go-base36@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.13",
+			"dependsOn": [
+				"pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.3",
+				"pkg:golang/github.com/multiformats/go-varint@v0.0.5",
+				"pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.5",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multibase@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/mr-tron/base58@v1.1.0",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.10",
+			"dependsOn": [
+				"pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.2",
+				"pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20190221155625-df39d6c2d992",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/smartystreets/goconvey@v0.0.0-20190222223459-a17d461953aa",
+			"dependsOn": [
+				"pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+				"pkg:golang/github.com/jtolds/gls@v4.2.1%2Bincompatible",
+				"pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20180510122957-5ad1f5abf436",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/cbor-gen@v0.0.0-20200123233031-1cdf64d27158",
+			"dependsOn": [
+				"pkg:golang/github.com/google/go-cmp@v0.4.0",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.3",
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multibase@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+				"pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+				"pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190131020904-2d45a736cd16",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.0",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190211182817-74369b46fc67",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190219092855-153ac476189d"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/gogo/protobuf@v1.3.1",
+			"dependsOn": [
+				"pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+				"pkg:golang/github.com/kisielk/gotool@v1.0.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-blockservice@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.5",
+				"pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-verifcid@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-datastore@v0.3.1",
+			"dependsOn": [
+				"pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+				"pkg:golang/github.com/google/uuid@v1.1.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/kr/pretty@v0.1.0",
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20190717185122-a985d3407aa7",
+				"pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+				"pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.1.0",
+				"pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-offline@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipld-cbor@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipld-format@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1",
+				"pkg:golang/github.com/polydawn/refmt@v0.0.0-20190221155625-df39d6c2d992",
+				"pkg:golang/github.com/smartystreets/goconvey@v0.0.0-20190222223459-a17d461953aa",
+				"pkg:golang/github.com/warpfork/go-wish@v0.0.0-20180510122957-5ad1f5abf436"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipld-format@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mr-tron/base58@v1.2.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-varint@v0.0.6",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20201211092308-30ac6d18308e",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/frankban/quicktest@v1.11.3",
+			"dependsOn": [
+				"pkg:golang/github.com/google/go-cmp@v0.5.4",
+				"pkg:golang/github.com/kr/pretty@v0.2.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.4",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multibase@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.10"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/polydawn/refmt@v0.0.0-20190807091052-3d65705ee9f1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/smartystreets/goconvey@v1.6.4",
+			"dependsOn": [
+				"pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+				"pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+				"pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+				"pkg:golang/golang.org/x/tools@v0.0.0-20190328211700-ab21143f2384"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/warpfork/go-wish@v0.0.0-20200122115046-b9ea61034e4a",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/minio/sha256-simd@v1.0.0",
+			"dependsOn": [
+				"pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20210220033148-5ea612d1eb83",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037",
+				"pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210309074719-68d13333faf2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.0-20200313102051-9f266ea9e77c",
+			"dependsOn": [
+				"pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.2",
+			"dependsOn": [
+				"pkg:golang/github.com/mattn/go-isatty@v0.0.8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.9",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190813064441-fde4db37ae7a"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/valyala/fasttemplate@v1.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/valyala/bytebufferpool@v1.0.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200223170610-d5e6a3e2c0ae",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/valyala/bytebufferpool@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200323222414-85ca7c5b95cd",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/text@v0.3.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/elastic/go-windows@v1.0.0",
+			"dependsOn": [
+				"pkg:golang/github.com/pkg/errors@v0.8.1",
+				"pkg:golang/github.com/stretchr/testify@v1.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/joeshaw/multierror@v0.0.0-20140124173710-69b34d4ec901",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/prometheus/procfs@v0.0.0-20190425082905-87a4384529e0",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191025021431-6c3a3bfe00ae",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/howett.net/plist@v0.0.0-20181124034731-591f970eefbb",
+			"dependsOn": [
+				"pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+				"pkg:golang/github.com/kr/pretty@v0.1.0",
+				"pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+				"pkg:golang/gopkg.in/yaml.v2@v2.2.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/google/go-cmp@v0.3.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sync@v0.0.0-20181221193216-37e7f081c4d4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/pkg/errors@v0.8.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20200509030707-2212a7e161a5",
+			"dependsOn": [
+				"pkg:golang/github.com/yuin/goldmark@v1.1.27",
+				"pkg:golang/golang.org/x/mod@v0.2.0",
+				"pkg:golang/golang.org/x/net@v0.0.0-20200226121028-0de0cce0169b",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/text@v0.3.2",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/tools@v0.0.0-20180917221912-90fa682c2a6e"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mr-tron/base58@v1.1.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/minio/sha256-simd@v0.1.1-0.20190913151208-6de447530771",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190611184440-5c40567a22f8",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mr-tron/base58@v1.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-base36@v0.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multibase@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multibase@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/mr-tron/base58@v1.1.0",
+				"pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mr-tron/base58@v1.1.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/gopherjs/gopherjs@v0.0.0-20181017120253-0766667cb4d1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jtolds/gls@v4.2.1%2Bincompatible",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/smartystreets/assertions@v0.0.0-20180927180507-b2de0cb4f26d",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/google/go-cmp@v0.4.0",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/gxed/hashland/keccakpg@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/gxed/hashland/murmur3@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190131020904-2d45a736cd16",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190211182817-74369b46fc67",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190219092855-153ac476189d",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/kisielk/errcheck@v1.2.0",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/tools@v0.0.0-20181030221726-6c7e314b6563"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-bitswap@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/cskr/pubsub@v1.0.2",
+				"pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/golang/protobuf@v1.3.1",
+				"pkg:golang/github.com/google/uuid@v1.1.1",
+				"pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.5",
+				"pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+				"pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+				"pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+				"pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+				"pkg:golang/github.com/mattn/go-colorable@v0.1.2",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+				"pkg:golang/golang.org/x/net@v0.0.0-20190522155817-f3200d17e092",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190524122548-abf6ff778158",
+				"pkg:golang/golang.org/x/text@v0.3.2",
+				"pkg:golang/gopkg.in/yaml.v2@v2.2.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-datastore@v0.0.5",
+			"dependsOn": [
+				"pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+				"pkg:golang/github.com/google/uuid@v1.1.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/kr/pretty@v0.1.0",
+				"pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-blockstore@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+				"pkg:golang/github.com/ipfs/bbloom@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-blocksutil@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-exchange-interface@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-block-format@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-routing@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+				"pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-log@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/mattn/go-colorable@v0.1.1",
+				"pkg:golang/github.com/opentracing/opentracing-go@v1.0.2",
+				"pkg:golang/github.com/stretchr/testify@v1.3.0",
+				"pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+				"pkg:golang/golang.org/x/net@v0.0.0-20190227160552-c95aed5357e7"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-verifcid@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/google/uuid@v1.1.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/kr/pretty@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/kr/text@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20190717185122-a985d3407aa7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-block-format@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-datastore@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+				"pkg:golang/github.com/google/uuid@v1.1.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/kr/pretty@v0.1.0",
+				"pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-ds-help@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-base32@v0.0.3"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-metrics-interface@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/go-check/check@v0.0.0-20180628173108-788fd7840127",
+				"pkg:golang/github.com/google/uuid@v1.1.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-delay@v0.0.0-20181109222059-70721b86a9a8",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/kr/pretty@v0.1.0",
+				"pkg:golang/gopkg.in/check.v1@v1.0.0-20180628173108-788fd7840127"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/google/go-cmp@v0.5.4",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/kr/pretty@v0.2.1",
+			"dependsOn": [
+				"pkg:golang/github.com/kr/text@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/jtolds/gls@v4.20.0%2Bincompatible",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190328211700-ab21143f2384",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.0.4",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/term@v0.0.0-20201117132131-f5c789dd3221",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sys@v0.0.0-20191026070338-33540a1f6037"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.8",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190813064441-fde4db37ae7a",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/jessevdk/go-flags@v1.4.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.1",
+			"dependsOn": [
+				"pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/yuin/goldmark@v1.1.27",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/mod@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550",
+				"pkg:golang/golang.org/x/tools@v0.0.0-20191119224855-298f0cb1881e",
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20191011141410-1b5146add898"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20200226121028-0de0cce0169b",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190911185100-cd5d95a43a6e",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20181030221726-6c7e314b6563",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/cskr/pubsub@v1.0.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/gogo/protobuf@v1.2.1",
+			"dependsOn": [
+				"pkg:golang/github.com/kisielk/errcheck@v1.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/golang/protobuf@v1.3.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-peertaskqueue@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+			"dependsOn": [
+				"pkg:golang/github.com/jbenet/go-cienv@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-detect-race@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+				"pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+				"pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+				"pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+				"pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+				"pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+				"pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+				"pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+				"pkg:golang/github.com/coreos/go-semver@v0.3.0",
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+				"pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190328051042-05b4dd3047e5",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.2",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5",
+				"pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190513172903-22d7a77e9e5f"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/google/uuid@v1.1.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-netutil@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-testutil@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20190522155817-f3200d17e092",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190524122548-abf6ff778158",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/bbloom@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-record@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-ipfs-util@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multihash@v0.0.5",
+			"dependsOn": [
+				"pkg:golang/github.com/minio/blake2b-simd@v0.0.0-20160723061019-3f5f724cb5b1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190328051042-05b4dd3047e5",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.2",
+				"pkg:golang/github.com/spaolacci/murmur3@v1.1.0",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190426145343-a29dc8fdc734"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-colorable@v0.1.1",
+			"dependsOn": [
+				"pkg:golang/github.com/mattn/go-isatty@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/opentracing/opentracing-go@v1.0.2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/go-logging@v0.0.0-20170515211332-0457bb6b88fc",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20190227160552-c95aed5357e7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/kr/text@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/kr/pty@v1.1.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20191011191535-87dc89f01550",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20191119224855-298f0cb1881e",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190620200207-3b0461eec859",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
+				"pkg:golang/golang.org/x/xerrors@v0.0.0-20190717185122-a985d3407aa7"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191011141410-1b5146add898",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/kisielk/errcheck@v1.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/kisielk/gotool@v1.0.0",
+				"pkg:golang/golang.org/x/tools@v0.0.0-20180221164845-07fd8470d635"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ipfs-pq@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190213025234-306aecffea32",
+				"pkg:golang/github.com/coreos/go-semver@v0.3.0",
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.1",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+				"pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190131020904-2d45a736cd16",
+				"pkg:golang/github.com/mr-tron/base58@v1.1.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1",
+				"pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190225124518-7f87c0fbb88b"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/jbenet/go-cienv@v0.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-autonat@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-circuit@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+				"pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-discovery@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-cid@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-blankhost@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-mplex@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-nat@v0.0.4",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/jbenet/go-cienv@v0.0.0-20150120210510-1bb1476777ec",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+				"pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/hashicorp/golang-lru@v0.5.1",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+				"pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+				"pkg:golang/github.com/multiformats/go-base32@v0.0.3",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1",
+				"pkg:golang/github.com/pkg/errors@v0.8.1",
+				"pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+				"pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gogo/protobuf@v1.2.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.2",
+				"pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+				"pkg:golang/github.com/minio/sha256-simd@v0.1.0",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190513172903-22d7a77e9e5f"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-swarm@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/jbenet/goprocess@v0.1.3",
+				"pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-conn-security-multistream@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-loggables@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-peerstore@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-secio@v0.1.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+				"pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+				"pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+				"pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+				"pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.0",
+				"pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+				"pkg:golang/github.com/onsi/gomega@v1.5.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-yamux@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-yamux@v1.2.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-maddr-filter@v0.0.4",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-stream-muxer-multistream@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multistream@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-tcp-transport@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+				"pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.5"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-ws-transport@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/gorilla/websocket@v1.4.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.0",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-libp2p-transport-upgrader@v0.1.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.4",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multistream@v0.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/mdns@v0.0.0-20180901202407-ef14215e6b30",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190523000118-16327141da8c",
+			"dependsOn": [
+				"pkg:golang/github.com/aead/siphash@v1.0.1",
+				"pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+				"pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+				"pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+				"pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+				"pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+				"pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+				"pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+				"pkg:golang/github.com/davecgh/go-spew@v0.0.0-20171005155431-ecdeabc65495",
+				"pkg:golang/github.com/jessevdk/go-flags@v0.0.0-20141203071132-1679536dcc89",
+				"pkg:golang/github.com/jrick/logrotate@v1.0.0",
+				"pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+				"pkg:golang/github.com/onsi/ginkgo@v1.7.0",
+				"pkg:golang/github.com/onsi/gomega@v1.4.3",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20170930174604-9419663f5a44"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/coreos/go-semver@v0.3.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-flow-metrics@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/minio/sha256-simd@v0.0.0-20190328051042-05b4dd3047e5",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/spacemonkeygo/openssl@v0.0.0-20181017203307-c2dcc5cca94a",
+			"dependsOn": [
+				"pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190513172903-22d7a77e9e5f",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190426145343-a29dc8fdc734",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190404232315-eb5bcb51f2a3",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190412213103-97732733099d"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.5",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/kr/pty@v1.1.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20190620200207-3b0461eec859",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190215142949-d0b11bdaac8a",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20180221164845-07fd8470d635",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/btcd@v0.0.0-20190213025234-306aecffea32",
+			"dependsOn": [
+				"pkg:golang/github.com/aead/siphash@v1.0.1",
+				"pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+				"pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190207003914-4c204d697803",
+				"pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+				"pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+				"pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+				"pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+				"pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+				"pkg:golang/github.com/davecgh/go-spew@v0.0.0-20171005155431-ecdeabc65495",
+				"pkg:golang/github.com/jessevdk/go-flags@v0.0.0-20141203071132-1679536dcc89",
+				"pkg:golang/github.com/jrick/logrotate@v1.0.0",
+				"pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+				"pkg:golang/github.com/onsi/ginkgo@v1.7.0",
+				"pkg:golang/github.com/onsi/gomega@v1.4.3",
+				"pkg:golang/golang.org/x/crypto@v0.0.0-20170930174604-9419663f5a44"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/mr-tron/base58@v1.1.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20190225124518-7f87c0fbb88b",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-mplex@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/jbenet/go-cienv@v0.0.0-20150120210510-1bb1476777ec",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-nat@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/huin/goupnp@v1.0.0",
+				"pkg:golang/github.com/jackpal/gateway@v1.0.5",
+				"pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+				"pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/go-notifier@v0.0.0-20170827234753-097c5d47330f",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ds-badger@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+				"pkg:golang/github.com/Kubuxu/go-os-helper@v0.0.1",
+				"pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+				"pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+				"pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+				"pkg:golang/github.com/golang/protobuf@v1.3.0",
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/pkg/errors@v0.8.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/ipfs/go-ds-leveldb@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-datastore@v0.0.1",
+				"pkg:golang/github.com/jbenet/goprocess@v0.0.0-20160826012719-b497e2f366b8",
+				"pkg:golang/github.com/syndtr/goleveldb@v1.0.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-peer@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-crypto@v0.1.0",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190222072716-a9d3bda3a223"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/go-keyspace@v0.0.0-20160322163242-5b898ac5add1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-msgio@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/minio/sha256-simd@v0.1.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-addr-util@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1",
+				"pkg:golang/github.com/whyrusleeping/mafmt@v1.2.8"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/whyrusleeping/multiaddr-filter@v0.0.0-20160516205228-e903e4adabd7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jbenet/go-temp-err-catcher@v0.0.0-20150120210811-aac704a3f4f2",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-libp2p-mplex@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-libp2p-core@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-libp2p-testing@v0.0.3",
+				"pkg:golang/github.com/libp2p/go-mplex@v0.0.3"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/onsi/ginkgo@v1.8.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/onsi/gomega@v1.5.0",
+			"dependsOn": [
+				"pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+				"pkg:golang/github.com/golang/protobuf@v1.2.0",
+				"pkg:golang/github.com/hpcloud/tail@v1.0.0",
+				"pkg:golang/github.com/onsi/ginkgo@v1.6.0",
+				"pkg:golang/golang.org/x/net@v0.0.0-20180906233101-161cd47e91fd",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20180909124046-d0be0721c37e",
+				"pkg:golang/golang.org/x/text@v0.3.0",
+				"pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+				"pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+				"pkg:golang/gopkg.in/yaml.v2@v2.2.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-yamux@v1.2.2",
+			"dependsOn": [
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.2"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multihash@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/pkg/errors@v0.8.1",
+				"pkg:golang/github.com/stretchr/testify@v1.3.0",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20190228124157-a34e9553db1e"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-reuseport-transport@v0.0.2",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-reuseport@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1",
+				"pkg:golang/github.com/multiformats/go-multiaddr-net@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr-fmt@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/gorilla/websocket@v1.4.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/multiformats/go-multiaddr-dns@v0.0.1",
+			"dependsOn": [
+				"pkg:golang/github.com/multiformats/go-multiaddr@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/aead/siphash@v1.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/btclog@v0.0.0-20170628155309-84c8d2346e9f",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190425235716-9e5f4b9a998d",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/go-socks@v0.0.0-20170105172521-4720035b7bfd",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/snappy-go@v0.0.0-20151229074030-0bdef8d06723",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/websocket@v0.0.0-20150119174127-31079b680792",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/winsvc@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/davecgh/go-spew@v0.0.0-20171005155431-ecdeabc65495",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jessevdk/go-flags@v0.0.0-20141203071132-1679536dcc89",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jrick/logrotate@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/kkdai/bstream@v0.0.0-20161212061736-f391b8402d23",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/onsi/ginkgo@v1.7.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/onsi/gomega@v1.4.3",
+			"dependsOn": [
+				"pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+				"pkg:golang/github.com/golang/protobuf@v1.2.0",
+				"pkg:golang/github.com/hpcloud/tail@v1.0.0",
+				"pkg:golang/github.com/onsi/ginkgo@v1.6.0",
+				"pkg:golang/golang.org/x/net@v0.0.0-20180906233101-161cd47e91fd",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f",
+				"pkg:golang/golang.org/x/sys@v0.0.0-20180909124046-d0be0721c37e",
+				"pkg:golang/golang.org/x/text@v0.3.0",
+				"pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+				"pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+				"pkg:golang/gopkg.in/yaml.v2@v2.2.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20170930174604-9419663f5a44",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/spacemonkeygo/spacelog@v0.0.0-20180420211403-2296661a0572",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/btcsuite/btcutil@v0.0.0-20190207003914-4c204d697803",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/huin/goupnp@v1.0.0",
+			"dependsOn": [
+				"pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+				"pkg:golang/golang.org/x/net@v0.0.0-20181011144130-49bb7cea24b1",
+				"pkg:golang/golang.org/x/text@v0.3.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/jackpal/gateway@v1.0.5",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/jackpal/go-nat-pmp@v1.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/koron/go-ssdp@v0.0.0-20180514024734-4a0ed625a78b",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/AndreasBriese/bbloom@v0.0.0-20180913140656-343706a395b7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/Kubuxu/go-os-helper@v0.0.1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/dgraph-io/badger@v1.5.5-0.20190226225317-8115aed38f8f",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/dgryski/go-farm@v0.0.0-20190104051053-3adb47b1fb0f",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/dustin/go-humanize@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/golang/protobuf@v1.3.0",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20180906233101-161cd47e91fd",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f",
+				"pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/syndtr/goleveldb@v1.0.0",
+			"dependsOn": [
+				"pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+				"pkg:golang/github.com/onsi/ginkgo@v1.7.0",
+				"pkg:golang/github.com/onsi/gomega@v1.4.3"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-mplex@v0.0.3",
+			"dependsOn": [
+				"pkg:golang/github.com/ipfs/go-log@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-buffer-pool@v0.0.1",
+				"pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/fsnotify/fsnotify@v1.4.7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/golang/protobuf@v1.2.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/hpcloud/tail@v1.0.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/onsi/ginkgo@v1.6.0",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20180906233101-161cd47e91fd",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sync@v0.0.0-20180314180146-1d60e4601c6f",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20180909124046-d0be0721c37e",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/fsnotify.v1@v1.4.7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/tomb.v1@v1.0.0-20141024135613-dd632973f1e7",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20190228124157-a34e9553db1e",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/huin/goutil@v0.0.0-20170803182201-1ca381bf3150",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20181011144130-49bb7cea24b1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20180831171423-11092d34479b",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/golang/snappy@v0.0.0-20180518054509-2e65f85255db",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/libp2p/go-stream-muxer@v0.0.1",
+			"dependsOn": []
+		}
+	]
+}

--- a/test/providers/tst_manifests/golang/go_mod_with_all_ignore/go.mod
+++ b/test/providers/tst_manifests/golang/go_mod_with_all_ignore/go.mod
@@ -1,0 +1,13 @@
+module github.com/devfile-samples/devfile-sample-go-basic
+
+go 1.19
+
+require(
+    github.com/labstack/echo/v4 v4.1.18-0.20201215153152-4422e3b66b9f //exhortignore
+    github.com/russellhaering/goxmldsig v1.1.0 //exhortignore
+    github.com/gin-gonic/gin v1.6.0 //exhortignore
+    github.com/miekg/dns v1.0.4-0.20180125103619-43913f2f4fbd //exhortignore
+    github.com/ipld/go-car v0.3.0 //exhortignore
+    go.elastic.co/apm v1.11.0 //exhortignore
+    gopkg.in/yaml.v3  v3.0.0-20220521103104-8f96da9f5d5e //exhortignore
+)

--- a/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
@@ -607,6 +607,70 @@
 			"bom-ref": "pkg:golang/google.golang.org/protobuf@v1.26.0"
 		},
 		{
+			"group": "github.com/docopt",
+			"name": "docopt-go",
+			"version": "v0.0.0-20180111231733-ee0de3bc6815",
+			"purl": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815"
+		},
+		{
+			"group": "github.com/kr",
+			"name": "pretty",
+			"version": "v0.2.0",
+			"purl": "pkg:golang/github.com/kr/pretty@v0.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.0"
+		},
+		{
+			"group": "github.com/stoewer",
+			"name": "go-strcase",
+			"version": "v1.2.0",
+			"purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+			"type": "library",
+			"bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "tools",
+			"version": "v0.0.0-20190524140312-2c0ae7006135",
+			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "xerrors",
+			"version": "v0.0.0-20200804184101-5ec99f83aff1",
+			"purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+		},
+		{
+			"group": "google.golang.org",
+			"name": "genproto",
+			"version": "v0.0.0-20201019141844-1ed22bb0c154",
+			"purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+			"type": "library",
+			"bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+		},
+		{
+			"group": "gopkg.in",
+			"name": "check.v1",
+			"version": "v1.0.0-20190902080502-41f04d3bba15",
+			"purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20190902080502-41f04d3bba15",
+			"type": "library",
+			"bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20190902080502-41f04d3bba15"
+		},
+		{
+			"group": "golang.org/x",
+			"name": "sys",
+			"version": "v0.0.0-20210320140829-1e4c9ba3b0c4",
+			"purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210320140829-1e4c9ba3b0c4",
+			"type": "library",
+			"bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210320140829-1e4c9ba3b0c4"
+		},
+		{
 			"group": "github.com/google",
 			"name": "gofuzz",
 			"version": "v1.0.0",
@@ -1063,14 +1127,6 @@
 			"bom-ref": "pkg:golang/golang.org/x/tools@v0.1.10"
 		},
 		{
-			"group": "golang.org/x",
-			"name": "xerrors",
-			"version": "v0.0.0-20200804184101-5ec99f83aff1",
-			"purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-			"type": "library",
-			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-		},
-		{
 			"group": "gopkg.in",
 			"name": "yaml.v2",
 			"version": "v2.2.8",
@@ -1191,30 +1247,6 @@
 			"bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20191204190536-9bdfabe68543"
 		},
 		{
-			"group": "github.com/kr",
-			"name": "pretty",
-			"version": "v0.2.0",
-			"purl": "pkg:golang/github.com/kr/pretty@v0.2.0",
-			"type": "library",
-			"bom-ref": "pkg:golang/github.com/kr/pretty@v0.2.0"
-		},
-		{
-			"group": "github.com/stoewer",
-			"name": "go-strcase",
-			"version": "v1.2.0",
-			"purl": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-			"type": "library",
-			"bom-ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0"
-		},
-		{
-			"group": "golang.org/x",
-			"name": "tools",
-			"version": "v0.0.0-20190524140312-2c0ae7006135",
-			"purl": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135",
-			"type": "library",
-			"bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135"
-		},
-		{
 			"group": "golang.org/x",
 			"name": "net",
 			"version": "v0.0.0-20190311183353-d8887717615a",
@@ -1229,14 +1261,6 @@
 			"purl": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
 			"type": "library",
 			"bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
-		},
-		{
-			"group": "google.golang.org",
-			"name": "genproto",
-			"version": "v0.0.0-20201019141844-1ed22bb0c154",
-			"purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-			"type": "library",
-			"bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
 		},
 		{
 			"group": "github.com/golang",
@@ -4576,6 +4600,51 @@
 			]
 		},
 		{
+			"ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/github.com/kr/pretty@v0.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/kr/text@v0.1.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+			"dependsOn": [
+				"pkg:golang/github.com/stretchr/testify@v1.5.1"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135",
+			"dependsOn": [
+				"pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
+				"pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
+			]
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+			"dependsOn": [
+				"pkg:golang/github.com/golang/protobuf@v1.4.1",
+				"pkg:golang/golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3",
+				"pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135",
+				"pkg:golang/google.golang.org/grpc@v1.27.0",
+				"pkg:golang/google.golang.org/protobuf@v1.24.0"
+			]
+		},
+		{
+			"ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20190902080502-41f04d3bba15",
+			"dependsOn": []
+		},
+		{
+			"ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210320140829-1e4c9ba3b0c4",
+			"dependsOn": []
+		},
+		{
 			"ref": "pkg:golang/github.com/google/gofuzz@v1.0.0",
 			"dependsOn": []
 		},
@@ -4847,10 +4916,6 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-			"dependsOn": []
-		},
-		{
 			"ref": "pkg:golang/gopkg.in/yaml.v2@v2.2.8",
 			"dependsOn": [
 				"pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
@@ -4935,25 +5000,6 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:golang/github.com/kr/pretty@v0.2.0",
-			"dependsOn": [
-				"pkg:golang/github.com/kr/text@v0.1.0"
-			]
-		},
-		{
-			"ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-			"dependsOn": [
-				"pkg:golang/github.com/stretchr/testify@v1.5.1"
-			]
-		},
-		{
-			"ref": "pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135",
-			"dependsOn": [
-				"pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
-				"pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58"
-			]
-		},
-		{
 			"ref": "pkg:golang/golang.org/x/net@v0.0.0-20190311183353-d8887717615a",
 			"dependsOn": [
 				"pkg:golang/golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2",
@@ -4963,16 +5009,6 @@
 		{
 			"ref": "pkg:golang/golang.org/x/sync@v0.0.0-20190423024810-112230192c58",
 			"dependsOn": []
-		},
-		{
-			"ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-			"dependsOn": [
-				"pkg:golang/github.com/golang/protobuf@v1.4.1",
-				"pkg:golang/golang.org/x/lint@v0.0.0-20190313153728-d0100b6bd8b3",
-				"pkg:golang/golang.org/x/tools@v0.0.0-20190524140312-2c0ae7006135",
-				"pkg:golang/google.golang.org/grpc@v1.27.0",
-				"pkg:golang/google.golang.org/protobuf@v1.24.0"
-			]
 		},
 		{
 			"ref": "pkg:golang/github.com/golang/protobuf@v1.4.1",


### PR DESCRIPTION
## Description

fix: exhortignored not respected for couple of edge cases regex that should capture all cases of packages names + versions in go.mod

fix: in case of automatic version bump, the exhortignored package wrongly shown as a direct dependency in generated sbom

fix: filter the exhortignored packages after sbom creation instead of during creation

test: add new test that all direct dependencies are ignored, and update existing tests expected sbom


## Related issue 
 fixes https://issues.redhat.com/browse/TC-573


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
