### PR TITLE
fix: missing docker while podman is configured

### DIFF
--- a/src/oci_image/utils.js
+++ b/src/oci_image/utils.js
@@ -149,7 +149,7 @@ function execSyft(imageRef, opts = {}) {
 function getSyftEnvs(dockerPath, podmanPath) {
 	let path = null;
 	if (dockerPath && podmanPath) {
-		path = `${dockerPath}${File.pathSeparator}${podmanPath}`;
+		path = `${dockerPath}${delimiter}${podmanPath}`;
 	} else if (dockerPath) {
 		path = dockerPath;
 	} else if (podmanPath) {
@@ -302,7 +302,13 @@ function podmanGetVariant(opts = {}) {
  * @returns {string} - The information
  */
 function dockerPodmanInfo(dockerSupplier, podmanSupplier, opts = {}) {
-	return dockerSupplier(opts) || podmanSupplier(opts);
+	try {
+		const result = dockerSupplier(opts);
+		if (result) { return result; }
+	} catch (_) {
+		// docker not available, fall through to podman
+	}
+	return podmanSupplier(opts);
 }
 
 /**


### PR DESCRIPTION
## Description

Previously, `dockerPodmanInfo` used a short-circuit OR (`||`) to choose between docker and podman suppliers. If the docker supplier threw an error (e.g. docker binary not found), the exception propagated and podman was never tried- even when podman was installed and configured. Wrap the docker supplier call in a try/catch so that when docker is
unavailable, execution falls through to the podman supplier instead of failing the entire analysis.

Also fix `getSyftEnvs` to use `delimiter` from `node:path` instead of
the non-existent `File.pathSeparator`.


**Related issues (if any):** 

- fixes: #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
