### PR TITLE
chore: verbose npm publish output for debugging

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Publish package
         env:
           NPM_CONFIG_PROVENANCE: true
-        run: npm publish --tag prerelease
+        run: npm publish --verbose --tag prerelease
 
       - name: Commit and push package modifications
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Publish package
         env:
           NPM_CONFIG_PROVENANCE: true
-        run: npm publish
+        run: npm publish --verbose
 
       - name: Commit and push package modifications
         run: |


### PR DESCRIPTION
## Description

We should see "npm verbose oidc Successfully retrieved and set token" according to https://github.com/npm/cli/issues/8525#issuecomment-3225114526

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
