### PR TITLE
feat: export parseImageRef and ImageRef for use in vsce

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ import { getCustom } from "./tools.js";
 import.meta.dirname
 import * as url from 'url';
 
+export { parseImageRef } from "./oci_image/utils.js";
+export { ImageRef } from "./oci_image/images.js";
+
 export default { componentAnalysis, stackAnalysis, imageAnalysis, validateToken }
 
 export const exhortDevDefaultUrl = 'https://exhort.stage.devshift.net';


### PR DESCRIPTION
## Description

As part of combining, the previous way of importing via `import { parseImageRef } from '@trustification/exhort-javascript-api/dist/src/oci_image/utils';` does not seem to cooperate with how the vsce build process is setup. 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
