### PR TITLE
fix: match releasebranch artifact name with filename

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/upload-artifact@v5
         with:
-          name: releasebranch
+          name: releasebranch.txt
           path: releasebranch.txt
 
       - name: Create GitHub release tag


### PR DESCRIPTION
Fixes `Unable to download artifact(s): Artifact not found for name: releasebranch.txt` in publish pipeline. 