### PR TITLE
feat(workspace): add Maven multi-module workspace discovery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import analysis from './analysis.js'
 import fs from 'node:fs'
 import { getCustom } from "./tools.js";
 import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
+import { discoverMavenModules } from './providers/java_maven.js'
 import {
-	discoverMavenModules,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -100,7 +100,7 @@ export {
  * @param {any} valueToBePrinted - The value to log.
  * @private
  */
-function logOptionsAndEnvironmentsVariables(alongsideText,valueToBePrinted) {
+function logOptionsAndEnvironmentsVariables(alongsideText, valueToBePrinted) {
 	if (process.env["TRUSTIFY_DA_DEBUG"] === "true") {
 		console.log(`${alongsideText}: ${valueToBePrinted} ${EOL}`)
 	}
@@ -112,9 +112,9 @@ function logOptionsAndEnvironmentsVariables(alongsideText,valueToBePrinted) {
  */
 function readAndPrintVersionFromPackageJson() {
 	let dirName
-// new ESM way in nodeJS ( since node version 22 ) to bring module directory.
+	// new ESM way in nodeJS ( since node version 22 ) to bring module directory.
 	dirName = import.meta.dirname
-// old ESM way in nodeJS ( before node versions 22.00 to bring module directory)
+	// old ESM way in nodeJS ( before node versions 22.00 to bring module directory)
 	if (!dirName) {
 		dirName = url.fileURLToPath(new URL('.', import.meta.url));
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import fs from 'node:fs'
 import { getCustom } from "./tools.js";
 import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
 import {
+	discoverMavenModules,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -23,6 +24,7 @@ export { getProjectLicense, findLicenseFilePath, identifyLicense, getLicenseDeta
 
 export default { componentAnalysis, stackAnalysis, stackAnalysisBatch, imageAnalysis, validateToken, generateSbom }
 export {
+	discoverMavenModules,
 	discoverWorkspacePackages,
 	discoverWorkspaceCrates,
 	validatePackageJson,
@@ -319,16 +321,24 @@ async function generateOneSbom(manifestPath, workspaceOpts) {
  *
  * @param {string} root - Resolved workspace root
  * @param {Options} opts
- * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'unknown', manifestPaths: string[] }>}
+ * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'maven' | 'unknown', manifestPaths: string[] }>}
  * @private
  */
 async function detectWorkspaceManifests(root, opts) {
 	const cargoToml = path.join(root, 'Cargo.toml')
 	const cargoLock = path.join(root, 'Cargo.lock')
 	const packageJson = path.join(root, 'package.json')
+	const pomXml = path.join(root, 'pom.xml')
 
 	if (fs.existsSync(cargoToml) && fs.existsSync(cargoLock)) {
 		return { ecosystem: 'cargo', manifestPaths: await discoverWorkspaceCrates(root, opts) }
+	}
+
+	if (fs.existsSync(pomXml)) {
+		const manifestPaths = await discoverMavenModules(root, opts)
+		if (manifestPaths.length > 0) {
+			return { ecosystem: 'maven', manifestPaths }
+		}
 	}
 
 	const hasJsLock = fs.existsSync(path.join(root, 'pnpm-lock.yaml'))

--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -144,7 +144,6 @@ export default class Base_Java {
 
 		const useWrapper = getWrapperPreference(this.globalBinary, opts)
 		if (useWrapper) {
-			const manifestDir = path.dirname(this.normalizePath(manifestPath))
 			const wrapper = traverseForWrapper(manifestDir, this.localWrapper)
 			if (wrapper !== undefined) {
 				try {
@@ -168,8 +167,4 @@ export default class Base_Java {
 		return toolPath
 	}
 
-	normalizePath(thePath) {
-		const normalized = path.resolve(thePath).normalize();
-		return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
-	}
 }

--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -145,7 +145,7 @@ export default class Base_Java {
 		const useWrapper = getWrapperPreference(this.globalBinary, opts)
 		if (useWrapper) {
 			const manifestDir = path.dirname(this.normalizePath(manifestPath))
-			const wrapper = traverseForWrapper(manifestDir)
+			const wrapper = traverseForWrapper(manifestDir, this.localWrapper)
 			if (wrapper !== undefined) {
 				try {
 					this._invokeCommand(wrapper, ['--version'], {cwd: manifestDir})

--- a/src/providers/base_java.js
+++ b/src/providers/base_java.js
@@ -1,9 +1,8 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
 import { PackageURL } from 'packageurl-js'
 
-import { getCustomPath, getGitRootDir, getWrapperPreference, invokeCommand } from "../tools.js"
+import { getCustomPath, getWrapperPreference, invokeCommand, traverseForWrapper } from "../tools.js"
 
 /** @typedef {import('../provider').Provider} */
 
@@ -145,7 +144,8 @@ export default class Base_Java {
 
 		const useWrapper = getWrapperPreference(this.globalBinary, opts)
 		if (useWrapper) {
-			const wrapper = this.traverseForWrapper(manifestPath)
+			const manifestDir = path.dirname(this.normalizePath(manifestPath))
+			const wrapper = traverseForWrapper(manifestDir)
 			if (wrapper !== undefined) {
 				try {
 					this._invokeCommand(wrapper, ['--version'], {cwd: manifestDir})
@@ -166,39 +166,6 @@ export default class Base_Java {
 			}
 		}
 		return toolPath
-	}
-
-	/**
-	 *
-	 * @param {string} startingManifest - the path of the manifest from which to start searching for the wrapper
-	 * @param {string} repoRoot - the root of the repository at which point to stop searching for mvnw, derived via git if unset and then fallsback
-	 * to the root of the drive the manifest is on (assumes absolute path is given)
-	 * @returns {string|undefined}
-	 */
-	traverseForWrapper(startingManifest, repoRoot = undefined) {
-		const normalizedManifest = this.normalizePath(startingManifest);
-		const currentDir = this.normalizePath(path.dirname(normalizedManifest));
-		repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(normalizedManifest).root;
-		const wrapperPath = path.join(currentDir, this.localWrapper);
-
-		try {
-			fs.accessSync(wrapperPath, fs.constants.X_OK);
-			return wrapperPath;
-		}
-		catch (error) {
-			if (error.code === 'ENOENT') {
-				const rootDir = path.parse(currentDir).root;
-				if (currentDir === repoRoot || currentDir === rootDir) {
-					return undefined;
-				}
-				const parentDir = path.dirname(currentDir);
-				if (parentDir === currentDir || parentDir === rootDir) {
-					return undefined;
-				}
-				return this.traverseForWrapper(path.join(parentDir, path.basename(normalizedManifest)), repoRoot);
-			}
-			throw new Error(`failure searching for ${this.localWrapper}`, { cause: error });
-		}
 	}
 
 	normalizePath(thePath) {

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -401,12 +401,10 @@ function listMavenModules(dir, mvnBin) {
  * @returns {string[]}
  */
 function parseMavenModuleList(raw) {
-	const modules = []
-	const re = /<string>(.+?)<\/string>/g
-	let m
-	while ((m = re.exec(raw)) !== null) {
-		const val = m[1].trim()
-		if (val) modules.push(val)
-	}
-	return modules
+	const parser = new XMLParser()
+	const parsed = parser.parse(raw)
+	const entries = parsed?.strings?.string
+	if (!entries) { return [] }
+	const list = Array.isArray(entries) ? entries : [entries]
+	return list.map(s => String(s).trim()).filter(Boolean)
 }

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -7,7 +7,7 @@ import { XMLParser } from 'fast-xml-parser'
 
 import { getLicense } from '../license/license_utils.js'
 import Sbom from '../sbom.js'
-import { getCustom, getCustomPath, getWrapperPreference, invokeCommand, traverseForWrapper } from '../tools.js'
+import { getCustom, invokeCommand, resolveBinary } from '../tools.js'
 import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_java, { ecosystem_maven } from "./base_java.js";
@@ -316,25 +316,6 @@ const DEFAULT_MAVEN_DISCOVERY_IGNORE = [
 ]
 
 /**
- * Resolve the Maven binary, respecting wrapper preference.
- *
- * @param {string} startDir - Directory from which to start the wrapper search
- * @param {object} [opts={}]
- * @returns {string} Path to the Maven binary
- */
-function resolveMavenBinary(startDir, opts = {}) {
-	const localWrapper = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')
-	const useWrapper = getWrapperPreference('mvn', opts)
-	if (useWrapper) {
-		const wrapper = traverseForWrapper(startDir, localWrapper)
-		if (wrapper !== undefined) {
-			return wrapper
-		}
-	}
-	return getCustomPath('mvn', opts)
-}
-
-/**
  * Discover all pom.xml manifest paths in a Maven multi-module project.
  *
  * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pom.xml)
@@ -349,7 +330,8 @@ export async function discoverMavenModules(workspaceRoot, opts = {}) {
 		return []
 	}
 
-	const mvnBin = resolveMavenBinary(root, opts)
+	const localWrapper = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')
+	const mvnBin = resolveBinary('mvn', localWrapper, root, opts)
 	const visited = new Set()
 	const manifestPaths = [rootPom]
 

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -7,7 +7,8 @@ import { XMLParser } from 'fast-xml-parser'
 
 import { getLicense } from '../license/license_utils.js'
 import Sbom from '../sbom.js'
-import { getCustom } from '../tools.js'
+import { getCustom, getCustomPath, getWrapperPreference, invokeCommand, traverseForWrapper } from '../tools.js'
+import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_java, { ecosystem_maven } from "./base_java.js";
 
@@ -308,4 +309,115 @@ export default class Java_maven extends Base_java {
 	#dependencyIn(dep, deps) {
 		return deps.filter(d => dep.artifactId === d.artifactId && dep.groupId === d.groupId && dep.scope === d.scope).length > 0
 	}
+}
+
+const DEFAULT_MAVEN_DISCOVERY_IGNORE = [
+	'**/target/**',
+]
+
+/**
+ * Resolve the Maven binary, respecting wrapper preference.
+ *
+ * @param {string} startDir - Directory from which to start the wrapper search
+ * @param {object} [opts={}]
+ * @returns {string} Path to the Maven binary
+ */
+function resolveMavenBinary(startDir, opts = {}) {
+	const localWrapper = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')
+	const useWrapper = getWrapperPreference('mvn', opts)
+	if (useWrapper) {
+		const wrapper = traverseForWrapper(startDir, localWrapper)
+		if (wrapper !== undefined) {
+			return wrapper
+		}
+	}
+	return getCustomPath('mvn', opts)
+}
+
+/**
+ * Discover all pom.xml manifest paths in a Maven multi-module project.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pom.xml)
+ * @param {object} [opts={}]
+ * @returns {Promise<string[]>} Paths to pom.xml files (absolute)
+ */
+export async function discoverMavenModules(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const rootPom = path.join(root, 'pom.xml')
+
+	if (!fs.existsSync(rootPom)) {
+		return []
+	}
+
+	const mvnBin = resolveMavenBinary(root, opts)
+	const visited = new Set()
+	const manifestPaths = [rootPom]
+
+	collectMavenModules(root, mvnBin, visited, manifestPaths)
+
+	const ignorePatterns = [...resolveWorkspaceDiscoveryIgnore(opts), ...DEFAULT_MAVEN_DISCOVERY_IGNORE]
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * @param {string} dir - Absolute path to directory containing pom.xml
+ * @param {string} mvnBin - Maven binary path
+ * @param {Set<string>} visited - Already-visited directories (cycle guard)
+ * @param {string[]} manifestPaths - Accumulator for discovered pom.xml paths
+ */
+function collectMavenModules(dir, mvnBin, visited, manifestPaths) {
+	const resolvedDir = path.resolve(dir)
+	if (visited.has(resolvedDir)) {
+		return
+	}
+	visited.add(resolvedDir)
+
+	const modules = listMavenModules(resolvedDir, mvnBin)
+	for (const mod of modules) {
+		const moduleDir = path.resolve(resolvedDir, mod)
+		const modulePom = path.join(moduleDir, 'pom.xml')
+		if (fs.existsSync(modulePom)) {
+			manifestPaths.push(modulePom)
+			collectMavenModules(moduleDir, mvnBin, visited, manifestPaths)
+		}
+	}
+}
+
+/**
+ * @param {string} dir - Directory containing pom.xml
+ * @param {string} mvnBin - Maven binary path
+ * @returns {string[]} Module directory names (relative to `dir`)
+ */
+function listMavenModules(dir, mvnBin) {
+	let output
+	try {
+		output = invokeCommand(mvnBin, [
+			'help:evaluate',
+			'-Dexpression=project.modules',
+			'-q',
+			'-DforceStdout',
+			'-f', path.join(dir, 'pom.xml'),
+			'--batch-mode',
+		], { cwd: dir })
+	} catch {
+		return []
+	}
+
+	const raw = output.toString().trim()
+	if (!raw || raw === 'null') {
+		return []
+	}
+	return parseMavenModuleList(raw)
+}
+
+/**
+ * @param {string} raw - Raw stdout from mvn (e.g. `[module-a, module-b]`)
+ * @returns {string[]}
+ */
+function parseMavenModuleList(raw) {
+	const match = raw.match(/^\[(.+)]$/)
+	if (!match) {
+		return []
+	}
+	return match[1].split(',').map(s => s.trim()).filter(Boolean)
 }

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -7,7 +7,7 @@ import { XMLParser } from 'fast-xml-parser'
 
 import { getLicense } from '../license/license_utils.js'
 import Sbom from '../sbom.js'
-import { getCustom, invokeCommand, resolveBinary } from '../tools.js'
+import { getCustom, invokeCommand } from '../tools.js'
 import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_java, { ecosystem_maven } from "./base_java.js";
@@ -330,8 +330,12 @@ export async function discoverMavenModules(workspaceRoot, opts = {}) {
 		return []
 	}
 
-	const localWrapper = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')
-	const mvnBin = resolveBinary('mvn', localWrapper, root, opts)
+	let mvnBin
+	try {
+		mvnBin = new Java_maven().selectToolBinary(rootPom, opts)
+	} catch {
+		return [rootPom]
+	}
 	const visited = new Set()
 	const manifestPaths = [rootPom]
 

--- a/src/providers/java_maven.js
+++ b/src/providers/java_maven.js
@@ -390,20 +390,23 @@ function listMavenModules(dir, mvnBin) {
 	}
 
 	const raw = output.toString().trim()
-	if (!raw || raw === 'null') {
+	if (!raw || raw.startsWith('<modules')) {
 		return []
 	}
 	return parseMavenModuleList(raw)
 }
 
 /**
- * @param {string} raw - Raw stdout from mvn (e.g. `[module-a, module-b]`)
+ * @param {string} raw - Raw stdout from mvn help:evaluate -DforceStdout
  * @returns {string[]}
  */
 function parseMavenModuleList(raw) {
-	const match = raw.match(/^\[(.+)]$/)
-	if (!match) {
-		return []
+	const modules = []
+	const re = /<string>(.+?)<\/string>/g
+	let m
+	while ((m = re.exec(raw)) !== null) {
+		const val = m[1].trim()
+		if (val) modules.push(val)
 	}
-	return match[1].split(',').map(s => s.trim()).filter(Boolean)
+	return modules
 }

--- a/src/tools.js
+++ b/src/tools.js
@@ -178,6 +178,25 @@ export function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) 
 	}
 }
 
+/**
+ * Resolve a build-tool binary, preferring a wrapper when configured.
+ *
+ * @param {string} globalBinary - Global binary name (e.g. `mvn`, `gradle`)
+ * @param {string} localWrapper - Wrapper filename (e.g. `mvnw`, `gradlew.bat`)
+ * @param {string} startDir - Directory from which to start the wrapper search
+ * @param {import('./index.js').Options} [opts={}]
+ * @returns {string} Path to the resolved binary
+ */
+export function resolveBinary(globalBinary, localWrapper, startDir, opts = {}) {
+	if (getWrapperPreference(globalBinary, opts)) {
+		const wrapper = traverseForWrapper(startDir, localWrapper)
+		if (wrapper !== undefined) {
+			return wrapper
+		}
+	}
+	return getCustomPath(globalBinary, opts)
+}
+
 /** this method invokes command string in a process in a synchronous way.
  * @param {string} bin - the command to be invoked
  * @param {Array<string>} args - the args to pass to the binary

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,4 +1,6 @@
 import { execFileSync } from "child_process";
+import fs from 'node:fs'
+import path from 'node:path'
 import { EOL } from "os";
 
 import { HttpsProxyAgent } from "https-proxy-agent";
@@ -134,6 +136,34 @@ export function getGitRootDir(cwd) {
 		return root.toString().trim()
 	} catch (error) {
 		return undefined
+	}
+}
+
+/**
+ * Walk up from `startDir` to `repoRoot` looking for an executable wrapper script.
+ *
+ * @param {string} startDir - Absolute directory to start from
+ * @param {string} wrapperName - Wrapper filename (e.g. `mvnw`, `gradlew`)
+ * @param {string} [repoRoot] - Stop boundary (defaults to git root or filesystem root)
+ * @returns {string | undefined}
+ */
+export function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) {
+	const currentDir = path.resolve(startDir)
+	repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(currentDir).root
+	const wrapperPath = path.join(currentDir, wrapperName)
+	try {
+		fs.accessSync(wrapperPath, fs.constants.X_OK)
+		return wrapperPath
+	} catch {
+		const rootDir = path.parse(currentDir).root
+		if (currentDir === repoRoot || currentDir === rootDir) {
+			return undefined
+		}
+		const parentDir = path.dirname(currentDir)
+		if (parentDir === currentDir || parentDir === rootDir) {
+			return undefined
+		}
+		return traverseForWrapper(parentDir, wrapperName, repoRoot)
 	}
 }
 

--- a/src/tools.js
+++ b/src/tools.js
@@ -140,6 +140,17 @@ export function getGitRootDir(cwd) {
 }
 
 /**
+ * Normalize a filesystem path, lowercasing on Windows for case-insensitive comparison.
+ *
+ * @param {string} thePath
+ * @returns {string}
+ */
+export function normalizePath(thePath) {
+	const normalized = path.resolve(thePath).normalize()
+	return process.platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+/**
  * Walk up from `startDir` to `repoRoot` looking for an executable wrapper script.
  *
  * @param {string} startDir - Absolute directory to start from
@@ -148,7 +159,7 @@ export function getGitRootDir(cwd) {
  * @returns {string | undefined}
  */
 export function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) {
-	const currentDir = path.resolve(startDir)
+	const currentDir = normalizePath(startDir)
 	repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(currentDir).root
 	const wrapperPath = path.join(currentDir, wrapperName)
 	try {

--- a/src/tools.js
+++ b/src/tools.js
@@ -178,25 +178,6 @@ export function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) 
 	}
 }
 
-/**
- * Resolve a build-tool binary, preferring a wrapper when configured.
- *
- * @param {string} globalBinary - Global binary name (e.g. `mvn`, `gradle`)
- * @param {string} localWrapper - Wrapper filename (e.g. `mvnw`, `gradlew.bat`)
- * @param {string} startDir - Directory from which to start the wrapper search
- * @param {import('./index.js').Options} [opts={}]
- * @returns {string} Path to the resolved binary
- */
-export function resolveBinary(globalBinary, localWrapper, startDir, opts = {}) {
-	if (getWrapperPreference(globalBinary, opts)) {
-		const wrapper = traverseForWrapper(startDir, localWrapper)
-		if (wrapper !== undefined) {
-			return wrapper
-		}
-	}
-	return getCustomPath(globalBinary, opts)
-}
-
 /** this method invokes command string in a process in a synchronous way.
  * @param {string} bin - the command to be invoked
  * @param {Array<string>} args - the args to pass to the binary

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -5,12 +5,13 @@ import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
 
-import { getCustom, getCustomPath, invokeCommand } from './tools.js'
+import { getCustom, getCustomPath, getGitRootDir, getWrapperPreference, invokeCommand } from './tools.js'
 
 /** Default paths skipped during JS workspace discovery (merged with user patterns). */
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
+	'**/target/**',
 ]
 
 /**
@@ -222,6 +223,157 @@ async function discoverFromPackageJsonWorkspaces(root, packageJsonPath, globOpts
 		manifestPaths.unshift(rootPkg)
 	}
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Resolve the Maven binary, respecting wrapper preference.
+ *
+ * When `TRUSTIFY_DA_PREFER_MVNW` is truthy, traverses from `startDir` up to the
+ * git root (or filesystem root) looking for an executable `mvnw` wrapper.
+ * Falls back to the global `mvn` binary (or `TRUSTIFY_DA_MVN_PATH`).
+ *
+ * @param {string} startDir - Directory from which to start the wrapper search
+ * @param {import('./index.js').Options} [opts={}]
+ * @returns {string} Path to the Maven binary
+ */
+function resolveMavenBinary(startDir, opts = {}) {
+	const localWrapper = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')
+	const useWrapper = getWrapperPreference('mvn', opts)
+	if (useWrapper) {
+		const wrapper = traverseForWrapper(startDir, localWrapper)
+		if (wrapper !== undefined) {
+			return wrapper
+		}
+	}
+	return getCustomPath('mvn', opts)
+}
+
+/**
+ * Walk up from `startDir` to `repoRoot` looking for an executable wrapper script.
+ *
+ * @param {string} startDir - Absolute directory to start from
+ * @param {string} wrapperName - Wrapper filename (e.g. `mvnw`)
+ * @param {string} [repoRoot] - Stop boundary (defaults to git root or filesystem root)
+ * @returns {string | undefined}
+ */
+function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) {
+	const currentDir = path.resolve(startDir)
+	repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(currentDir).root
+	const wrapperPath = path.join(currentDir, wrapperName)
+
+	try {
+		fs.accessSync(wrapperPath, fs.constants.X_OK)
+		return wrapperPath
+	} catch (err) {
+		if (err.code === 'ENOENT') {
+			const rootDir = path.parse(currentDir).root
+			if (currentDir === repoRoot || currentDir === rootDir) {
+				return undefined
+			}
+			const parentDir = path.dirname(currentDir)
+			if (parentDir === currentDir || parentDir === rootDir) {
+				return undefined
+			}
+			return traverseForWrapper(parentDir, wrapperName, repoRoot)
+		}
+		throw new Error(`failure searching for ${wrapperName}`, { cause: err })
+	}
+}
+
+/**
+ * Discover all pom.xml manifest paths in a Maven multi-module project.
+ * Uses `mvn help:evaluate` to read `project.modules`, then recurses into
+ * nested aggregator modules.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pom.xml)
+ * @param {import('./index.js').Options} [opts={}]
+ * @returns {Promise<string[]>} Paths to pom.xml files (absolute)
+ */
+export async function discoverMavenModules(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const rootPom = path.join(root, 'pom.xml')
+
+	if (!fs.existsSync(rootPom)) {
+		return []
+	}
+
+	const mvnBin = resolveMavenBinary(root, opts)
+	const visited = new Set()
+	const manifestPaths = [rootPom]
+
+	collectMavenModules(root, mvnBin, visited, manifestPaths)
+
+	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Recursively collect Maven module pom.xml paths starting from a given directory.
+ *
+ * @param {string} dir - Absolute path to directory containing pom.xml
+ * @param {string} mvnBin - Maven binary path
+ * @param {Set<string>} visited - Already-visited directories (cycle guard)
+ * @param {string[]} manifestPaths - Accumulator for discovered pom.xml paths
+ */
+function collectMavenModules(dir, mvnBin, visited, manifestPaths) {
+	const resolvedDir = path.resolve(dir)
+	if (visited.has(resolvedDir)) {
+		return
+	}
+	visited.add(resolvedDir)
+
+	const modules = listMavenModules(resolvedDir, mvnBin)
+	for (const mod of modules) {
+		const moduleDir = path.resolve(resolvedDir, mod)
+		const modulePom = path.join(moduleDir, 'pom.xml')
+		if (fs.existsSync(modulePom)) {
+			manifestPaths.push(modulePom)
+			collectMavenModules(moduleDir, mvnBin, visited, manifestPaths)
+		}
+	}
+}
+
+/**
+ * Invoke `mvn help:evaluate` to list the `<modules>` declared in a pom.xml.
+ *
+ * @param {string} dir - Directory containing pom.xml
+ * @param {string} mvnBin - Maven binary path
+ * @returns {string[]} Module directory names (relative to `dir`)
+ */
+function listMavenModules(dir, mvnBin) {
+	let output
+	try {
+		output = invokeCommand(mvnBin, [
+			'help:evaluate',
+			'-Dexpression=project.modules',
+			'-q',
+			'-DforceStdout',
+			'-f', path.join(dir, 'pom.xml'),
+			'--batch-mode',
+		], { cwd: dir })
+	} catch {
+		return []
+	}
+
+	const raw = output.toString().trim()
+	if (!raw || raw === 'null') {
+		return []
+	}
+	return parseMavenModuleList(raw)
+}
+
+/**
+ * Parse the `[module-a, module-b]` output from `mvn help:evaluate -Dexpression=project.modules`.
+ *
+ * @param {string} raw - Raw stdout from mvn (e.g. `[module-a, module-b]`)
+ * @returns {string[]}
+ */
+function parseMavenModuleList(raw) {
+	const match = raw.match(/^\[(.+)]$/)
+	if (!match) {
+		return []
+	}
+	return match[1].split(',').map(s => s.trim()).filter(Boolean)
 }
 
 /**

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -5,13 +5,12 @@ import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
 
-import { getCustom, getCustomPath, getGitRootDir, getWrapperPreference, invokeCommand } from './tools.js'
+import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 
 /** Default paths skipped during JS workspace discovery (merged with user patterns). */
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
-	'**/target/**',
 ]
 
 /**
@@ -223,157 +222,6 @@ async function discoverFromPackageJsonWorkspaces(root, packageJsonPath, globOpts
 		manifestPaths.unshift(rootPkg)
 	}
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-}
-
-/**
- * Resolve the Maven binary, respecting wrapper preference.
- *
- * When `TRUSTIFY_DA_PREFER_MVNW` is truthy, traverses from `startDir` up to the
- * git root (or filesystem root) looking for an executable `mvnw` wrapper.
- * Falls back to the global `mvn` binary (or `TRUSTIFY_DA_MVN_PATH`).
- *
- * @param {string} startDir - Directory from which to start the wrapper search
- * @param {import('./index.js').Options} [opts={}]
- * @returns {string} Path to the Maven binary
- */
-function resolveMavenBinary(startDir, opts = {}) {
-	const localWrapper = 'mvnw' + (process.platform === 'win32' ? '.cmd' : '')
-	const useWrapper = getWrapperPreference('mvn', opts)
-	if (useWrapper) {
-		const wrapper = traverseForWrapper(startDir, localWrapper)
-		if (wrapper !== undefined) {
-			return wrapper
-		}
-	}
-	return getCustomPath('mvn', opts)
-}
-
-/**
- * Walk up from `startDir` to `repoRoot` looking for an executable wrapper script.
- *
- * @param {string} startDir - Absolute directory to start from
- * @param {string} wrapperName - Wrapper filename (e.g. `mvnw`)
- * @param {string} [repoRoot] - Stop boundary (defaults to git root or filesystem root)
- * @returns {string | undefined}
- */
-function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) {
-	const currentDir = path.resolve(startDir)
-	repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(currentDir).root
-	const wrapperPath = path.join(currentDir, wrapperName)
-
-	try {
-		fs.accessSync(wrapperPath, fs.constants.X_OK)
-		return wrapperPath
-	} catch (err) {
-		if (err.code === 'ENOENT') {
-			const rootDir = path.parse(currentDir).root
-			if (currentDir === repoRoot || currentDir === rootDir) {
-				return undefined
-			}
-			const parentDir = path.dirname(currentDir)
-			if (parentDir === currentDir || parentDir === rootDir) {
-				return undefined
-			}
-			return traverseForWrapper(parentDir, wrapperName, repoRoot)
-		}
-		throw new Error(`failure searching for ${wrapperName}`, { cause: err })
-	}
-}
-
-/**
- * Discover all pom.xml manifest paths in a Maven multi-module project.
- * Uses `mvn help:evaluate` to read `project.modules`, then recurses into
- * nested aggregator modules.
- *
- * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pom.xml)
- * @param {import('./index.js').Options} [opts={}]
- * @returns {Promise<string[]>} Paths to pom.xml files (absolute)
- */
-export async function discoverMavenModules(workspaceRoot, opts = {}) {
-	const root = path.resolve(workspaceRoot)
-	const rootPom = path.join(root, 'pom.xml')
-
-	if (!fs.existsSync(rootPom)) {
-		return []
-	}
-
-	const mvnBin = resolveMavenBinary(root, opts)
-	const visited = new Set()
-	const manifestPaths = [rootPom]
-
-	collectMavenModules(root, mvnBin, visited, manifestPaths)
-
-	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
-	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-}
-
-/**
- * Recursively collect Maven module pom.xml paths starting from a given directory.
- *
- * @param {string} dir - Absolute path to directory containing pom.xml
- * @param {string} mvnBin - Maven binary path
- * @param {Set<string>} visited - Already-visited directories (cycle guard)
- * @param {string[]} manifestPaths - Accumulator for discovered pom.xml paths
- */
-function collectMavenModules(dir, mvnBin, visited, manifestPaths) {
-	const resolvedDir = path.resolve(dir)
-	if (visited.has(resolvedDir)) {
-		return
-	}
-	visited.add(resolvedDir)
-
-	const modules = listMavenModules(resolvedDir, mvnBin)
-	for (const mod of modules) {
-		const moduleDir = path.resolve(resolvedDir, mod)
-		const modulePom = path.join(moduleDir, 'pom.xml')
-		if (fs.existsSync(modulePom)) {
-			manifestPaths.push(modulePom)
-			collectMavenModules(moduleDir, mvnBin, visited, manifestPaths)
-		}
-	}
-}
-
-/**
- * Invoke `mvn help:evaluate` to list the `<modules>` declared in a pom.xml.
- *
- * @param {string} dir - Directory containing pom.xml
- * @param {string} mvnBin - Maven binary path
- * @returns {string[]} Module directory names (relative to `dir`)
- */
-function listMavenModules(dir, mvnBin) {
-	let output
-	try {
-		output = invokeCommand(mvnBin, [
-			'help:evaluate',
-			'-Dexpression=project.modules',
-			'-q',
-			'-DforceStdout',
-			'-f', path.join(dir, 'pom.xml'),
-			'--batch-mode',
-		], { cwd: dir })
-	} catch {
-		return []
-	}
-
-	const raw = output.toString().trim()
-	if (!raw || raw === 'null') {
-		return []
-	}
-	return parseMavenModuleList(raw)
-}
-
-/**
- * Parse the `[module-a, module-b]` output from `mvn help:evaluate -Dexpression=project.modules`.
- *
- * @param {string} raw - Raw stdout from mvn (e.g. `[module-a, module-b]`)
- * @returns {string[]}
- */
-function parseMavenModuleList(raw) {
-	const match = raw.match(/^\[(.+)]$/)
-	if (!match) {
-		return []
-	}
-	return match[1].split(',').map(s => s.trim()).filter(Boolean)
 }
 
 /**

--- a/test/providers/tst_manifests/maven/maven_multi_module/module-a/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_multi_module/module-a/pom.xml
@@ -1,0 +1,9 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <artifactId>module-a</artifactId>
+</project>

--- a/test/providers/tst_manifests/maven/maven_multi_module/module-b/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_multi_module/module-b/pom.xml
@@ -1,0 +1,9 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <artifactId>module-b</artifactId>
+</project>

--- a/test/providers/tst_manifests/maven/maven_multi_module/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_multi_module/pom.xml
@@ -1,0 +1,11 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+</project>

--- a/test/providers/tst_manifests/maven/maven_nested_aggregator/parent/child/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_nested_aggregator/parent/child/pom.xml
@@ -1,0 +1,9 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <artifactId>child</artifactId>
+</project>

--- a/test/providers/tst_manifests/maven/maven_nested_aggregator/parent/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_nested_aggregator/parent/pom.xml
@@ -1,0 +1,10 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>child</module>
+  </modules>
+</project>

--- a/test/providers/tst_manifests/maven/maven_nested_aggregator/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_nested_aggregator/pom.xml
@@ -1,0 +1,10 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>root</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>parent</module>
+  </modules>
+</project>

--- a/test/providers/tst_manifests/maven/maven_no_modules/pom.xml
+++ b/test/providers/tst_manifests/maven/maven_no_modules/pom.xml
@@ -1,0 +1,6 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>single</artifactId>
+  <version>1.0.0</version>
+</project>

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 import esmock from 'esmock'
 
 import {
+	discoverMavenModules,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -185,5 +186,128 @@ suite('discoverWorkspaceCrates', () => {
 		expect(result.every(p => p.endsWith('Cargo.toml'))).to.be.true
 		expect(result.some(p => p.includes('crate-a'))).to.be.true
 		expect(result.some(p => p.includes('crate-b'))).to.be.true
+	})
+})
+
+suite('discoverMavenModules', () => {
+	test('returns empty when no pom.xml at root', async () => {
+		const result = await discoverMavenModules('test/providers/tst_manifests/npm')
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('returns root pom only when mvn reports no modules', async () => {
+		const root = path.resolve('test/providers/tst_manifests/maven/maven_no_modules')
+		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'mvn',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => Buffer.from('null'),
+			},
+		})
+		const result = await discoverMavenModules(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(1)
+		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
+	})
+
+	test('discovers multi-module project', async () => {
+		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
+		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'mvn',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: (bin, args) => {
+					const pomArg = args.find((a, i) => args[i - 1] === '-f')
+					if (pomArg && pomArg.includes('module-a')) {
+						return Buffer.from('null')
+					}
+					if (pomArg && pomArg.includes('module-b')) {
+						return Buffer.from('null')
+					}
+					return Buffer.from('[module-a, module-b]')
+				},
+			},
+		})
+		const result = await discoverMavenModules(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result.every(p => p.endsWith('pom.xml'))).to.be.true
+		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
+		expect(result.some(p => p.includes('module-a'))).to.be.true
+		expect(result.some(p => p.includes('module-b'))).to.be.true
+	})
+
+	test('discovers nested aggregator modules recursively', async () => {
+		const root = path.resolve('test/providers/tst_manifests/maven/maven_nested_aggregator')
+		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'mvn',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: (bin, args) => {
+					const pomArg = args.find((a, i) => args[i - 1] === '-f')
+					if (pomArg && pomArg.endsWith(path.join('parent', 'child', 'pom.xml'))) {
+						return Buffer.from('null')
+					}
+					if (pomArg && pomArg.endsWith(path.join('parent', 'pom.xml'))) {
+						return Buffer.from('[child]')
+					}
+					return Buffer.from('[parent]')
+				},
+			},
+		})
+		const result = await discoverMavenModules(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
+		expect(result.some(p => p.includes(path.join('parent', 'pom.xml')))).to.be.true
+		expect(result.some(p => p.includes(path.join('parent', 'child', 'pom.xml')))).to.be.true
+	})
+
+	test('returns root pom when mvn command fails', async () => {
+		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
+		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'mvn',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => { throw new Error('mvn not found') },
+			},
+		})
+		const result = await discoverMavenModules(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(1)
+		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
+	})
+
+	test('excludes paths matching workspaceDiscoveryIgnore', async () => {
+		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
+		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'mvn',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: (bin, args) => {
+					const pomArg = args.find((a, i) => args[i - 1] === '-f')
+					if (pomArg && (pomArg.includes('module-a') || pomArg.includes('module-b'))) {
+						return Buffer.from('null')
+					}
+					return Buffer.from('[module-a, module-b]')
+				},
+			},
+		})
+		const result = await discoverMavenModules(root, {
+			workspaceDiscoveryIgnore: ['**/module-b/**'],
+		})
+		expect(result.some(p => p.includes('module-a'))).to.be.true
+		expect(result.some(p => p.includes('module-b'))).to.be.false
 	})
 })

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -229,22 +229,17 @@ suite('discoverMavenModules', function () {
 
 	test('returns root pom when mvn is not available', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const saved = process.env.TRUSTIFY_DA_MVN_PATH
-		try {
-			process.env.TRUSTIFY_DA_MVN_PATH = '/nonexistent/mvn'
-			process.env.TRUSTIFY_DA_PREFER_MVNW = 'false'
-			const result = await discoverMavenModules(root)
-			expect(result).to.be.an('array')
-			expect(result).to.have.lengthOf(1)
-			expect(result[0]).to.equal(path.join(root, 'pom.xml'))
-		} finally {
-			if (saved !== undefined) {
-				process.env.TRUSTIFY_DA_MVN_PATH = saved
-			} else {
-				delete process.env.TRUSTIFY_DA_MVN_PATH
-			}
-			delete process.env.TRUSTIFY_DA_PREFER_MVNW
-		}
+		const { discoverMavenModules: discoverMocked } = await esmock('../../src/providers/java_maven.js', {
+			'../../src/tools.js': {
+				getCustomPath: () => '/nonexistent/mvn',
+				getWrapperPreference: () => false,
+				invokeCommand: () => { throw Object.assign(new Error('mvn not found'), { code: 'ENOENT' }) },
+			},
+		})
+		const result = await discoverMocked(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(1)
+		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
 	})
 
 	test('excludes paths matching workspaceDiscoveryIgnore', async () => {

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -4,8 +4,8 @@ import path from 'node:path'
 import { expect } from 'chai'
 import esmock from 'esmock'
 
+import { discoverMavenModules } from '../../src/providers/java_maven.js'
 import {
-	discoverMavenModules,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -198,7 +198,7 @@ suite('discoverMavenModules', () => {
 
 	test('returns root pom only when mvn reports no modules', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_no_modules')
-		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'mvn',
@@ -215,7 +215,7 @@ suite('discoverMavenModules', () => {
 
 	test('discovers multi-module project', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'mvn',
@@ -244,7 +244,7 @@ suite('discoverMavenModules', () => {
 
 	test('discovers nested aggregator modules recursively', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_nested_aggregator')
-		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'mvn',
@@ -272,7 +272,7 @@ suite('discoverMavenModules', () => {
 
 	test('returns root pom when mvn command fails', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'mvn',
@@ -289,7 +289,7 @@ suite('discoverMavenModules', () => {
 
 	test('excludes paths matching workspaceDiscoveryIgnore', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const { discoverMavenModules } = await esmock('../../src/workspace.js', {
+		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'mvn',

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -202,7 +202,7 @@ suite('discoverMavenModules', () => {
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(1)
 		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
-	})
+	}).timeout(40000)
 
 	test('discovers multi-module project', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
@@ -213,7 +213,7 @@ suite('discoverMavenModules', () => {
 		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
 		expect(result.some(p => p.includes('module-a'))).to.be.true
 		expect(result.some(p => p.includes('module-b'))).to.be.true
-	})
+	}).timeout(40000)
 
 	test('discovers nested aggregator modules recursively', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_nested_aggregator')
@@ -223,7 +223,7 @@ suite('discoverMavenModules', () => {
 		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
 		expect(result.some(p => p.includes(path.join('parent', 'pom.xml')))).to.be.true
 		expect(result.some(p => p.includes(path.join('parent', 'child', 'pom.xml')))).to.be.true
-	})
+	}).timeout(40000)
 
 	test('returns root pom when mvn is not available', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
@@ -247,5 +247,5 @@ suite('discoverMavenModules', () => {
 		})
 		expect(result.some(p => p.includes('module-a'))).to.be.true
 		expect(result.some(p => p.includes('module-b'))).to.be.false
-	})
+	}).timeout(40000)
 })

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -189,9 +189,7 @@ suite('discoverWorkspaceCrates', () => {
 	})
 })
 
-suite('discoverMavenModules', function () {
-	this.timeout(60_000)
-
+suite('discoverMavenModules', () => {
 	test('returns empty when no pom.xml at root', async () => {
 		const result = await discoverMavenModules('test/providers/tst_manifests/npm')
 		expect(result).to.be.an('array')

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -189,7 +189,9 @@ suite('discoverWorkspaceCrates', () => {
 	})
 })
 
-suite('discoverMavenModules', () => {
+suite('discoverMavenModules', function () {
+	this.timeout(60_000)
+
 	test('returns empty when no pom.xml at root', async () => {
 		const result = await discoverMavenModules('test/providers/tst_manifests/npm')
 		expect(result).to.be.an('array')
@@ -198,15 +200,6 @@ suite('discoverMavenModules', () => {
 
 	test('returns root pom only when mvn reports no modules', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_no_modules')
-		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
-			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'mvn',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
-				invokeCommand: () => Buffer.from('null'),
-			},
-		})
 		const result = await discoverMavenModules(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(1)
@@ -215,24 +208,6 @@ suite('discoverMavenModules', () => {
 
 	test('discovers multi-module project', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
-			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'mvn',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
-				invokeCommand: (bin, args) => {
-					const pomArg = args.find((a, i) => args[i - 1] === '-f')
-					if (pomArg && pomArg.includes('module-a')) {
-						return Buffer.from('null')
-					}
-					if (pomArg && pomArg.includes('module-b')) {
-						return Buffer.from('null')
-					}
-					return Buffer.from('[module-a, module-b]')
-				},
-			},
-		})
 		const result = await discoverMavenModules(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(3)
@@ -244,24 +219,6 @@ suite('discoverMavenModules', () => {
 
 	test('discovers nested aggregator modules recursively', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_nested_aggregator')
-		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
-			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'mvn',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
-				invokeCommand: (bin, args) => {
-					const pomArg = args.find((a, i) => args[i - 1] === '-f')
-					if (pomArg && pomArg.endsWith(path.join('parent', 'child', 'pom.xml'))) {
-						return Buffer.from('null')
-					}
-					if (pomArg && pomArg.endsWith(path.join('parent', 'pom.xml'))) {
-						return Buffer.from('[child]')
-					}
-					return Buffer.from('[parent]')
-				},
-			},
-		})
 		const result = await discoverMavenModules(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(3)
@@ -270,40 +227,28 @@ suite('discoverMavenModules', () => {
 		expect(result.some(p => p.includes(path.join('parent', 'child', 'pom.xml')))).to.be.true
 	})
 
-	test('returns root pom when mvn command fails', async () => {
+	test('returns root pom when mvn is not available', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
-			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'mvn',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
-				invokeCommand: () => { throw new Error('mvn not found') },
-			},
-		})
-		const result = await discoverMavenModules(root)
-		expect(result).to.be.an('array')
-		expect(result).to.have.lengthOf(1)
-		expect(result[0]).to.equal(path.join(root, 'pom.xml'))
+		const saved = process.env.TRUSTIFY_DA_MVN_PATH
+		try {
+			process.env.TRUSTIFY_DA_MVN_PATH = '/nonexistent/mvn'
+			process.env.TRUSTIFY_DA_PREFER_MVNW = 'false'
+			const result = await discoverMavenModules(root)
+			expect(result).to.be.an('array')
+			expect(result).to.have.lengthOf(1)
+			expect(result[0]).to.equal(path.join(root, 'pom.xml'))
+		} finally {
+			if (saved !== undefined) {
+				process.env.TRUSTIFY_DA_MVN_PATH = saved
+			} else {
+				delete process.env.TRUSTIFY_DA_MVN_PATH
+			}
+			delete process.env.TRUSTIFY_DA_PREFER_MVNW
+		}
 	})
 
 	test('excludes paths matching workspaceDiscoveryIgnore', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_multi_module')
-		const { discoverMavenModules } = await esmock('../../src/providers/java_maven.js', {
-			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'mvn',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
-				invokeCommand: (bin, args) => {
-					const pomArg = args.find((a, i) => args[i - 1] === '-f')
-					if (pomArg && (pomArg.includes('module-a') || pomArg.includes('module-b'))) {
-						return Buffer.from('null')
-					}
-					return Buffer.from('[module-a, module-b]')
-				},
-			},
-		})
 		const result = await discoverMavenModules(root, {
 			workspaceDiscoveryIgnore: ['**/module-b/**'],
 		})


### PR DESCRIPTION
## Summary
- Add `discoverMavenModules()` function to discover all pom.xml manifest paths in Maven multi-module projects using `mvn help:evaluate`
- Support recursive nested aggregator discovery with cycle detection
- Support Maven wrapper (mvnw) via `TRUSTIFY_DA_PREFER_MVNW` preference
- Add Maven ecosystem detection to `detectWorkspaceManifests()` between Cargo and JavaScript
- Add `**/target/**` to default workspace discovery ignore patterns

## Test plan
- [x] Unit tests for multi-module discovery with mocked `invokeCommand`
- [x] Unit tests for nested aggregator recursive discovery
- [x] Unit tests for graceful degradation when `mvn` fails
- [x] Unit tests for `workspaceDiscoveryIgnore` filtering
- [x] Unit tests for single-module project (no modules declared)
- [x] No test regressions in existing workspace/provider tests

Implements TC-4259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Maven multi-module workspace discovery and integrate Maven projects into automatic workspace manifest detection.

New Features:
- Introduce Maven workspace discovery that collects pom.xml manifests across multi-module and nested aggregator projects using mvn metadata.
- Expose discoverMavenModules via the public API for consumers needing Maven workspace manifest enumeration.

Enhancements:
- Respect Maven wrapper preference when resolving the Maven binary, falling back to the global mvn path.
- Extend default workspace discovery ignore patterns to exclude Maven target directories.
- Update workspace manifest detection to recognize Maven ecosystems alongside Cargo and JavaScript.

Tests:
- Add unit tests covering Maven multi-module, nested aggregator, single-module, failure scenarios, and ignore-pattern filtering for discoverMavenModules.