### PR TITLE
fix: it using a wrong reference for PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,5 +22,5 @@ jobs:
     uses: trustification/exhort-integration-tests/.github/workflows/integration.yml@main
     with:
       language: javascript
-      repo-url: ${{ github.repository }}
-      commit-sha: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha && github.event.workflow_run.head_sha != github.event.workflow_run.base_sha && github.event.workflow_run.head_sha ||github.sha }}
+      repo-url: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name || github.repository }}
+      commit-sha: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
## Description

The reference is wrong and the IT is taking the sha from the fork and the base url from the upstream.

