### PR TITLE
ci: disable auto-me-bot signed off verification

### DIFF
--- a/.github/auto-me-bot.yml
+++ b/.github/auto-me-bot.yml
@@ -1,4 +1,3 @@
 pr:
   conventionalTitle:
-  signedCommits:
   tasksList:


### PR DESCRIPTION
## Description

The Bot that verifies commits are signed off keeps failing although I verified all commits are correctly signed.
Disabling this check will allow us to keep maintaining this repository.

Potentially we can replace this with something like https://probot.github.io/apps/dco/

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

