### PR TITLE
fix: 2 bugs of gradle and maven

### DIFF
--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -46,8 +46,8 @@ export default class Base_Java {
 			if (targetDepth === srcDepth + 1) {
 				let from = this.parseDep(src);
 				let to = this.parseDep(target);
-				let matchedScope = target.match(/:compile|:provided|:runtime|:test|:system/g)
-				let matchedScopeSrc = src.match(/:compile|:provided|:runtime|:test|:system/g)
+				let matchedScope = target.match(/:compile|:provided|:runtime|:test|:system|:import/g)
+				let matchedScopeSrc = src.match(/:compile|:provided|:runtime|:test|:system|:import/g)
 				// only add dependency to sbom if it's not with test scope or if it's root
 				if ((matchedScope && matchedScope[0] !== ":test" && (matchedScopeSrc && matchedScopeSrc[0] !== ":test")) || (srcDepth == 0 && matchedScope && matchedScope[0] !== ":test")) {
 					sbom.addDependency(sbom.purlToComponent(from), to)

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -393,7 +393,7 @@ export default class Java_gradle extends Base_java {
 		// 	Dependency line is of form String Notation
 		} else {
 			let depParts
-			if(depToBeIgnored.match(/^[a-z]+\s/)) {
+			if(depToBeIgnored.match(/^[a-zA-Z]+\s/)) {
 				depParts = depToBeIgnored.split(" ")[1].split(":");
 			}
 			else {


### PR DESCRIPTION
## Description

1. Fix https://issues.redhat.com/browse/TC-1706 - a bug in which only `api` and `implementation` gradle configuration types are respected for //exhortignore
2. Fix https://issues.redhat.com/browse/TC-1707 - a bug in which `import` scope is not included in stack analysis.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
