### PR TITLE
chore(deps): exclude tst_manifests from dependabot scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "test/providers/tst_manifests/**"
+  - package-ecosystem: "docker"
+    directory: "/docker-image/Dockerfiles"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description

Dependabot creates PR for test files. We should disable it

Fix #331 
