### PR TITLE
fix: gradle component analsyis duplicates artifacts in sbom

### DIFF
--- a/test/it/test_manifests/gradle/build.gradle
+++ b/test/it/test_manifests/gradle/build.gradle
@@ -21,7 +21,8 @@ dependencies {
     implementation "jakarta.validation:jakarta.validation-api:2.0.2"
     implementation "io.quarkus:quarkus-resteasy-multipart:2.13.7.Final"
     implementation "io.quarkus:quarkus-hibernate-orm-deployment:2.0.2.Final"
-    implementation "log4j:log4j:1.2.17" // exhortignore
+    implementation "log4j:log4j:1.2.17"
+	implementation group: 'log4j', name: 'log4j'
 }
 test {
     useJUnitPlatform()


### PR DESCRIPTION
## Description

For gradle component analysis, if in manifest an artifact is specified twice, once with version and second time without version, then it's generated like that in the sbom , which is a duplicate ( the fix filtering out the artifact that doesn't contain version)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

build.gradle: 

```gradle
dependencies {
    implementation "log4j:log4j:1.2.17"
    implementation group: 'log4j', name: 'log4j'
}
```
generated sbom
```json
{

     {
            "group": "log4j",
            "name": "log4j",
            "version": "1.2.17",
            "purl": "pkg:maven/log4j/log4j@1.2.17",
            "type": "library",
            "bom-ref": "pkg:maven/log4j/log4j@1.2.17"
       },
       {
            "group": "log4j",
            "name": "log4j",
            "purl": "pkg:maven/log4j/log4j",
            "type": "library",
            "bom-ref": "pkg:maven/log4j/log4j"
       }
}
```

the generated sbom for component analysis should only contain the log4j with the version, and with subjected fix it becomes as required:
```json
{

     {
            "group": "log4j",
            "name": "log4j",
            "version": "1.2.17",
            "purl": "pkg:maven/log4j/log4j@1.2.17",
            "type": "library",
            "bom-ref": "pkg:maven/log4j/log4j@1.2.17"
       }
 }
```

