### PR TITLE
fix: add missing binaries to container image

### DIFF
--- a/docker-image/Dockerfiles/Dockerfile
+++ b/docker-image/Dockerfiles/Dockerfile
@@ -1,20 +1,40 @@
 # first stage
-FROM registry.access.redhat.com/ubi9/nodejs-20 AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-24 AS builder
 
-# use privilaged user
+# use privileged user
 USER root
 
-# install Java
-RUN curl -kL https://download.oracle.com/java/21/archive/jdk-21.0.1_linux-x64_bin.tar.gz -o /tmp/java-package.tar.gz \
-    && tar xvzf /tmp/java-package.tar.gz -C /usr/
+# install OpenJDK from Adoptium (Eclipse Temurin) - latest JDK 21 LTS
+RUN curl -kL "https://api.adoptium.net/v3/binary/latest/21/ga/linux/x64/jdk/hotspot/normal/eclipse" -o /tmp/java-package.tar.gz \
+    && tar xvzf /tmp/java-package.tar.gz -C /usr/ \
+    && mv /usr/jdk-21* /usr/temurin-21
 
 # install Maven package manager
-RUN curl -kL https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz -o /tmp/maven-package.tar.gz \
+RUN curl -kL https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz -o /tmp/maven-package.tar.gz \
     && tar xvzf /tmp/maven-package.tar.gz -C /usr/
 
+# install gradle package manager
+RUN curl -kL https://services.gradle.org/distributions/gradle-9.2.1-bin.zip -o /tmp/gradle-package.zip \
+    && unzip /tmp/gradle-package.zip -d /usr/
+
 # install golang package manager
-RUN curl -kL https://go.dev/dl/go1.21.5.linux-amd64.tar.gz -o /tmp/golang-package.tar.gz \
+RUN curl -kL https://go.dev/dl/go1.25.5.linux-amd64.tar.gz -o /tmp/golang-package.tar.gz \
     && tar xvzf /tmp/golang-package.tar.gz -C /usr/
+
+# install corepack and package managers (pnpm, yarn) - stage to /usr/local for easy copying
+ENV COREPACK_HOME=/usr/local/corepack/cache
+RUN npm install -g corepack@latest \
+    && corepack enable \
+    && corepack prepare pnpm@10.1.0 --activate \
+    && corepack prepare yarn@4.9.1 --activate \
+    && NPM_PREFIX=$(npm config get prefix) \
+    && mkdir -p /usr/local/corepack/bin \
+    && cp -rL $NPM_PREFIX/lib/node_modules/corepack/* /usr/local/corepack/ \
+    && cp $NPM_PREFIX/bin/pnpm /usr/local/corepack/bin/ \
+    && cp $NPM_PREFIX/bin/yarn /usr/local/corepack/bin/ \
+    && cp $NPM_PREFIX/bin/yarnpkg /usr/local/corepack/bin/ \
+    && cp $NPM_PREFIX/bin/corepack /usr/local/corepack/bin/ \
+    && ln -s ../dist/lib /usr/local/corepack/bin/lib
 
 # install jq JSON formating tool
 RUN curl -kL https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux64 -o /usr/bin/jq
@@ -32,8 +52,9 @@ RUN npm install --production \
     && ln -s /app/dist/src/cli.js /app/node_modules/.bin/trustify-da-javascript-client
 
 # assign executable permissions to all installed binaries
-RUN chmod +x /usr/jdk-21.0.1/bin/java \
-    && chmod +x /usr/apache-maven-3.9.6/bin/mvn \
+RUN chmod +x /usr/temurin-21/bin/java \
+    && chmod +x /usr/apache-maven-3.9.12/bin/mvn \
+    && chmod +x /usr/gradle-9.2.1/bin/gradle \
     && chmod +x /usr/go/bin/go \
     && chmod +x /usr/bin/jq \
     && chmod +x /app/dist/src/cli.js \
@@ -44,7 +65,7 @@ RUN chmod +x /usr/jdk-21.0.1/bin/java \
 USER default
 
 # second stage
-FROM registry.access.redhat.com/ubi9/nodejs-20-minimal
+FROM registry.access.redhat.com/ubi9/nodejs-24-minimal
 
 # Build arguments for metadata
 ARG IMAGE_VERSION
@@ -53,7 +74,7 @@ ARG IMAGE_CREATED
 
 # Open Container Initiative (OCI) metadata labels
 LABEL org.opencontainers.image.source=https://github.com/guacsec/trustify-da-javascript-client
-LABEL org.opencontainers.image.description="Trustify Dependency Analytics JavaScript Client - Container image for dependency analysis and vulnerability scanning supporting Maven, NPM, Golang, and Python ecosystems"
+LABEL org.opencontainers.image.description="Trustify Dependency Analytics JavaScript Client - Container image for dependency analysis and vulnerability scanning supporting Maven, NPM, Golang, Gradle, Pnpm, Yarn, and Python ecosystems"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 LABEL org.opencontainers.image.title="Trustify Dependency Analytics JavaScript Client"
 LABEL org.opencontainers.image.vendor="guacsec"
@@ -70,20 +91,33 @@ ENV TRUSTIFY_DA_PIP_SHOW=''
 # indicate whether to use the Minimal version selection (MVS) algorithm to select a set of module versions to use when building Go packages.
 ENV TRUSTIFY_DA_GO_MVS_LOGIC_ENABLED='true'
 
-# Copy java executable from the builder stage
-COPY --from=builder /usr/jdk-21.0.1/ /usr/jdk-21.0.1/
-ENV JAVA_HOME=/usr/jdk-21.0.1
+# Copy OpenJDK (Temurin) from the builder stage
+COPY --from=builder /usr/temurin-21/ /usr/temurin-21/
+ENV JAVA_HOME=/usr/temurin-21
 
 # Copy maven executable from the builder stage
-COPY --from=builder /usr/apache-maven-3.9.6/ /usr/apache-maven-3.9.6/
-ENV MAVEN_HOME=/usr/apache-maven-3.9.6
+COPY --from=builder /usr/apache-maven-3.9.12/ /usr/apache-maven-3.9.12/
+ENV MAVEN_HOME=/usr/apache-maven-3.9.12
 
 # Copy golang executable from the builder stage
 COPY --from=builder /usr/go/ /usr/go/
 ENV GOLANG_HOME=/usr/go
 
-# Update PATH
-ENV PATH=$PATH:$JAVA_HOME/bin:$MAVEN_HOME/bin:$GOLANG_HOME/bin:/app/node_modules/.bin
+# Copy gradle executable from the builder stage
+COPY --from=builder /usr/gradle-9.2.1/ /usr/gradle-9.2.1/
+ENV GRADLE_HOME=/usr/gradle-9.2.1
+
+# Copy corepack and package manager binaries from builder stage
+COPY --from=builder /usr/local/corepack/ /usr/local/corepack/
+ENV COREPACK_HOME=/usr/local/corepack/cache
+
+# Install Python via microdnf (cleanest approach for minimal images)
+USER root
+RUN microdnf install -y python3 python3-pip && microdnf clean all
+USER 1001
+
+# Update PATH (includes corepack bin for pnpm/yarn)
+ENV PATH=$PATH:$JAVA_HOME/bin:$MAVEN_HOME/bin:$GOLANG_HOME/bin:$GRADLE_HOME/bin:/usr/local/corepack/bin:/app/node_modules/.bin
 
 # Copy jq executable from the builder stage
 COPY --from=builder /usr/bin/jq /usr/bin/jq

--- a/docker-image/README.md
+++ b/docker-image/README.md
@@ -11,12 +11,21 @@ Before getting started, ensure that you have one of the following prerequisites 
 
 Both Docker and Podman are container runtimes that can be used to build and run the Trustify Dependency Analytics images. You can choose either Docker or Podman based on your preference and the compatibility with your operating system.
 
-## Images generated for Trustify Dependency Analytics Javascript Client
+## Image generated for Trustify Dependency Analytics Javascript Client
 
-Ecosystem                     | Version                                                            | IMAGE                                           | TAG               |
-------------------------------| ------------------------------------------------------------------ | ----------------------------------------------- |-------------------|
-Maven, NPM, Golang   | mvn 3.9.6, <br>npm 10.2.4, <br>go 1.21.5, <br>python \<any\>                                                                                                  |  ghcr.io/guacsec/trustify-da-javascript-client | 0.2.4-ea.12      |
+ghcr.io/guacsec/trustify-da-javascript-client
 
+See the [GitHub Container Registry](https://github.com/guacsec/trustify-da-javascript-client/pkgs/container/trustify-da-javascript-client)
+
+Ecosystem                     | Version                                                            |
+------------------------------| ------------------------------------------------------------------ | 
+Maven | 3.9.12 |
+Gradle | 9.2.1 |
+Go | 1.25.5 |
+NPM | 10.8.2 |
+PNPM | 10.1.0 |
+Yarn | 4.9.1 |
+Python | 3.9.25 |
 
 ## Usage Notes
 


### PR DESCRIPTION
## Description

Update container image to more recent nodejs image
Add missing binaries that are now supported by the cli
 * pnpm
 * gradle
 * yarn berry
 * python3 - was missing too?

**Related issues (if any):** 

- fixes: #320 

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

