### PR TITLE
feat: fix performance issue in python version >= 3.11.X

### DIFF
--- a/src/analysis.js
+++ b/src/analysis.js
@@ -111,10 +111,11 @@ async function validateToken(url, opts = {}) {
 			...getTokenHeaders(opts),
 		}
 	})
-	let exRequestId = resp.headers.get("ex-request-id");
-	if(exRequestId)
-	{
-		console.log("Unique Identifier associated with this request - ex-request-id=" + exRequestId)
+	if (process.env["EXHORT_DEBUG"] === "true") {
+		let exRequestId = resp.headers.get("ex-request-id");
+		if (exRequestId) {
+			console.log("Unique Identifier associated with this request - ex-request-id=" + exRequestId)
+		}
 	}
 	return resp.status
 }

--- a/src/providers/python_controller.js
+++ b/src/providers/python_controller.js
@@ -170,7 +170,7 @@ export default class Python_controller {
 		let pipDepTreeJsonArrayOutput
 		if(usePipDepTree !== "true") {
 			freezeOutput = getPipFreezeOutput.call(this);
-			 lines = freezeOutput.split(EOL)
+			lines = freezeOutput.split(EOL)
 			depNames = lines.map( line => getDependencyName(line)).join(" ")
 		}
 		else {
@@ -337,10 +337,10 @@ function bringAllDependencies(dependencies, dependencyName, cachedEnvironmentDep
 	let depName
 	let version;
 	let directDeps
-    if(usePipDepTree !== "true") {
+	if(usePipDepTree !== "true") {
 		depName = getDependencyNameShow(record)
 		version = getDependencyVersion(record);
-	    directDeps = getDepsList(record)
+		directDeps = getDepsList(record)
 	}
 	else {
 		depName = record.name
@@ -393,19 +393,17 @@ function getDependencyTreeJsonFromPipDepTree(pipPath,pythonPath) {
 	} catch (e) {
 		throw new Error(`Couldn't install pipdeptree utility, reason: ${e.getMessage}`)
 	}
-	finally {
-		try {
-			if(pythonPath.startsWith("python")) {
-				dependencyTree = execSync(`pipdeptree  --json`).toString()
-			}
-			else {
-				dependencyTree = execSync(`pipdeptree  --json --python  ${pythonPath} `).toString()
-			}
-		} catch (e) {
-			throw new Error(`couldn't produce dependency tree using pipdeptree tool, stop analysis, message -> ${e.getMessage}`)
+
+	try {
+		if(pythonPath.startsWith("python")) {
+			dependencyTree = execSync(`pipdeptree  --json`).toString()
 		}
-
-
+		else {
+			dependencyTree = execSync(`pipdeptree  --json --python  ${pythonPath} `).toString()
+		}
+	} catch (e) {
+		throw new Error(`couldn't produce dependency tree using pipdeptree tool, stop analysis, message -> ${e.getMessage}`)
 	}
+
 	return JSON.parse(dependencyTree)
 }

--- a/src/providers/python_controller.js
+++ b/src/providers/python_controller.js
@@ -330,8 +330,8 @@ function bringAllDependencies(dependencies, dependencyName, cachedEnvironmentDep
 	let record = cachedEnvironmentDeps[dependencyName.toLowerCase()]
 	if(record === null || record  === undefined) {
 		throw new Error(`Package name=>${dependencyName} is not installed on your python environment,
-		                         either install it ( better to install requirements.txt altogether) or turn on
-		                         environment variable EXHORT_PYTHON_VIRTUAL_ENV=true to automatically installs
+		                         either install it ( better to install requirements.txt altogether) or set
+		                         setting EXHORT_PYTHON_VIRTUAL_ENV=true to automatically installs
 		                          it on virtual environment ( will slow down the analysis) `)
 	}
 	let depName

--- a/src/providers/python_pip.js
+++ b/src/providers/python_pip.js
@@ -13,7 +13,7 @@ export default { isSupported, provideComponent, provideStack }
 
 const dummyVersionNotation = "dummy*=#?";
 
-/** @typedef {{name: string, , version: string, dependencies: DependencyEntry[]}} DependencyEntry */
+/** @typedef {{name: string, version: string, dependencies: DependencyEntry[]}} DependencyEntry */
 
 /**
  * @type {string} ecosystem for python-pip is 'pip'

--- a/test/providers/python_pip.test.js
+++ b/test/providers/python_pip.test.js
@@ -8,6 +8,48 @@ import {getCustomPath } from "../../src/tools.js"
 
 
 let clock
+
+async function sharedComponentAnalysisTestFlow(testCase,usePipDepTreeUtility) {
+	// load the expected list for the scenario
+	let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/expected_component_sbom.json`,).toString().trim()
+	expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
+	// read target manifest file
+	let manifestContent = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/requirements.txt`).toString()
+	// invoke sut stack analysis for scenario manifest
+	let opts = { "EXHORT_PIP_USE_DEP_TREE" : usePipDepTreeUtility }
+	let providedDatForComponent = await pythonPip.provideComponent(manifestContent,opts)
+	// verify returned data matches expectation
+	expect(providedDatForComponent).to.deep.equal({
+		ecosystem: 'pip',
+		contentType: 'application/vnd.cyclonedx+json',
+		content: expectedSbom
+	})
+}
+
+async function sharedStackAnalysisTestFlow(testCase,usePipDepTreeUtility) {
+	// load the expected graph for the scenario
+	let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/expected_stack_sbom.json`,).toString()
+	expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
+	// invoke sut stack analysis for scenario manifest
+	let pipPath = getCustomPath("pip3");
+	execSync(`${pipPath} install -r test/providers/tst_manifests/pip/${testCase}/requirements.txt`, err => {
+		if (err) {
+			throw new Error('fail installing requirements.txt manifest in created virtual python environment --> ' + err.message)
+		}
+	})
+	let opts = { "EXHORT_PIP_USE_DEP_TREE" : usePipDepTreeUtility }
+	let providedDataForStack = await pythonPip.provideStack(`test/providers/tst_manifests/pip/${testCase}/requirements.txt`,opts)
+	// new(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date
+
+	// providedDataForStack.content = providedDataForStack.content.replaceAll("\"timestamp\":\"[a-zA-Z0-9\\-\\:]+\"","")
+	// verify returned data matches expectation
+	expect(providedDataForStack).to.deep.equal({
+		ecosystem: 'pip',
+		contentType: 'application/vnd.cyclonedx+json',
+		content: expectedSbom
+	})
+}
+
 suite('testing the python-pip data provider', () => {
 	[
 		{name: 'requirements.txt', expected: true},
@@ -24,45 +66,28 @@ suite('testing the python-pip data provider', () => {
 	].forEach(testCase => {
 		let scenario = testCase.replace('pip_requirements_', '').replaceAll('_', ' ')
 		test(`verify requirements.txt sbom provided for stack analysis with scenario ${scenario}`, async () => {
-			// load the expected graph for the scenario
-			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/expected_stack_sbom.json`,).toString()
-			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
-			// invoke sut stack analysis for scenario manifest
-			let pipPath = getCustomPath("pip3");
-			execSync(`${pipPath} install -r test/providers/tst_manifests/pip/${testCase}/requirements.txt`, err => {
-				if (err) {
-					throw new Error('fail installing requirements.txt manifest in created virtual python environment --> ' + err.message)
-				}
-			})
-			let providedDataForStack = await pythonPip.provideStack(`test/providers/tst_manifests/pip/${testCase}/requirements.txt`)
-			// new(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date
-
-			// providedDataForStack.content = providedDataForStack.content.replaceAll("\"timestamp\":\"[a-zA-Z0-9\\-\\:]+\"","")
-			// verify returned data matches expectation
-			expect(providedDataForStack).to.deep.equal({
-				ecosystem: 'pip',
-				contentType: 'application/vnd.cyclonedx+json',
-				content: expectedSbom
-			})
-		// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
+			await sharedStackAnalysisTestFlow(testCase,false);
+			// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
 		}).timeout(process.env.GITHUB_ACTIONS ? 30000 : 10000)
 
 		test(`verify requirements.txt sbom provided for component analysis with scenario ${scenario}`, async () => {
-			// load the expected list for the scenario
-			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/expected_component_sbom.json`,).toString().trim()
-			expectedSbom = JSON.stringify(JSON.parse(expectedSbom))
-			// read target manifest file
-			let manifestContent = fs.readFileSync(`test/providers/tst_manifests/pip/${testCase}/requirements.txt`).toString()
-			// invoke sut stack analysis for scenario manifest
-			let providedDatForComponent = await pythonPip.provideComponent(manifestContent)
-			// verify returned data matches expectation
-			expect(providedDatForComponent).to.deep.equal({
-				ecosystem: 'pip',
-				contentType: 'application/vnd.cyclonedx+json',
-				content: expectedSbom
-			})
+			await sharedComponentAnalysisTestFlow(testCase,false);
 			// these test cases takes ~1400-2000 ms each pr >10000 in CI (for the first test-case)
 		}).timeout(process.env.GITHUB_ACTIONS ? 15000 : 10000)
+
+		test(`verify requirements.txt sbom provided for stack analysis using pipdeptree utility with scenario ${scenario}`, async () => {
+			await sharedStackAnalysisTestFlow(testCase,true);
+			// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
+		}).timeout(process.env.GITHUB_ACTIONS ? 30000 : 10000)
+
+		test(`verify requirements.txt sbom provided for component analysis using pipdeptree utility with scenario ${scenario}`, async () => {
+			await sharedComponentAnalysisTestFlow(testCase,true);
+			// these test cases takes ~1400-2000 ms each pr >10000 in CI (for the first test-case)
+		}).timeout(process.env.GITHUB_ACTIONS ? 15000 : 10000)
+
+
+
+
 	});
 
 }).beforeAll(() => clock = sinon.useFakeTimers(new Date('2023-10-01T00:00:00.000Z'))).afterAll(()=> clock.restore());


### PR DESCRIPTION
## Description

Because of a performance issue with native pip show command , starting from python version 3.11.X, introduced an alternate flow of using pipdeptree python utility , instead of pip freeze --all + pip show list_of_deps as a source of data for building the dependency tree of python ( the algorithm remain the same anyway).

**Related issue (if any):** fixes [JIRA APPENG-2154](https://issues.redhat.com/browse/APPENG-2154)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional Info

The new logic will be controlled by a new setting (env var/property) - `EXHORT_PIP_USE_DEP_TREE`, if it will be set to true, it will use the pipdeptree as the source to build the dependency tree, otherwise, it will use native pip commands pip freeze + show. default is EXHORT_PIP_USE_DEP_TREE=false.

