### PR TITLE
fix: don't analyze FAILED dependencies

### DIFF
--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -309,7 +309,7 @@ export default class Java_gradle extends Base_java {
 	}
 
 	#prepareLinesForParsingDependencyTree(lines) {
-		return lines.filter(dep => dep.trim() !== "").map(dependency => dependency.replaceAll("---", "-").replaceAll("    ", "  "))
+		return lines.filter(dep => dep.trim() !== "" && !dep.endsWith(" FAILED")).map(dependency => dependency.replaceAll("---", "-").replaceAll("    ", "  "))
 			.map(dependency => dependency.replaceAll(/:(.*):(.*) -> (.*)$/g, ":$1:$3"))
 			.map(dependency => dependency.replaceAll(/:(.*)\W*->\W*(.*)$/g, ":$1:$2"))
 			.map(dependency => dependency.replaceAll(/(.*):(.*):(.*)$/g, "$1:$2:jar:$3"))

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/build.gradle
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "io.quarkus:quarkus-resteasy-multipart:2.13.7.Final"
     implementation "io.quarkus:quarkus-hibernate-orm-deployment:2.0.2.Final"
     implementation group: 'log4j', name: 'log4j', version: '1.2.17' // exhortignore
+    implementation "com.acme:invented.dependency:1.0.0"
 
 }
 test {

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/build.gradle.kts
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("io.quarkus:quarkus-resteasy-multipart:2.13.7.Final")
     implementation("io.quarkus:quarkus-hibernate-orm-deployment:2.0.2.Final")
     implementation(group: "log4j", name: "log4j", version: "1.2.17") // exhortignore
+    implementation("com.acme:invented.dependency:1.0.0")
 }
 
 test {

--- a/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/depTree.txt
+++ b/test/providers/tst_manifests/gradle/deps_with_ignore_named_params/depTree.txt
@@ -2574,7 +2574,8 @@ testRuntimeClasspath - Runtime classpath of source set 'test'.
 |         +--- io.quarkus:quarkus-arc-deployment:2.0.2.Final (*)
 |         +--- org.jboss:jandex:2.3.0.Final
 |         \--- org.ow2.asm:asm:9.1 -> 9.3
-\--- log4j:log4j:1.2.17
++--- log4j:log4j:1.2.17
+\--- com.acme:invented.dependency:1.0.0 FAILED
 
 testRuntimeOnly - Runtime only dependencies for source set 'test'. (n)
 No dependencies


### PR DESCRIPTION
## Description

Ignore Gradle vulnerabilities that `FAILED` to be resolved

**Related issues (if any):** 

- fixes: https://github.com/trustification/exhort-javascript-api/issues/224

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

