### PR TITLE
chore: use archive.apache.org instead of dlcdn.apache.org

### DIFF
--- a/docker-image/Dockerfiles/Dockerfile
+++ b/docker-image/Dockerfiles/Dockerfile
@@ -1,5 +1,5 @@
 # first stage
-FROM registry.access.redhat.com/ubi9/nodejs-20 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-20 AS builder
 
 # use privilaged user
 USER root
@@ -13,7 +13,7 @@ RUN curl -kL https://download.oracle.com/java/21/archive/jdk-21.0.1_linux-x64_bi
     && tar xvzf /tmp/java-package.tar.gz -C /usr/
 
 # install Maven package manager
-RUN curl -kL https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -o /tmp/maven-package.tar.gz \
+RUN curl -kL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -o /tmp/maven-package.tar.gz \
     && tar xvzf /tmp/maven-package.tar.gz -C /usr/
 
 # install golang package manager
@@ -47,7 +47,7 @@ USER default
 # second stage
 FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
 
-LABEL org.opencontainers.image.source https://github.com/trustification/exhort-javascript-api
+LABEL org.opencontainers.image.source=https://github.com/trustification/exhort-javascript-api
 
 # assign rhda source for exhort tracking purposes
 ENV RHDA_SOURCE=''


### PR DESCRIPTION
## Description

3.9.6 was removed from dlcdn.apache.org, so we move to archive.apache.org. Apache recommend not doing this in CI, but our volume should be low enough that it isnt a problem. They should be hosting older versions on dlcdn : )

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
