### PR TITLE
docs: document _getDependencyData() directory parameter semantics

### DIFF
--- a/src/providers/base_pyproject.js
+++ b/src/providers/base_pyproject.js
@@ -169,18 +169,10 @@ export default class Base_pyproject {
 	/**
 	 * Resolve dependencies using the tool-specific command and parser.
 	 *
-	 * Called by {@link _createSbom} with two directory parameters:
-	 * - `manifestDir` is where `pyproject.toml` lives (the project directory).
-	 * - `workspaceDir` is where the lock file lives, resolved by `_findLockFileDir()`.
-	 *   Falls back to `manifestDir` when no lock file is found.
-	 *
-	 * Lock-file-based providers (uv, poetry) use `workspaceDir` for lock-file
-	 * operations. Non-lock-file providers (pip) must use `manifestDir` because
-	 * commands like `pip install .` run relative to the project directory.
-	 * Subclasses that ignore `workspaceDir` should prefix it with `_`.
-	 *
 	 * @param {string} manifestDir - directory containing the target pyproject.toml
-	 * @param {string} workspaceDir - workspace root (where the lock file lives), or same as manifestDir for standalone projects
+	 * @param {string} workspaceDir - workspace root (where the lock file lives);
+	 *   only used by providers that need workspace-level resolution (e.g. uv).
+	 *   Providers that don't use it should prefix with `_`.
 	 * @param {object} parsed - parsed pyproject.toml
 	 * @param {Object} opts
 	 * @returns {Promise<DependencyData>}

--- a/src/providers/base_pyproject.js
+++ b/src/providers/base_pyproject.js
@@ -171,8 +171,7 @@ export default class Base_pyproject {
 	 *
 	 * @param {string} manifestDir - directory containing the target pyproject.toml
 	 * @param {string} workspaceDir - workspace root (where the lock file lives);
-	 *   only used by providers that need workspace-level resolution (e.g. uv).
-	 *   Providers that don't use it should prefix with `_`.
+	 *   only used by providers that need workspace-level resolution (e.g. uv)
 	 * @param {object} parsed - parsed pyproject.toml
 	 * @param {Object} opts
 	 * @returns {Promise<DependencyData>}

--- a/src/providers/base_pyproject.js
+++ b/src/providers/base_pyproject.js
@@ -168,6 +168,17 @@ export default class Base_pyproject {
 
 	/**
 	 * Resolve dependencies using the tool-specific command and parser.
+	 *
+	 * Called by {@link _createSbom} with two directory parameters:
+	 * - `manifestDir` is where `pyproject.toml` lives (the project directory).
+	 * - `workspaceDir` is where the lock file lives, resolved by `_findLockFileDir()`.
+	 *   Falls back to `manifestDir` when no lock file is found.
+	 *
+	 * Lock-file-based providers (uv, poetry) use `workspaceDir` for lock-file
+	 * operations. Non-lock-file providers (pip) must use `manifestDir` because
+	 * commands like `pip install .` run relative to the project directory.
+	 * Subclasses that ignore `workspaceDir` should prefix it with `_`.
+	 *
 	 * @param {string} manifestDir - directory containing the target pyproject.toml
 	 * @param {string} workspaceDir - workspace root (where the lock file lives), or same as manifestDir for standalone projects
 	 * @param {object} parsed - parsed pyproject.toml


### PR DESCRIPTION
## Summary

- Add a "Provider Implementation" section to CONVENTIONS.md documenting the `_getDependencyData()` directory parameter semantics
- Explains that `_createSbom` passes both `manifestDir` (project directory) and `workspaceDir` (lock file directory) to `_getDependencyData`
- Provides guidance for new provider implementations on which directory parameter to use

Implements [TC-4102](https://redhat.atlassian.net/browse/TC-4102)

[TC-4102]: https://redhat.atlassian.net/browse/TC-4102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ