### PR TITLE
ci: secrets are only defined in staging environment

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -5,10 +5,7 @@ env:
   # 🖊️ EDIT to change the image build settings.
   IMAGE_NAME: exhort-javascript-api
   IMAGE_REGISTRY: quay.io/ecosystem-appeng
-  IMAGE_REGISTRY_USER: ${{ secrets.IMAGE_REGISTRY_USER }}
-  IMAGE_REGISTRY_PASSWORD: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}
   DOCKERFILE_PATH: ./docker-image/Dockerfiles/Dockerfile.alpha
-  PACKAGE_REGISTRY_ACCESS_TOKEN: ${{ secrets.PACKAGE_REGISTRY_ACCESS_TOKEN }}
 
 on:
   workflow_dispatch:
@@ -96,7 +93,7 @@ jobs:
           dockerfiles: |
             ${{ env.DOCKERFILE_PATH }}
           build-args: |
-            PACKAGE_REGISTRY_ACCESS_TOKEN=${{ env.PACKAGE_REGISTRY_ACCESS_TOKEN }}
+            GITHUB_PACKAGE_REGISTRY_ACCESS_TOKEN=${{ secrets.GITHUB_PACKAGE_REGISTRY_ACCESS_TOKEN }}
           context: docker-image
           
       - name: Push Image To Registry
@@ -105,5 +102,5 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: ${{ env.IMAGE_REGISTRY }}
-          username: ${{ env.IMAGE_REGISTRY_USER }}
-          password: ${{ env.IMAGE_REGISTRY_PASSWORD }}
+          username: ${{ secrets.IMAGE_REGISTRY_USER }}
+          password: ${{ secrets.IMAGE_REGISTRY_PASSWORD }}


### PR DESCRIPTION
## Description

buildah fails to resolve user and password for container registry ( in order to push built image) , because environment variables containing the secrets evaluated globally, and not in staging environment, hence failed to be resolved correctly from staging environment' secrets.

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.


