### PR TITLE
ci: add re-test functionality to staging workflow

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -18,6 +18,7 @@ on:
     paths:
       - "generated/**"
       - "src/**"
+      - "test/**"
       - "package-lock.json"
       - "package.json"
       - "tsconfig.json"
@@ -44,6 +45,31 @@ jobs:
           cache: npm
           registry-url: 'https://npm.pkg.github.com'
 
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - name: get Python location
+        id: python-location
+        run: |
+          echo "python-bin-location=$(echo $pythonLocation)/bin" >> $GITHUB_OUTPUT
+
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20.1'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
       - name: Configure git
         run: |
           git config user.name "${{ github.actor }}"
@@ -59,6 +85,29 @@ jobs:
 
       - name: Compile project
         run: npm run compile
+
+      - name: Check if re-test is needed
+        id: test-check
+        uses: zvigrinberg/git-retest-checkup-action@v1.1
+        with:
+          base-ref: ${{ github.base_ref }}
+          pr-ref: ${{ github.head_ref }}
+          file-pattern-regex: "^src/.*|^test/.*"
+
+      - name: re-test Unit-Tests + Integration Tests
+        env:
+          RETEST_IS_NECESSARY: ${{ steps.test-check.outputs.retest-is-needed}}
+          TRIGGERING_FILE: ${{ steps.test-check.outputs.triggering-file}}
+        run: |
+          if [[ $RETEST_IS_NECESSARY == "true" ]]; then
+             echo "Re-test was triggered!!, triggering changed file - $TRIGGERING_FILE"
+             echo "Running Again Unit-test =>"
+             npm run test
+             echo "Running Again Unit-test =>"
+             npm run integration-tests
+          else
+            echo "Re-test of library is not needed, continuing to deployment!"
+          fi
 
       - name: Publish package
         env:


### PR DESCRIPTION
## Description

Add re-test functionality to staging workflow - using [re-test github action](https://github.com/zvigrinberg/git-retest-checkup-action)


## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

In case head branch ( feature/topic/hotfix - whichever  ) forked from the base branch, and before merging it back, base branch commits tree advanced with additional commits ( merged from different branches or pushed directly - whichever ), in such case, if the head branch is not rebased on top of the base branch, there is a chance ( not big chance but still) that tests that were passed on PR workflow will fail after head branch will be merged to base, in this case, i want to identify such situations during the staging workflow, but still, i don't want to run all the time tests before publishing the npm package, but i want to identify if a re-test is needed, so probably most of the times re-test will not be required , and then there is no point to run the UT + IT Tests in staging , but in few times that re-test is needed in staging( before publishing the package), we'll run the tests.  That way i'll guarantee that no broken packages will be staged.
I've noticed that checkout action of PR workflow, by default ( being used there - the action checkout, checking out the base branch - main, and merged the Head into it), but still in such case, if the PR workflow executed successfully , both tests suites passed flawlessly , still the PR need to be reviewed, approved and merged before the staging workflow will run, these lifecycle actions of PR might take couple of days, during this time, base branch can advance with new commits containing new logic.
In order to identify all of these use cases,  we'll use a dedicated action that capable of identifying precisely whenever re-test is needed.
