### PR TITLE
feat: get output of pip commands from env variables

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Publish package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_MAVEN_TOKEN }}
         run: npm publish
 
       - name: Commit and push package modifications

--- a/test/it/end-to-end.js
+++ b/test/it/end-to-end.js
@@ -81,7 +81,6 @@ suite('Integration Tests', () => {
 			let parsedSummaryFromHtml = getParsedKeyFromHtml(html,"\"summary\"",10)
 			let parsedScannedFromHtml = reportParsedFromHtml.scanned
 			let parsedStatusFromHtmlSnyk = reportParsedFromHtml.providers["snyk"].status
-			let parsedStatusFromHtmlossIndex = reportParsedFromHtml.providers["oss-index"].status
 			expect( typeof html).equals("string")
 			expect(html).include("html").include("svg")
 			expect(parsedScannedFromHtml.total).greaterThan(0)
@@ -92,7 +91,6 @@ suite('Integration Tests', () => {
 			}
 			expect(parsedSummaryFromHtml.total).greaterThanOrEqual(0)
 			expect(parsedStatusFromHtmlSnyk.code).equals(200)
-			expect(parsedStatusFromHtmlossIndex.code).equals(401)
 			// parsedSummaryFromHtml.providerStatuses.forEach(provider => expect(provider.status).equals(200))
 		}).timeout(15000);
 


### PR DESCRIPTION
## Description

For CI/CD pipelines, it's a lot of times better to install requirements.txt manifest in a dedicated agent/slave/computer/container that contains the desired  python & pip versions, and invoke the rhda analysis in different agent/slave/computer/container ( let's denote it as "node") -  that contains the whole infrastructure required to invoke the analysis alone ( including python and pip binaries, but the problem is that it "stuck" with a given versions of python and pip in this node, hence very limited to the versions of packages in requirements.txt).

For that purpose, and in such cases that we need to separate the analysis and the pip install in different steps/stages and even on different nodes, this PR introduces two environment variables, these two env variables will need to be populated with the output of the commands encoded in base64 ( in order to preserve new lines in environment variables, the library will decode it to ASCII plain-text before passing it to the logic of the API).

1. EXHORT_PIP_FREEZE - need to be populated with the pip freeze --all output **after** pip install on requirements.txt finished on the python node.
2. EXHORT_PIP_SHOW - need to be populated with the output of pip freeze show listOfAllPackagesInPipFreeze.
Example how to retrieve in shell script:
```shell
export SHOW_LIST=$(pip freeze --all | awk -F '==' '{print $1}')
pip show $SHOW_LIST > pip_show.txt
export EXHORT_PIP_SHOW=$(cat pip_show.txt | base64 -w0)
```

needs to work together with setting EXHORT_PYTHON_VIRTUAL_ENV=false ( this is the default so not specifying this setting is just fine).

Off course, you need to use pipelines workspaces/shared volumes/pipes/fifos/ ipc shared memory/networking in order to pass the data from one node to another.

in case the two new environment variables are not populated, then the logic will be the same ( taking the pip freeze and pip show of the environment formed by pip and python binaries passed to the library.


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

