### PR TITLE
fix: fix broken cli stack analysis summary option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -88,9 +88,26 @@ const stack = {
 		let manifest = args['/path/to/manifest']
 		let html = args['html']
 		let summary = args['summary']
+		let theProvidersSummary = new Map();
+		let theProvidersObject ={}
 		let res = await exhort.stackAnalysis(manifest, html)
+		if(summary)
+		{
+			for (let provider in res.providers ) {
+				if (res.providers[provider].sources !== undefined) {
+					for(let source in res.providers[provider].sources ) {
+						if(res.providers[provider].sources[source].summary) {
+							theProvidersSummary.set(source,res.providers[provider].sources[source].summary)
+						}
+					}
+				}
+			}
+			for (let [provider, providerSummary] of theProvidersSummary) {
+				theProvidersObject[provider]=providerSummary
+			}
+		}
 		console.log(html ? res : JSON.stringify(
-			!html && summary ? res['summary'] : res,
+			!html && summary ? theProvidersObject : res,
 			null,
 			2
 		))


### PR DESCRIPTION
## Description

Recent api changes in exhort backend change the summary option of the stack analysis command in the exhort cli.

Fixes [JIRA-2321](https://issues.redhat.com/browse/APPENG-2321)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
