### PR TITLE
feat: add functionality of matching manifest versions 

### DIFF
--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -29,7 +29,6 @@ suite('testing the golang-go-modules data provider', () => {
 			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/golang/${testCase}/expected_sbom_stack_analysis.json`,).toString()
 			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
 			// invoke sut stack analysis for scenario manifest
-
 			let providedDataForStack = await golangGoModules.provideStack(`test/providers/tst_manifests/golang/${testCase}/go.mod`)
 			// new(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date
 

--- a/test/providers/python_pip.test.js
+++ b/test/providers/python_pip.test.js
@@ -67,7 +67,7 @@ suite('testing the python-pip data provider', () => {
 
 }).beforeAll(() => clock = sinon.useFakeTimers(new Date('2023-10-01T00:00:00.000Z'))).afterAll(()=> clock.restore());
 
-suite('testing the python-pip data provider', () => {
+suite('testing the python-pip data provider with virtual environment', () => {
 	[
 		"pip_requirements_virtual_env_txt_no_ignore",
 		"pip_requirements_virtual_env_with_ignore"
@@ -93,7 +93,7 @@ suite('testing the python-pip data provider', () => {
 			// 	content: expectedSbom
 			// })
 			// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
-		}).timeout(process.env.GITHUB_ACTIONS ? 30000 : 15000)
+		}).timeout(process.env.GITHUB_ACTIONS ? 60000 : 30000)
 
 
 	})


### PR DESCRIPTION
against installed ones

Jira Ticket: https://issues.redhat.com/browse/APPENG-2062

## Description

Added functionality of matching manifest versions against installed versions in client environment.
If env var/setting MATCH_MANIFEST_VERSIONS=true, an error will be thrown to user in case installed version of a package has different version than the version written in the manifest.

This functionality was added for python pip' requirements.txt and golang go modules go.mod.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.


