### PR TITLE
ci: add pip exclusion for pyproject test fixtures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,7 @@ updates:
   - package-ecosystem: "pip"
     directories:
       - "/test/providers/tst_manifests/pip/**"
+      - "/test/providers/tst_manifests/pyproject/**"
     schedule:
       interval: "monthly"
     labels: []


### PR DESCRIPTION
## Summary
- Add `/test/providers/tst_manifests/pyproject/**` to the `pip` ecosystem exclusion in `.github/dependabot.yml`
- The existing `uv` ecosystem exclusion for this directory did not prevent Dependabot's `pip` scanner from picking up Poetry-based fixtures without `uv.lock`
- This closes the gap that allowed PR #481 to be created

## Test plan
- [ ] Verify no new dependabot PRs are created for pyproject test fixtures under the pip ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)