### PR TITLE
fix: unlimited wrapping for a terminal output

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ const component = {
 		{
 			desc: 'manifest name and type',
 			type: 'string',
-			choices: ['pom.xml','package.json', 'go.mo', 'requirements.txt']
+			choices: ['pom.xml','package.json', 'go.mod', 'requirements.txt']
 
 		}
 	).positional(
@@ -124,4 +124,5 @@ yargs(hideBin(process.argv))
 	.scriptName('')
 	.version(false)
 	.demandCommand(1)
+	.wrap(null)
 	.parse()


### PR DESCRIPTION
## Description

By setting `.wrap(null)`  a terminal output will wrap without a column limit, ensuring optimal readability on terminals of any width.

The issue with line wrapping

![Screenshot from 2024-03-11 09-59-31](https://github.com/RHEcosystemAppEng/exhort-javascript-api/assets/89217163/da2b2c55-9a64-4e6d-a427-873767f12e52)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

[Source](https://yargs.js.org/docs/#api-reference-wrapcolumns)