### PR TITLE
fix: maven - in case version is of type `number` , "stringify" it

### DIFF
--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -286,6 +286,10 @@ function getRootFromPom(manifest) {
  */
 function toPurl(group,artifact,version)
 {
+	if(typeof version === "number")
+	{
+		version = version.toString()
+	}
 	return new PackageURL('maven',group,artifact,version,undefined,undefined);
 }
 


### PR DESCRIPTION
## Description

Sometimes XML parser parse from maven pom.xml ( effective or real pom) a full major version ( for example 1 or 2 or 3), as number instead of string, hence causing exceptions when creating purls.
on such cases, need to "stringify" the number before creating the purl.

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.
