### PR TITLE
fix: python prevent infinite loop

### DIFF
--- a/src/providers/python_controller.js
+++ b/src/providers/python_controller.js
@@ -251,7 +251,7 @@ function getDependencyVersion(record) {
  * @return {string} the name of dependency
  */
 function getDependencyName(depLine) {
-	const regex = /[^\w\s-_]/g;
+	const regex = /[^\w\s-_.]/g;
 	let endIndex = depLine.search(regex);
 	return depLine.substring(0,endIndex) ;
 }

--- a/src/providers/python_controller.js
+++ b/src/providers/python_controller.js
@@ -200,7 +200,11 @@ export default class Python_controller {
 
 				}
 			}
-			bringAllDependencies(dependencies,getDependencyName(dep),CachedEnvironmentDeps,includeTransitive)
+			let path = new Array()
+			let depName = getDependencyName(dep)
+			//array to track a path for each branch in the dependency tree
+			path.push(depName.toLowerCase())
+			bringAllDependencies(dependencies,depName,CachedEnvironmentDeps,includeTransitive,path)
 		})
 		dependencies.sort((dep1,dep2) =>{
 			const DEP1 = dep1.name.toLowerCase()
@@ -272,8 +276,9 @@ function getDepsList(record) {
  * @param dependencyName
  * @param cachedEnvironmentDeps
  * @param includeTransitive
+ * @param {[string]}path array representing the path of the current branch in dependency tree, starting with a root dependency - that is - a given dependency in requirements.txt
  */
-function bringAllDependencies(dependencies, dependencyName, cachedEnvironmentDeps, includeTransitive) {
+function bringAllDependencies(dependencies, dependencyName, cachedEnvironmentDeps, includeTransitive,path) {
 	if(dependencyName === null || dependencyName === undefined || dependencyName.trim() === "" ) {
 		return
 	}
@@ -292,8 +297,15 @@ function bringAllDependencies(dependencies, dependencyName, cachedEnvironmentDep
 	let entry = { "name" : getDependencyNameShow(record) , "version" : version, "dependencies" : [] }
 	dependencies.push(entry)
 	directDeps.forEach( (dep) => {
-		if(includeTransitive) {
-			bringAllDependencies(targetDeps,dep,cachedEnvironmentDeps,includeTransitive)
+		let depArray = new Array()
+		// to avoid infinite loop, check if the dependency not already on current path, before going recursively resolving its dependencies.
+		if(!path.includes(dep.toLowerCase())) {
+			// send to recurrsion the path + the current dep
+			depArray.push(dep.toLowerCase())
+			if (includeTransitive) {
+				// send to recurrsion the array of all deps in path + the current dependency name which is not on the path.
+				bringAllDependencies(targetDeps, dep, cachedEnvironmentDeps, includeTransitive,path.concat(depArray))
+			}
 		}
 		// sort ra
 		targetDeps.sort((dep1,dep2) =>{


### PR DESCRIPTION
## Description

In case there is a Cyclic reference in python pip dependency tree , then without detecting it and "cut" the cycle, resolving the dependency tree will never end and the API will enter into infinite loop.
So in every case there is a cycle in the dependency tree, detect it, and cut it.

### Example

for example, consider sphinx and sphinxcontrib-applehelp, each one is a dependency of the other , as can seen from the following pip show command of both of packages:

![image](https://github.com/RHEcosystemAppEng/exhort-javascript-api/assets/75700623/e785e4e4-9d6e-4e53-8c63-ebc27674447e)


Fix: https://issues.redhat.com/browse/TC-671

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
