### PR TITLE
feat: map providers' user setting to request header for authentication

### DIFF
--- a/src/analysis.js
+++ b/src/analysis.js
@@ -109,6 +109,10 @@ function getTokenHeaders(opts = {}) {
 		if (token) {
 			headers[`ex-${vendor}-token`] = token
 		}
+		let user = getCustom(`EXHORT_${vendor.replace("-","_").toUpperCase()}_USER`, null, opts);
+		if (user) {
+			headers[`ex-${vendor}-user`] = user
+		}
 	})
 	setRhdaHeader(rhdaTokenHeader,headers, opts);
 	setRhdaHeader(rhdaSourceHeader,headers, opts);


### PR DESCRIPTION
## Description

feat: map providers' user setting to request header for authentication, in case the provider requires basic authentication ( user + token)


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.


