### PR TITLE
feat(workspace): add Gradle multi-project workspace discovery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ import fs from 'node:fs'
 import { getCustom } from "./tools.js";
 import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
 import { discoverMavenModules } from './providers/java_maven.js'
+import { discoverGradleSubprojects } from './providers/java_gradle.js'
 import {
-	discoverGradleSubprojects,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { getCustom } from "./tools.js";
 import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
 import { discoverMavenModules } from './providers/java_maven.js'
 import {
+	discoverGradleSubprojects,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -25,6 +26,7 @@ export { getProjectLicense, findLicenseFilePath, identifyLicense, getLicenseDeta
 export default { componentAnalysis, stackAnalysis, stackAnalysisBatch, imageAnalysis, validateToken, generateSbom }
 export {
 	discoverMavenModules,
+	discoverGradleSubprojects,
 	discoverWorkspacePackages,
 	discoverWorkspaceCrates,
 	validatePackageJson,
@@ -321,7 +323,7 @@ async function generateOneSbom(manifestPath, workspaceOpts) {
  *
  * @param {string} root - Resolved workspace root
  * @param {Options} opts
- * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'maven' | 'unknown', manifestPaths: string[] }>}
+ * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'maven' | 'gradle' | 'unknown', manifestPaths: string[] }>}
  * @private
  */
 async function detectWorkspaceManifests(root, opts) {
@@ -338,6 +340,15 @@ async function detectWorkspaceManifests(root, opts) {
 		const manifestPaths = await discoverMavenModules(root, opts)
 		if (manifestPaths.length > 0) {
 			return { ecosystem: 'maven', manifestPaths }
+		}
+	}
+
+	const hasGradleSettings = fs.existsSync(path.join(root, 'settings.gradle'))
+		|| fs.existsSync(path.join(root, 'settings.gradle.kts'))
+	if (hasGradleSettings) {
+		const manifestPaths = await discoverGradleSubprojects(root, opts)
+		if (manifestPaths.length > 0) {
+			return { ecosystem: 'gradle', manifestPaths }
 		}
 	}
 

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -1,4 +1,6 @@
+import crypto from 'node:crypto'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { EOL } from 'os'
 
@@ -6,6 +8,8 @@ import TOML from 'fast-toml'
 
 import { readLicenseFile } from '../license/license_utils.js'
 import Sbom from '../sbom.js'
+import { getCustomPath, getWrapperPreference, invokeCommand, traverseForWrapper } from '../tools.js'
+import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_java, { ecosystem_gradle } from "./base_java.js";
 
@@ -465,4 +469,131 @@ export default class Java_gradle extends Base_java {
 
 		return undefined
 	}
+}
+
+const DEFAULT_GRADLE_DISCOVERY_IGNORE = [
+	'**/build/**',
+	'**/.gradle/**',
+]
+
+/**
+ * Resolve the Gradle binary, respecting wrapper preference.
+ *
+ * @param {string} startDir - Directory from which to start the wrapper search
+ * @param {import('../index.js').Options} [opts={}]
+ * @returns {string} Path to the Gradle binary
+ */
+function resolveGradleBinary(startDir, opts = {}) {
+	const localWrapper = 'gradlew' + (process.platform === 'win32' ? '.bat' : '')
+	const useWrapper = getWrapperPreference('gradle', opts)
+	if (useWrapper) {
+		const wrapper = traverseForWrapper(startDir, localWrapper)
+		if (wrapper !== undefined) {
+			return wrapper
+		}
+	}
+	return getCustomPath('gradle', opts)
+}
+
+/** Gradle init script that emits structured project listing. */
+const GRADLE_INIT_SCRIPT = `allprojects {
+    task daListProjects {
+        doLast {
+            println "::DA_PROJECT::\${project.path}::\${project.projectDir}"
+        }
+    }
+}
+`
+
+/**
+ * Discover all build.gradle[.kts] manifest paths in a Gradle multi-project build.
+ * Uses a custom init script to get structured project listing.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain settings.gradle[.kts])
+ * @param {import('../index.js').Options} [opts={}]
+ * @returns {Promise<string[]>} Paths to build.gradle[.kts] files (absolute)
+ */
+export async function discoverGradleSubprojects(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const hasSettings = fs.existsSync(path.join(root, 'settings.gradle'))
+		|| fs.existsSync(path.join(root, 'settings.gradle.kts'))
+
+	if (!hasSettings) {
+		return []
+	}
+
+	const gradleBin = resolveGradleBinary(root, opts)
+	const manifestPaths = []
+
+	const rootBuildKts = path.join(root, 'build.gradle.kts')
+	const rootBuild = path.join(root, 'build.gradle')
+	if (fs.existsSync(rootBuildKts)) {
+		manifestPaths.push(rootBuildKts)
+	} else if (fs.existsSync(rootBuild)) {
+		manifestPaths.push(rootBuild)
+	}
+
+	const initScriptPath = path.join(os.tmpdir(), `da-list-projects-${crypto.randomUUID()}.gradle`)
+	try {
+		fs.writeFileSync(initScriptPath, GRADLE_INIT_SCRIPT)
+		let output
+		try {
+			output = invokeCommand(gradleBin, [
+				'-q', '--no-daemon',
+				'--init-script', initScriptPath,
+				'daListProjects',
+			], { cwd: root })
+		} catch {
+			const ignorePatterns = [...resolveWorkspaceDiscoveryIgnore(opts), ...DEFAULT_GRADLE_DISCOVERY_IGNORE]
+			return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+		}
+
+		const projects = parseGradleInitScriptOutput(output.toString())
+		for (const proj of projects) {
+			if (proj.path === ':') {
+				continue
+			}
+			const projDir = path.resolve(proj.dir)
+			const buildKts = path.join(projDir, 'build.gradle.kts')
+			const buildGroovy = path.join(projDir, 'build.gradle')
+			if (fs.existsSync(buildKts)) {
+				manifestPaths.push(buildKts)
+			} else if (fs.existsSync(buildGroovy)) {
+				manifestPaths.push(buildGroovy)
+			}
+		}
+	} finally {
+		try { fs.unlinkSync(initScriptPath) } catch { /* ignore */ }
+	}
+
+	const ignorePatterns = [...resolveWorkspaceDiscoveryIgnore(opts), ...DEFAULT_GRADLE_DISCOVERY_IGNORE]
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Parse the structured output from the Gradle init script.
+ *
+ * @param {string} raw - Raw stdout from gradle
+ * @returns {{ path: string, dir: string }[]}
+ */
+export function parseGradleInitScriptOutput(raw) {
+	const projects = []
+	for (const rawLine of raw.split('\n')) {
+		const line = rawLine.trimEnd()
+		if (!line.startsWith('::DA_PROJECT::')) {
+			continue
+		}
+		const prefix = '::DA_PROJECT::'
+		const remainder = line.substring(prefix.length)
+		const lastSep = remainder.lastIndexOf('::')
+		if (lastSep < 0) {
+			continue
+		}
+		const projPath = remainder.substring(0, lastSep)
+		const dir = remainder.substring(lastSep + 2)
+		if (projPath && dir) {
+			projects.push({ path: projPath, dir })
+		}
+	}
+	return projects
 }

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -8,7 +8,7 @@ import TOML from 'fast-toml'
 
 import { readLicenseFile } from '../license/license_utils.js'
 import Sbom from '../sbom.js'
-import { getCustomPath, getWrapperPreference, invokeCommand, traverseForWrapper } from '../tools.js'
+import { invokeCommand, resolveBinary } from '../tools.js'
 import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_java, { ecosystem_gradle } from "./base_java.js";
@@ -476,25 +476,6 @@ const DEFAULT_GRADLE_DISCOVERY_IGNORE = [
 	'**/.gradle/**',
 ]
 
-/**
- * Resolve the Gradle binary, respecting wrapper preference.
- *
- * @param {string} startDir - Directory from which to start the wrapper search
- * @param {import('../index.js').Options} [opts={}]
- * @returns {string} Path to the Gradle binary
- */
-function resolveGradleBinary(startDir, opts = {}) {
-	const localWrapper = 'gradlew' + (process.platform === 'win32' ? '.bat' : '')
-	const useWrapper = getWrapperPreference('gradle', opts)
-	if (useWrapper) {
-		const wrapper = traverseForWrapper(startDir, localWrapper)
-		if (wrapper !== undefined) {
-			return wrapper
-		}
-	}
-	return getCustomPath('gradle', opts)
-}
-
 /** Gradle init script that emits structured project listing. */
 const GRADLE_INIT_SCRIPT = `allprojects {
     task daListProjects {
@@ -522,7 +503,8 @@ export async function discoverGradleSubprojects(workspaceRoot, opts = {}) {
 		return []
 	}
 
-	const gradleBin = resolveGradleBinary(root, opts)
+	const localWrapper = 'gradlew' + (process.platform === 'win32' ? '.bat' : '')
+	const gradleBin = resolveBinary('gradle', localWrapper, root, opts)
 	const manifestPaths = []
 
 	const rootBuildKts = path.join(root, 'build.gradle.kts')

--- a/src/providers/java_gradle.js
+++ b/src/providers/java_gradle.js
@@ -8,7 +8,7 @@ import TOML from 'fast-toml'
 
 import { readLicenseFile } from '../license/license_utils.js'
 import Sbom from '../sbom.js'
-import { invokeCommand, resolveBinary } from '../tools.js'
+import { invokeCommand } from '../tools.js'
 import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_java, { ecosystem_gradle } from "./base_java.js";
@@ -503,16 +503,21 @@ export async function discoverGradleSubprojects(workspaceRoot, opts = {}) {
 		return []
 	}
 
-	const localWrapper = 'gradlew' + (process.platform === 'win32' ? '.bat' : '')
-	const gradleBin = resolveBinary('gradle', localWrapper, root, opts)
 	const manifestPaths = []
 
 	const rootBuildKts = path.join(root, 'build.gradle.kts')
 	const rootBuild = path.join(root, 'build.gradle')
-	if (fs.existsSync(rootBuildKts)) {
-		manifestPaths.push(rootBuildKts)
-	} else if (fs.existsSync(rootBuild)) {
-		manifestPaths.push(rootBuild)
+	const rootManifest = fs.existsSync(rootBuildKts) ? rootBuildKts : fs.existsSync(rootBuild) ? rootBuild : null
+	if (rootManifest) {
+		manifestPaths.push(rootManifest)
+	}
+
+	let gradleBin
+	try {
+		gradleBin = new Java_gradle().selectToolBinary(rootManifest || rootBuild, opts)
+	} catch {
+		const ignorePatterns = [...resolveWorkspaceDiscoveryIgnore(opts), ...DEFAULT_GRADLE_DISCOVERY_IGNORE]
+		return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
 	}
 
 	const initScriptPath = path.join(os.tmpdir(), `da-list-projects-${crypto.randomUUID()}.gradle`)

--- a/src/tools.js
+++ b/src/tools.js
@@ -178,6 +178,25 @@ export function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) 
 	}
 }
 
+/**
+ * Resolve a build-tool binary, preferring a wrapper when configured.
+ *
+ * @param {string} globalBinary - Global binary name (e.g. `mvn`, `gradle`)
+ * @param {string} localWrapper - Wrapper filename (e.g. `mvnw`, `gradlew.bat`)
+ * @param {string} startDir - Directory from which to start the wrapper search
+ * @param {import('./index.js').Options} [opts={}]
+ * @returns {string} Path to the resolved binary
+ */
+export function resolveBinary(globalBinary, localWrapper, startDir, opts = {}) {
+	if (getWrapperPreference(globalBinary, opts)) {
+		const wrapper = traverseForWrapper(startDir, localWrapper)
+		if (wrapper !== undefined) {
+			return wrapper
+		}
+	}
+	return getCustomPath(globalBinary, opts)
+}
+
 /** this method invokes command string in a process in a synchronous way.
  * @param {string} bin - the command to be invoked
  * @param {Array<string>} args - the args to pass to the binary

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,16 +1,19 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
 
-import { getCustom, getCustomPath, invokeCommand } from './tools.js'
+import { getCustom, getCustomPath, getGitRootDir, getWrapperPreference, invokeCommand } from './tools.js'
 
 /** Default paths skipped during JS workspace discovery (merged with user patterns). */
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
+	'**/build/**',
+	'**/.gradle/**',
 ]
 
 /**
@@ -222,6 +225,159 @@ async function discoverFromPackageJsonWorkspaces(root, packageJsonPath, globOpts
 		manifestPaths.unshift(rootPkg)
 	}
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Walk up from `startDir` to `repoRoot` looking for an executable wrapper script.
+ *
+ * @param {string} startDir - Absolute directory to start from
+ * @param {string} wrapperName - Wrapper filename (e.g. `mvnw`)
+ * @param {string} [repoRoot] - Stop boundary (defaults to git root or filesystem root)
+ * @returns {string | undefined}
+ */
+function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) {
+	const currentDir = path.resolve(startDir)
+	repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(currentDir).root
+	const wrapperPath = path.join(currentDir, wrapperName)
+
+	try {
+		fs.accessSync(wrapperPath, fs.constants.X_OK)
+		return wrapperPath
+	} catch (err) {
+		if (err.code === 'ENOENT') {
+			const rootDir = path.parse(currentDir).root
+			if (currentDir === repoRoot || currentDir === rootDir) {
+				return undefined
+			}
+			const parentDir = path.dirname(currentDir)
+			if (parentDir === currentDir || parentDir === rootDir) {
+				return undefined
+			}
+			return traverseForWrapper(parentDir, wrapperName, repoRoot)
+		}
+		throw new Error(`failure searching for ${wrapperName}`, { cause: err })
+	}
+}
+
+/** Gradle init script that emits structured project listing. */
+const GRADLE_INIT_SCRIPT = `allprojects {
+    task daListProjects {
+        doLast {
+            println "::DA_PROJECT::\${project.path}::\${project.projectDir}"
+        }
+    }
+}
+`
+
+/**
+ * Resolve the Gradle binary, respecting wrapper preference.
+ *
+ * @param {string} startDir - Directory from which to start the wrapper search
+ * @param {import('./index.js').Options} [opts={}]
+ * @returns {string} Path to the Gradle binary
+ */
+function resolveGradleBinary(startDir, opts = {}) {
+	const localWrapper = 'gradlew' + (process.platform === 'win32' ? '.bat' : '')
+	const useWrapper = getWrapperPreference('gradle', opts)
+	if (useWrapper) {
+		const wrapper = traverseForWrapper(startDir, localWrapper)
+		if (wrapper !== undefined) {
+			return wrapper
+		}
+	}
+	return getCustomPath('gradle', opts)
+}
+
+/**
+ * Discover all build.gradle[.kts] manifest paths in a Gradle multi-project build.
+ * Uses a custom init script to get structured project listing.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain settings.gradle[.kts])
+ * @param {import('./index.js').Options} [opts={}]
+ * @returns {Promise<string[]>} Paths to build.gradle[.kts] files (absolute)
+ */
+export async function discoverGradleSubprojects(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const hasSettings = fs.existsSync(path.join(root, 'settings.gradle'))
+		|| fs.existsSync(path.join(root, 'settings.gradle.kts'))
+
+	if (!hasSettings) {
+		return []
+	}
+
+	const gradleBin = resolveGradleBinary(root, opts)
+	const manifestPaths = []
+
+	const rootBuildKts = path.join(root, 'build.gradle.kts')
+	const rootBuild = path.join(root, 'build.gradle')
+	if (fs.existsSync(rootBuildKts)) {
+		manifestPaths.push(rootBuildKts)
+	} else if (fs.existsSync(rootBuild)) {
+		manifestPaths.push(rootBuild)
+	}
+
+	const initScriptPath = path.join(os.tmpdir(), `da-list-projects-${process.pid}.gradle`)
+	try {
+		fs.writeFileSync(initScriptPath, GRADLE_INIT_SCRIPT)
+		let output
+		try {
+			output = invokeCommand(gradleBin, [
+				'-q', '--no-daemon',
+				'--init-script', initScriptPath,
+				'daListProjects',
+			], { cwd: root })
+		} catch {
+			const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
+			return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+		}
+
+		const projects = parseGradleInitScriptOutput(output.toString())
+		for (const proj of projects) {
+			if (proj.path === ':') {
+				continue
+			}
+			const projDir = path.resolve(proj.dir)
+			const buildKts = path.join(projDir, 'build.gradle.kts')
+			const buildGroovy = path.join(projDir, 'build.gradle')
+			if (fs.existsSync(buildKts)) {
+				manifestPaths.push(buildKts)
+			} else if (fs.existsSync(buildGroovy)) {
+				manifestPaths.push(buildGroovy)
+			}
+		}
+	} finally {
+		try { fs.unlinkSync(initScriptPath) } catch { /* ignore */ }
+	}
+
+	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Parse the structured output from the Gradle init script.
+ *
+ * @param {string} raw - Raw stdout from gradle
+ * @returns {{ path: string, dir: string }[]}
+ */
+function parseGradleInitScriptOutput(raw) {
+	const projects = []
+	for (const line of raw.split('\n')) {
+		if (!line.startsWith('::DA_PROJECT::')) {
+			continue
+		}
+		const prefix = '::DA_PROJECT::'
+		const remainder = line.substring(prefix.length)
+		const lastSep = remainder.lastIndexOf('::')
+		if (lastSep < 0) {
+			continue
+		}
+		const projPath = remainder.substring(0, lastSep)
+		const dir = remainder.substring(lastSep + 2)
+		if (projPath && dir) {
+			projects.push({ path: projPath, dir })
+		}
+	}
+	return projects
 }
 
 /**

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,19 +1,16 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 
 import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
 
-import { getCustom, getCustomPath, getGitRootDir, getWrapperPreference, invokeCommand } from './tools.js'
+import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 
 /** Default paths skipped during JS workspace discovery (merged with user patterns). */
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
-	'**/build/**',
-	'**/.gradle/**',
 ]
 
 /**
@@ -225,159 +222,6 @@ async function discoverFromPackageJsonWorkspaces(root, packageJsonPath, globOpts
 		manifestPaths.unshift(rootPkg)
 	}
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-}
-
-/**
- * Walk up from `startDir` to `repoRoot` looking for an executable wrapper script.
- *
- * @param {string} startDir - Absolute directory to start from
- * @param {string} wrapperName - Wrapper filename (e.g. `mvnw`)
- * @param {string} [repoRoot] - Stop boundary (defaults to git root or filesystem root)
- * @returns {string | undefined}
- */
-function traverseForWrapper(startDir, wrapperName, repoRoot = undefined) {
-	const currentDir = path.resolve(startDir)
-	repoRoot = repoRoot || getGitRootDir(currentDir) || path.parse(currentDir).root
-	const wrapperPath = path.join(currentDir, wrapperName)
-
-	try {
-		fs.accessSync(wrapperPath, fs.constants.X_OK)
-		return wrapperPath
-	} catch (err) {
-		if (err.code === 'ENOENT') {
-			const rootDir = path.parse(currentDir).root
-			if (currentDir === repoRoot || currentDir === rootDir) {
-				return undefined
-			}
-			const parentDir = path.dirname(currentDir)
-			if (parentDir === currentDir || parentDir === rootDir) {
-				return undefined
-			}
-			return traverseForWrapper(parentDir, wrapperName, repoRoot)
-		}
-		throw new Error(`failure searching for ${wrapperName}`, { cause: err })
-	}
-}
-
-/** Gradle init script that emits structured project listing. */
-const GRADLE_INIT_SCRIPT = `allprojects {
-    task daListProjects {
-        doLast {
-            println "::DA_PROJECT::\${project.path}::\${project.projectDir}"
-        }
-    }
-}
-`
-
-/**
- * Resolve the Gradle binary, respecting wrapper preference.
- *
- * @param {string} startDir - Directory from which to start the wrapper search
- * @param {import('./index.js').Options} [opts={}]
- * @returns {string} Path to the Gradle binary
- */
-function resolveGradleBinary(startDir, opts = {}) {
-	const localWrapper = 'gradlew' + (process.platform === 'win32' ? '.bat' : '')
-	const useWrapper = getWrapperPreference('gradle', opts)
-	if (useWrapper) {
-		const wrapper = traverseForWrapper(startDir, localWrapper)
-		if (wrapper !== undefined) {
-			return wrapper
-		}
-	}
-	return getCustomPath('gradle', opts)
-}
-
-/**
- * Discover all build.gradle[.kts] manifest paths in a Gradle multi-project build.
- * Uses a custom init script to get structured project listing.
- *
- * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain settings.gradle[.kts])
- * @param {import('./index.js').Options} [opts={}]
- * @returns {Promise<string[]>} Paths to build.gradle[.kts] files (absolute)
- */
-export async function discoverGradleSubprojects(workspaceRoot, opts = {}) {
-	const root = path.resolve(workspaceRoot)
-	const hasSettings = fs.existsSync(path.join(root, 'settings.gradle'))
-		|| fs.existsSync(path.join(root, 'settings.gradle.kts'))
-
-	if (!hasSettings) {
-		return []
-	}
-
-	const gradleBin = resolveGradleBinary(root, opts)
-	const manifestPaths = []
-
-	const rootBuildKts = path.join(root, 'build.gradle.kts')
-	const rootBuild = path.join(root, 'build.gradle')
-	if (fs.existsSync(rootBuildKts)) {
-		manifestPaths.push(rootBuildKts)
-	} else if (fs.existsSync(rootBuild)) {
-		manifestPaths.push(rootBuild)
-	}
-
-	const initScriptPath = path.join(os.tmpdir(), `da-list-projects-${process.pid}.gradle`)
-	try {
-		fs.writeFileSync(initScriptPath, GRADLE_INIT_SCRIPT)
-		let output
-		try {
-			output = invokeCommand(gradleBin, [
-				'-q', '--no-daemon',
-				'--init-script', initScriptPath,
-				'daListProjects',
-			], { cwd: root })
-		} catch {
-			const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
-			return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-		}
-
-		const projects = parseGradleInitScriptOutput(output.toString())
-		for (const proj of projects) {
-			if (proj.path === ':') {
-				continue
-			}
-			const projDir = path.resolve(proj.dir)
-			const buildKts = path.join(projDir, 'build.gradle.kts')
-			const buildGroovy = path.join(projDir, 'build.gradle')
-			if (fs.existsSync(buildKts)) {
-				manifestPaths.push(buildKts)
-			} else if (fs.existsSync(buildGroovy)) {
-				manifestPaths.push(buildGroovy)
-			}
-		}
-	} finally {
-		try { fs.unlinkSync(initScriptPath) } catch { /* ignore */ }
-	}
-
-	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
-	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-}
-
-/**
- * Parse the structured output from the Gradle init script.
- *
- * @param {string} raw - Raw stdout from gradle
- * @returns {{ path: string, dir: string }[]}
- */
-function parseGradleInitScriptOutput(raw) {
-	const projects = []
-	for (const line of raw.split('\n')) {
-		if (!line.startsWith('::DA_PROJECT::')) {
-			continue
-		}
-		const prefix = '::DA_PROJECT::'
-		const remainder = line.substring(prefix.length)
-		const lastSep = remainder.lastIndexOf('::')
-		if (lastSep < 0) {
-			continue
-		}
-		const projPath = remainder.substring(0, lastSep)
-		const dir = remainder.substring(lastSep + 2)
-		if (projPath && dir) {
-			projects.push({ path: projPath, dir })
-		}
-	}
-	return projects
 }
 
 /**

--- a/test/providers/tst_manifests/gradle/gradle_mixed_variants/app/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_mixed_variants/app/build.gradle
@@ -1,0 +1,1 @@
+// app build groovy

--- a/test/providers/tst_manifests/gradle/gradle_mixed_variants/build.gradle.kts
+++ b/test/providers/tst_manifests/gradle/gradle_mixed_variants/build.gradle.kts
@@ -1,0 +1,1 @@
+// root build kts

--- a/test/providers/tst_manifests/gradle/gradle_mixed_variants/lib/build.gradle.kts
+++ b/test/providers/tst_manifests/gradle/gradle_mixed_variants/lib/build.gradle.kts
@@ -1,0 +1,1 @@
+// lib build kts

--- a/test/providers/tst_manifests/gradle/gradle_mixed_variants/settings.gradle.kts
+++ b/test/providers/tst_manifests/gradle/gradle_mixed_variants/settings.gradle.kts
@@ -1,0 +1,1 @@
+include ':app', ':lib'

--- a/test/providers/tst_manifests/gradle/gradle_mixed_variants/settings.gradle.kts
+++ b/test/providers/tst_manifests/gradle/gradle_mixed_variants/settings.gradle.kts
@@ -1,1 +1,1 @@
-include ':app', ':lib'
+include(":app", ":lib")

--- a/test/providers/tst_manifests/gradle/gradle_multi_project/app/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_multi_project/app/build.gradle
@@ -1,0 +1,1 @@
+// app build

--- a/test/providers/tst_manifests/gradle/gradle_multi_project/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_multi_project/build.gradle
@@ -1,0 +1,1 @@
+// root build

--- a/test/providers/tst_manifests/gradle/gradle_multi_project/lib/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_multi_project/lib/build.gradle
@@ -1,0 +1,1 @@
+// lib build

--- a/test/providers/tst_manifests/gradle/gradle_multi_project/settings.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_multi_project/settings.gradle
@@ -1,0 +1,1 @@
+include ':app', ':lib'

--- a/test/providers/tst_manifests/gradle/gradle_nested_subprojects/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_nested_subprojects/build.gradle
@@ -1,0 +1,1 @@
+// root build

--- a/test/providers/tst_manifests/gradle/gradle_nested_subprojects/libs/core/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_nested_subprojects/libs/core/build.gradle
@@ -1,0 +1,1 @@
+// core build

--- a/test/providers/tst_manifests/gradle/gradle_nested_subprojects/libs/util/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_nested_subprojects/libs/util/build.gradle
@@ -1,0 +1,1 @@
+// util build

--- a/test/providers/tst_manifests/gradle/gradle_nested_subprojects/settings.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_nested_subprojects/settings.gradle
@@ -1,0 +1,1 @@
+include ':libs:core', ':libs:util'

--- a/test/providers/tst_manifests/gradle/gradle_no_subprojects/build.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_no_subprojects/build.gradle
@@ -1,0 +1,1 @@
+// root build

--- a/test/providers/tst_manifests/gradle/gradle_no_subprojects/settings.gradle
+++ b/test/providers/tst_manifests/gradle/gradle_no_subprojects/settings.gradle
@@ -1,0 +1,1 @@
+// no includes

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -208,10 +208,7 @@ suite('discoverGradleSubprojects', () => {
 
 		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'gradle',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
+				resolveBinary: () => 'gradle',
 				invokeCommand: () => Buffer.from(initScriptOutput),
 			},
 		})
@@ -233,10 +230,7 @@ suite('discoverGradleSubprojects', () => {
 
 		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'gradle',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
+				resolveBinary: () => 'gradle',
 				invokeCommand: () => Buffer.from(initScriptOutput),
 			},
 		})
@@ -258,10 +252,7 @@ suite('discoverGradleSubprojects', () => {
 
 		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'gradle',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
+				resolveBinary: () => 'gradle',
 				invokeCommand: () => Buffer.from(initScriptOutput),
 			},
 		})
@@ -279,10 +270,7 @@ suite('discoverGradleSubprojects', () => {
 
 		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'gradle',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
+				resolveBinary: () => 'gradle',
 				invokeCommand: () => Buffer.from(initScriptOutput),
 			},
 		})
@@ -296,10 +284,7 @@ suite('discoverGradleSubprojects', () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
 		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'gradle',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
+				resolveBinary: () => 'gradle',
 				invokeCommand: () => { throw new Error('gradle not found') },
 			},
 		})
@@ -319,10 +304,7 @@ suite('discoverGradleSubprojects', () => {
 
 		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				getCustom: () => null,
-				getCustomPath: () => 'gradle',
-				getGitRootDir: () => null,
-				getWrapperPreference: () => false,
+				resolveBinary: () => 'gradle',
 				invokeCommand: () => Buffer.from(initScriptOutput),
 			},
 		})

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -206,7 +206,7 @@ suite('discoverGradleSubprojects', () => {
 		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
 		expect(result.some(p => p.includes(path.join('app', 'build.gradle')))).to.be.true
 		expect(result.some(p => p.includes(path.join('lib', 'build.gradle')))).to.be.true
-	})
+	}).timeout(40000)
 
 	test('discovers nested subprojects', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_nested_subprojects')
@@ -216,7 +216,7 @@ suite('discoverGradleSubprojects', () => {
 		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
 		expect(result.some(p => p.includes(path.join('libs', 'core', 'build.gradle')))).to.be.true
 		expect(result.some(p => p.includes(path.join('libs', 'util', 'build.gradle')))).to.be.true
-	})
+	}).timeout(40000)
 
 	test('handles mixed Groovy and Kotlin build files', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_mixed_variants')
@@ -226,7 +226,7 @@ suite('discoverGradleSubprojects', () => {
 		expect(result[0]).to.equal(path.join(root, 'build.gradle.kts'))
 		expect(result.some(p => p.endsWith(path.join('app', 'build.gradle')))).to.be.true
 		expect(result.some(p => p.endsWith(path.join('lib', 'build.gradle.kts')))).to.be.true
-	})
+	}).timeout(40000)
 
 	test('returns root only when no subprojects', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_no_subprojects')
@@ -234,7 +234,7 @@ suite('discoverGradleSubprojects', () => {
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(1)
 		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
-	})
+	}).timeout(40000)
 
 	test('returns root build file when gradle is not available', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
@@ -258,7 +258,7 @@ suite('discoverGradleSubprojects', () => {
 		})
 		expect(result.some(p => p.includes(path.join('app', 'build.gradle')))).to.be.true
 		expect(result.some(p => p.includes(path.join('lib', 'build.gradle')))).to.be.false
-	})
+	}).timeout(40000)
 })
 
 suite('discoverMavenModules', () => {

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -4,9 +4,9 @@ import path from 'node:path'
 import { expect } from 'chai'
 import esmock from 'esmock'
 
+import { discoverGradleSubprojects } from '../../src/providers/java_gradle.js'
 import { discoverMavenModules } from '../../src/providers/java_maven.js'
 import {
-	discoverGradleSubprojects,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -206,7 +206,7 @@ suite('discoverGradleSubprojects', () => {
 			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
 		].join('\n')
 
-		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'gradle',
@@ -231,7 +231,7 @@ suite('discoverGradleSubprojects', () => {
 			`::DA_PROJECT:::libs:util::${path.resolve(root, 'libs/util')}`,
 		].join('\n')
 
-		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'gradle',
@@ -256,7 +256,7 @@ suite('discoverGradleSubprojects', () => {
 			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
 		].join('\n')
 
-		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'gradle',
@@ -277,7 +277,7 @@ suite('discoverGradleSubprojects', () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_no_subprojects')
 		const initScriptOutput = `::DA_PROJECT:::${path.resolve(root)}\n`
 
-		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'gradle',
@@ -294,7 +294,7 @@ suite('discoverGradleSubprojects', () => {
 
 	test('returns root build file when gradle command fails', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
-		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'gradle',
@@ -317,7 +317,7 @@ suite('discoverGradleSubprojects', () => {
 			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
 		].join('\n')
 
-		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
 				getCustom: () => null,
 				getCustomPath: () => 'gradle',

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -6,6 +6,7 @@ import esmock from 'esmock'
 
 import { discoverMavenModules } from '../../src/providers/java_maven.js'
 import {
+	discoverGradleSubprojects,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -189,13 +190,156 @@ suite('discoverWorkspaceCrates', () => {
 	})
 })
 
+
+suite('discoverGradleSubprojects', () => {
+	test('returns empty when no settings.gradle at root', async () => {
+		const result = await discoverGradleSubprojects('test/providers/tst_manifests/npm')
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('discovers multi-project build', async () => {
+		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
+		const initScriptOutput = [
+			`::DA_PROJECT:::${path.resolve(root)}`,
+			`::DA_PROJECT:::app::${path.resolve(root, 'app')}`,
+			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
+		].join('\n')
+
+		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'gradle',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => Buffer.from(initScriptOutput),
+			},
+		})
+		const result = await discoverGradleSubprojects(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
+		expect(result.some(p => p.includes(path.join('app', 'build.gradle')))).to.be.true
+		expect(result.some(p => p.includes(path.join('lib', 'build.gradle')))).to.be.true
+	})
+
+	test('discovers nested subprojects', async () => {
+		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_nested_subprojects')
+		const initScriptOutput = [
+			`::DA_PROJECT:::${path.resolve(root)}`,
+			`::DA_PROJECT:::libs:core::${path.resolve(root, 'libs/core')}`,
+			`::DA_PROJECT:::libs:util::${path.resolve(root, 'libs/util')}`,
+		].join('\n')
+
+		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'gradle',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => Buffer.from(initScriptOutput),
+			},
+		})
+		const result = await discoverGradleSubprojects(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
+		expect(result.some(p => p.includes(path.join('libs', 'core', 'build.gradle')))).to.be.true
+		expect(result.some(p => p.includes(path.join('libs', 'util', 'build.gradle')))).to.be.true
+	})
+
+	test('handles mixed Groovy and Kotlin build files', async () => {
+		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_mixed_variants')
+		const initScriptOutput = [
+			`::DA_PROJECT:::${path.resolve(root)}`,
+			`::DA_PROJECT:::app::${path.resolve(root, 'app')}`,
+			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
+		].join('\n')
+
+		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'gradle',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => Buffer.from(initScriptOutput),
+			},
+		})
+		const result = await discoverGradleSubprojects(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result[0]).to.equal(path.join(root, 'build.gradle.kts'))
+		expect(result.some(p => p.endsWith(path.join('app', 'build.gradle')))).to.be.true
+		expect(result.some(p => p.endsWith(path.join('lib', 'build.gradle.kts')))).to.be.true
+	})
+
+	test('returns root only when no subprojects', async () => {
+		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_no_subprojects')
+		const initScriptOutput = `::DA_PROJECT:::${path.resolve(root)}\n`
+
+		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'gradle',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => Buffer.from(initScriptOutput),
+			},
+		})
+		const result = await discoverGradleSubprojects(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(1)
+		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
+	})
+
+	test('returns root build file when gradle command fails', async () => {
+		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
+		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'gradle',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => { throw new Error('gradle not found') },
+			},
+		})
+		const result = await discoverGradleSubprojects(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(1)
+		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
+	})
+
+	test('excludes paths matching workspaceDiscoveryIgnore', async () => {
+		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
+		const initScriptOutput = [
+			`::DA_PROJECT:::${path.resolve(root)}`,
+			`::DA_PROJECT:::app::${path.resolve(root, 'app')}`,
+			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
+		].join('\n')
+
+		const { discoverGradleSubprojects } = await esmock('../../src/workspace.js', {
+			'../../src/tools.js': {
+				getCustom: () => null,
+				getCustomPath: () => 'gradle',
+				getGitRootDir: () => null,
+				getWrapperPreference: () => false,
+				invokeCommand: () => Buffer.from(initScriptOutput),
+			},
+		})
+		const result = await discoverGradleSubprojects(root, {
+			workspaceDiscoveryIgnore: ['**/lib/**'],
+		})
+		expect(result.some(p => p.includes(path.join('app', 'build.gradle')))).to.be.true
+		expect(result.some(p => p.includes(path.join('lib', 'build.gradle')))).to.be.false
+	})
+})
+
 suite('discoverMavenModules', () => {
 	test('returns empty when no pom.xml at root', async () => {
 		const result = await discoverMavenModules('test/providers/tst_manifests/npm')
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(0)
 	})
-
 	test('returns root pom only when mvn reports no modules', async () => {
 		const root = path.resolve('test/providers/tst_manifests/maven/maven_no_modules')
 		const result = await discoverMavenModules(root)

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -200,18 +200,6 @@ suite('discoverGradleSubprojects', () => {
 
 	test('discovers multi-project build', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
-		const initScriptOutput = [
-			`::DA_PROJECT:::${path.resolve(root)}`,
-			`::DA_PROJECT:::app::${path.resolve(root, 'app')}`,
-			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
-		].join('\n')
-
-		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
-			'../../src/tools.js': {
-				resolveBinary: () => 'gradle',
-				invokeCommand: () => Buffer.from(initScriptOutput),
-			},
-		})
 		const result = await discoverGradleSubprojects(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(3)
@@ -222,18 +210,6 @@ suite('discoverGradleSubprojects', () => {
 
 	test('discovers nested subprojects', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_nested_subprojects')
-		const initScriptOutput = [
-			`::DA_PROJECT:::${path.resolve(root)}`,
-			`::DA_PROJECT:::libs:core::${path.resolve(root, 'libs/core')}`,
-			`::DA_PROJECT:::libs:util::${path.resolve(root, 'libs/util')}`,
-		].join('\n')
-
-		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
-			'../../src/tools.js': {
-				resolveBinary: () => 'gradle',
-				invokeCommand: () => Buffer.from(initScriptOutput),
-			},
-		})
 		const result = await discoverGradleSubprojects(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(3)
@@ -244,18 +220,6 @@ suite('discoverGradleSubprojects', () => {
 
 	test('handles mixed Groovy and Kotlin build files', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_mixed_variants')
-		const initScriptOutput = [
-			`::DA_PROJECT:::${path.resolve(root)}`,
-			`::DA_PROJECT:::app::${path.resolve(root, 'app')}`,
-			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
-		].join('\n')
-
-		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
-			'../../src/tools.js': {
-				resolveBinary: () => 'gradle',
-				invokeCommand: () => Buffer.from(initScriptOutput),
-			},
-		})
 		const result = await discoverGradleSubprojects(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(3)
@@ -266,29 +230,22 @@ suite('discoverGradleSubprojects', () => {
 
 	test('returns root only when no subprojects', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_no_subprojects')
-		const initScriptOutput = `::DA_PROJECT:::${path.resolve(root)}\n`
-
-		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
-			'../../src/tools.js': {
-				resolveBinary: () => 'gradle',
-				invokeCommand: () => Buffer.from(initScriptOutput),
-			},
-		})
 		const result = await discoverGradleSubprojects(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(1)
 		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
 	})
 
-	test('returns root build file when gradle command fails', async () => {
+	test('returns root build file when gradle is not available', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
-		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
+		const { discoverGradleSubprojects: discoverMocked } = await esmock('../../src/providers/java_gradle.js', {
 			'../../src/tools.js': {
-				resolveBinary: () => 'gradle',
-				invokeCommand: () => { throw new Error('gradle not found') },
+				getCustomPath: () => '/nonexistent/gradle',
+				getWrapperPreference: () => false,
+				invokeCommand: () => { throw Object.assign(new Error('gradle not found'), { code: 'ENOENT' }) },
 			},
 		})
-		const result = await discoverGradleSubprojects(root)
+		const result = await discoverMocked(root)
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(1)
 		expect(result[0]).to.equal(path.join(root, 'build.gradle'))
@@ -296,18 +253,6 @@ suite('discoverGradleSubprojects', () => {
 
 	test('excludes paths matching workspaceDiscoveryIgnore', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
-		const initScriptOutput = [
-			`::DA_PROJECT:::${path.resolve(root)}`,
-			`::DA_PROJECT:::app::${path.resolve(root, 'app')}`,
-			`::DA_PROJECT:::lib::${path.resolve(root, 'lib')}`,
-		].join('\n')
-
-		const { discoverGradleSubprojects } = await esmock('../../src/providers/java_gradle.js', {
-			'../../src/tools.js': {
-				resolveBinary: () => 'gradle',
-				invokeCommand: () => Buffer.from(initScriptOutput),
-			},
-		})
 		const result = await discoverGradleSubprojects(root, {
 			workspaceDiscoveryIgnore: ['**/lib/**'],
 		})


### PR DESCRIPTION
## Summary
- Discover subprojects in Gradle multi-project builds using a custom init script (`daListProjects`) that emits structured project listings
- Support Groovy (`build.gradle`) and Kotlin DSL (`build.gradle.kts`) variants with automatic detection
- Integrate `gradlew` wrapper detection via upward directory traversal, controlled by `TRUSTIFY_DA_PREFER_GRADLEW`
- Apply `workspaceDiscoveryIgnore` filtering to discovered subproject paths
- Add Gradle detection in `detectWorkspaceManifests()` between Maven and JavaScript

## Test plan
- [x] 7 new tests covering: no settings.gradle, multi-project, nested subprojects, mixed Groovy/Kotlin, single project, gradle failure fallback, ignore pattern filtering
- [x] All 25 workspace tests pass
- [x] ESLint clean

Jira: [TC-4261](https://redhat.atlassian.net/browse/TC-4261)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4261]: https://redhat.atlassian.net/browse/TC-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add Maven and Gradle multi-project workspace discovery and integrate them into automatic workspace manifest detection.

New Features:
- Discover Maven multi-module projects and collect all pom.xml manifests starting from a root pom.xml.
- Discover Gradle multi-project builds and collect all build.gradle and build.gradle.kts manifests using a custom init script.
- Expose Maven and Gradle workspace discovery functions from the public API.

Enhancements:
- Prefer Maven and Gradle wrapper binaries via configurable wrapper discovery when resolving build tools.
- Extend default workspace discovery ignore patterns to skip common Java build output and Gradle metadata directories.
- Update workspace manifest detection to recognize Maven and Gradle projects alongside existing Cargo and JavaScript ecosystems.

Tests:
- Add unit tests and fixture projects covering Maven module discovery, nested aggregators, failure handling, and ignore-pattern filtering.
- Add unit tests and fixture projects covering Gradle multi-project discovery, nested subprojects, mixed Groovy/Kotlin builds, failure handling, and ignore-pattern filtering.