### PR TITLE
fix: update npm before npm ci in CI workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.11.1
 
       - name: Configure git
         run: |
@@ -103,7 +103,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.11.1
 
       - name: Install project modules
         run: npm ci

--- a/.github/workflows/push-to-registry.yml
+++ b/.github/workflows/push-to-registry.yml
@@ -31,6 +31,9 @@ jobs:
           node-version: 24
           cache: npm
 
+      - name: Install latest npm
+        run: npm install -g npm@11.11.1
+
       - name: Install project modules
         run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
           NEW_VERSION=$(npm version ${{ inputs.version_type }} --no-git-tag-version | sed 's/v//')
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Install latest npm
+        run: npm install -g npm@11.11.1
+
       - name: Install project modules
         run: npm ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Setup skopeo
         run: sudo apt update && sudo apt-get -y install skopeo
 
+      - name: Install latest npm
+        run: npm install -g npm@11.11.1
+
       - name: Install project modules
         run: npm ci
 


### PR DESCRIPTION
## Description

The npm bundled with Node 24 (and now Node 22) has a bug where it passes conflicting `--prefer-offline` and -`-prefer-online` flags internally when installing git dependencies, causing npm ci to fail.

This pins npm to 11.11.1 (last known working version) across all CI workflows before running npm ci.

**Related issues (if any):** 

- fixes: #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
