### PR TITLE
fix: add node-fetch to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"fast-toml": "^0.5.4",
 				"fast-xml-parser": "^4.2.4",
 				"help": "^3.0.2",
+				"node-fetch": "^2.6.7",
 				"packageurl-js": "^1.0.2",
 				"yargs": "^17.7.2"
 			},
@@ -3265,7 +3266,6 @@
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.11",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
@@ -3876,7 +3876,6 @@
 		},
 		"node_modules/tr46": {
 			"version": "0.0.3",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tree-kill": {
@@ -4043,12 +4042,10 @@
 		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
-			"dev": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 		"fast-xml-parser": "^4.2.4",
 		"help": "^3.0.2",
 		"packageurl-js": "^1.0.2",
-		"yargs": "^17.7.2"
+		"yargs": "^17.7.2",
+		"node-fetch": "^2.6.7"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.2",


### PR DESCRIPTION
## Description

Up until now, node-fetch lib was fetched via the dev-dependency `open-api-generator` ( which obviously this package  and its transitives are  not inherited by clients of this api)
ever since we changed the cyclone-dx library version ( that by chance included node-fetch lib as well) - we started to experience errors in component analysis in clients ( rhda vscode extension and rhda lsp server) that it can't find node-fetch library.

**Related issue (if any):** fixes [TC-1400](https://issues.redhat.com/browse/TC-1400)

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

