### PR TITLE
fix: pass --tag prerelease for prerelease publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         run: npm run compile
 
       - name: Publish package
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance ${{ inputs.version_type == 'prerelease' && '--tag prerelease' || '' }}
 
       - name: Commit and push package modifications
         run: |


### PR DESCRIPTION
## Description

Required since npm ~v11
https://docs.npmjs.com/cli/v10/commands/npm-dist-tag#description

## Checklist

- [ ] I have followed this repository's contributing guidelines.
- [ ] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
