### PR TITLE
ci: suppress dependabot updates for test fixture manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
 # yaml-language-server: $schema=https://www.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
+  # ── Production dependencies ──────────────────────────────────────────
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
     exclude-paths:
       - "test/providers/tst_manifests/**"
+      - "test/providers/provider_manifests/**"
     groups:
       npm-dependencies:
         patterns:
@@ -27,21 +29,72 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # ── Test fixture manifests (suppress all updates including security) ─
+  # These directories contain intentionally pinned dependencies used as
+  # test fixtures. They must NOT be updated by dependabot.
+  - package-ecosystem: "npm"
+    directories:
+      - "/test/providers/tst_manifests/npm/**"
+      - "/test/providers/tst_manifests/pnpm/**"
+      - "/test/providers/tst_manifests/yarn-berry/**"
+      - "/test/providers/tst_manifests/yarn-classic/**"
+      - "/test/providers/tst_manifests/js-common/**"
+      - "/test/providers/provider_manifests/npm/**"
+      - "/test/providers/provider_manifests/pnpm/**"
+      - "/test/providers/provider_manifests/yarn-berry/**"
+      - "/test/providers/provider_manifests/yarn-classic/**"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/test/providers/tst_manifests/pip/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "test/providers/tst_manifests/**"
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "uv"
+    directories:
+      - "/test/providers/tst_manifests/pyproject/**"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "maven"
-    directory: "/"
+    directories:
+      - "/test/providers/tst_manifests/maven/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "test/providers/tst_manifests/**"
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "gradle"
+    directories:
+      - "/test/providers/tst_manifests/gradle/**"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "cargo"
+    directories:
+      - "/test/providers/tst_manifests/cargo/**"
+      - "/test/providers/provider_manifests/cargo/**"
+    schedule:
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/test/providers/tst_manifests/golang/**"
     schedule:
-      interval: "weekly"
-    exclude-paths:
-      - "test/providers/tst_manifests/**"
+      interval: "monthly"
+    labels: []
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Summary

- **Problem:** `exclude-paths` in `dependabot.yml` only applies to version updates, [not security updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#exclude-paths). This caused 26+ noisy PRs from dependabot trying to bump intentionally-pinned vulnerable deps in test fixture manifests under `test/providers/tst_manifests/` and `test/providers/provider_manifests/`.

- **Solution:** Add dedicated dependabot entries per ecosystem that target the test fixture directories with `ignore: [{dependency-name: "*"}]` to suppress both version and security update PRs ([ref](https://ovirium.com/blog/exclude-directory-from-dependabot-checks/)). The `ignore` option [supports security updates](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore) unlike `exclude-paths`.

### Changes

| Ecosystem | Change |
|---|---|
| npm (production) | Added `provider_manifests/**` to `exclude-paths` |
| npm (test fixtures) | New entry with `directories` targeting all JS test fixture dirs + `ignore: *` |
| pip, uv, maven, gradle, cargo, gomod | Replaced broad `directory: "/"` entries with targeted `directories` pointing to test fixture paths + `ignore: *` |
| uv, gradle, cargo | New ecosystem entries (previously missing — uv alone caused 4 security PRs) |

### What this does NOT suppress

npm deps like `picomatch` and `brace-expansion` that exist in both test fixtures AND the production transitive dependency tree. Ignoring those would also suppress legitimate production security updates.

## Test plan

- [ ] Verify dependabot stops creating PRs for test fixture manifests (check after next scan cycle)
- [ ] Verify production npm security/version updates still work
- [ ] Close existing 26 test fixture dependabot PRs after confirming

🤖 Generated with [Claude Code](https://claude.com/claude-code)