### PR TITLE
fix: maven component analysis xml wrong parsing of x.0 versions ( x >=0)

### DIFF
--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -228,7 +228,10 @@ export default class Java_maven extends Base_java {
 		// build xml parser with options
 		let parser = new XMLParser({
 			commentPropName: '#comment', // mark comments with #comment
-			isArray: (_, jpath) => 'project.dependencies.dependency' === jpath // load deps as array
+			isArray: (_, jpath) => 'project.dependencies.dependency' === jpath,
+			numberParseOptions: {
+				skipLike: /[0-9]+[.]0/
+			}
 		})
 		// read manifest pom.xml file into buffer
 		let buf = fs.readFileSync(manifest)

--- a/test/it/end-to-end.js
+++ b/test/it/end-to-end.js
@@ -65,7 +65,7 @@ suite('Integration Tests', () => {
 			let pomPath = `test/it/test_manifests/${packageManager}/${manifestName}`
 			let providedDataForStack = await index.stackAnalysis(pomPath)
 			console.log(JSON.stringify(providedDataForStack,null , 4))
-			let providers = ["osv-nvd"]
+			let providers = ["osv"]
 			providers.forEach(provider => expect(extractTotalsGeneralOrFromProvider(providedDataForStack, provider)).greaterThan(0))
 			//TO DO - if sources doesn't exists, add "scanned" instead
 			// python transitive count for stack analysis is awaiting fix in exhort backend
@@ -104,7 +104,7 @@ suite('Integration Tests', () => {
 			}
 			finally
 			{
-				parsedStatusFromHtmlOsvNvd = reportParsedFromHtml.providers["osv-nvd"].status
+				parsedStatusFromHtmlOsvNvd = reportParsedFromHtml.providers["osv"].status
 				expect(parsedStatusFromHtmlOsvNvd.code).equals(200)
 				parsedScannedFromHtml = reportParsedFromHtml.scanned
 				expect( typeof html).equals("string")
@@ -128,7 +128,7 @@ suite('Integration Tests', () => {
 
 			expect(analysisReport.scanned.total).greaterThan(0)
 			expect(analysisReport.scanned.transitive).equal(0)
-			let providers = ["osv-nvd"]
+			let providers = ["osv"]
 			providers.forEach(provider => expect(extractTotalsGeneralOrFromProvider(analysisReport,provider)).greaterThan(0))
 			providers.forEach(provider => expect(analysisReport.providers[provider].status.code).equals(200))
 		}).timeout(20000);

--- a/test/providers/tst_manifests/maven/pom_with_multiple_modules/component_analysis_expected_sbom.json
+++ b/test/providers/tst_manifests/maven/pom_with_multiple_modules/component_analysis_expected_sbom.json
@@ -169,10 +169,10 @@
 		{
 			"group": "javax.enterprise",
 			"name": "cdi-api",
-			"version": "2",
-			"purl": "pkg:maven/javax.enterprise/cdi-api@2",
+			"version": "2.0",
+			"purl": "pkg:maven/javax.enterprise/cdi-api@2.0",
 			"type": "library",
-			"bom-ref": "pkg:maven/javax.enterprise/cdi-api@2"
+			"bom-ref": "pkg:maven/javax.enterprise/cdi-api@2.0"
 		},
 		{
 			"group": "commons-configuration",
@@ -221,7 +221,7 @@
 				"pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.16.0",
 				"pkg:maven/com.google.code.findbugs/jsr305@3.0.2",
 				"pkg:maven/com.github.spotbugs/spotbugs-annotations@4.8.3",
-				"pkg:maven/javax.enterprise/cdi-api@2",
+				"pkg:maven/javax.enterprise/cdi-api@2.0",
 				"pkg:maven/commons-configuration/commons-configuration@1.1",
 				"pkg:maven/com.squareup.okhttp3/okhttp@4.12.0",
 				"pkg:maven/org.projectlombok/lombok@1.18.30"
@@ -300,7 +300,7 @@
 			"dependsOn": []
 		},
 		{
-			"ref": "pkg:maven/javax.enterprise/cdi-api@2",
+			"ref": "pkg:maven/javax.enterprise/cdi-api@2.0",
 			"dependsOn": []
 		},
 		{


### PR DESCRIPTION
## Description

In maven  Component analysis , we're using xml-fast-parser in order to retrieve direct dependencies from pom.xml
in case there is a string version in the format of "x.0" ( x is an integer, x >=0 ) , then by default it omits the ".0" and convert it number as integer - x.

We need to configure xml fast parser to ignore such cases, so it will let the string become as is in case of format x.0 ( for every natural integer x >= 0).

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.


