### PR TITLE
feat(workspace): add uv workspace (pyproject.toml) discovery

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import { discoverMavenModules } from './providers/java_maven.js'
 import { discoverGradleSubprojects } from './providers/java_gradle.js'
 import { discoverGoWorkspaceModules } from './providers/golang_gomodules.js'
 import {
+	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -29,6 +30,7 @@ export {
 	discoverMavenModules,
 	discoverGradleSubprojects,
 	discoverGoWorkspaceModules,
+	discoverUvWorkspaceMembers,
 	discoverWorkspacePackages,
 	discoverWorkspaceCrates,
 	validatePackageJson,
@@ -89,7 +91,7 @@ export {
 /**
  * @typedef {{
  *   workspaceRoot: string,
- *   ecosystem: 'javascript' | 'cargo' | 'unknown',
+ *   ecosystem: 'javascript' | 'cargo' | 'pyproject' | 'unknown',
  *   total: number,
  *   successful: number,
  *   failed: number,
@@ -325,7 +327,7 @@ async function generateOneSbom(manifestPath, workspaceOpts) {
  *
  * @param {string} root - Resolved workspace root
  * @param {Options} opts
- * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'maven' | 'gradle' | 'gomodules' | 'unknown', manifestPaths: string[] }>}
+ * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'maven' | 'gradle' | 'gomodules' | 'pyproject' | 'unknown', manifestPaths: string[] }>}
  * @private
  */
 async function detectWorkspaceManifests(root, opts) {
@@ -358,6 +360,13 @@ async function detectWorkspaceManifests(root, opts) {
 		const manifestPaths = await discoverGoWorkspaceModules(root, opts)
 		if (manifestPaths.length > 0) {
 			return { ecosystem: 'gomodules', manifestPaths }
+		}
+	}
+
+	if (fs.existsSync(path.join(root, 'pyproject.toml')) && fs.existsSync(path.join(root, 'uv.lock'))) {
+		const manifestPaths = await discoverUvWorkspaceMembers(root, opts)
+		if (manifestPaths.length > 0) {
+			return { ecosystem: 'pyproject', manifestPaths }
 		}
 	}
 
@@ -556,7 +565,7 @@ async function stackAnalysisBatch(workspaceRoot, html = false, opts = {}) {
 	}
 
 	if (manifestPaths.length === 0) {
-		throw new Error(`No workspace manifests found at ${root}. Ensure a supported workspace root exists (Cargo.toml+Cargo.lock, go.work, or package.json+lock file).`)
+		throw new Error(`No workspace manifests found at ${root}. Ensure a supported workspace root exists (Cargo.toml+Cargo.lock, pom.xml, build.gradle, go.work, pyproject.toml+uv.lock, or package.json+lock file).`)
 	}
 
 	const workspaceOpts = { ...opts, TRUSTIFY_DA_WORKSPACE_DIR: root }

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,8 @@ import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
 import { discoverMavenModules } from './providers/java_maven.js'
 import { discoverGradleSubprojects } from './providers/java_gradle.js'
 import { discoverGoWorkspaceModules } from './providers/golang_gomodules.js'
+import { discoverUvWorkspaceMembers } from './providers/python_uv.js'
 import {
-	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,

--- a/src/providers/python_uv.js
+++ b/src/providers/python_uv.js
@@ -1,9 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import fg from 'fast-glob'
 import { parse as parseToml } from 'smol-toml'
 
 import { environmentVariableIsPopulated, getCustomPath, invokeCommand } from '../tools.js'
+import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_pyproject from './base_pyproject.js'
 import { evaluateMarker } from './marker_evaluator.js'
@@ -175,5 +177,100 @@ export default class Python_uv extends Base_pyproject {
 		}
 
 		return { directDeps, graph }
+	}
+}
+
+const DEFAULT_UV_DISCOVERY_IGNORE = [
+	'**/__pycache__/**',
+	'**/.venv/**',
+]
+
+/**
+ * Convert workspace glob patterns to manifest-file glob patterns,
+ * correctly handling negation prefixes.
+ *
+ * @param {string[]} patterns - Workspace glob patterns (may include negations)
+ * @param {string} manifestFileName - e.g. 'pyproject.toml'
+ * @returns {string[]}
+ */
+function toManifestGlobPatterns(patterns, manifestFileName) {
+	return patterns.map(p => {
+		if (p.startsWith('!')) {
+			return `!${p.slice(1)}/${manifestFileName}`
+		}
+		return `${p}/${manifestFileName}`
+	})
+}
+
+/**
+ * Discover all pyproject.toml manifest paths in a uv workspace.
+ * Parses `[tool.uv.workspace]` from root pyproject.toml and glob-expands member patterns.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pyproject.toml and uv.lock)
+ * @param {{ workspaceDiscoveryIgnore?: string[], TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE?: string, [key: string]: unknown }} [opts={}]
+ * @returns {Promise<string[]>} Paths to pyproject.toml files (absolute)
+ */
+export async function discoverUvWorkspaceMembers(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const rootPyproject = path.join(root, 'pyproject.toml')
+	const uvLock = path.join(root, 'uv.lock')
+
+	if (!fs.existsSync(rootPyproject) || !fs.existsSync(uvLock)) {
+		return []
+	}
+
+	let parsed
+	try {
+		parsed = parseToml(fs.readFileSync(rootPyproject, 'utf-8'))
+	} catch {
+		return []
+	}
+
+	const workspaceConfig = parsed?.tool?.uv?.workspace
+	if (!workspaceConfig) {
+		return []
+	}
+
+	const memberPatterns = workspaceConfig.members
+	if (!Array.isArray(memberPatterns) || memberPatterns.length === 0) {
+		return []
+	}
+
+	const excludePatterns = Array.isArray(workspaceConfig.exclude) ? workspaceConfig.exclude : []
+	const excludeGlobs = excludePatterns
+		.filter(p => typeof p === 'string' && p.trim())
+		.map(p => `${p.trim()}/pyproject.toml`)
+
+	const ignorePatterns = [...resolveWorkspaceDiscoveryIgnore(opts), ...DEFAULT_UV_DISCOVERY_IGNORE]
+	const globOpts = {
+		cwd: root,
+		absolute: true,
+		onlyFiles: true,
+		ignore: [...ignorePatterns, ...excludeGlobs],
+		followSymbolicLinks: false,
+	}
+
+	const patterns = toManifestGlobPatterns(
+		memberPatterns.filter(p => typeof p === 'string'),
+		'pyproject.toml',
+	)
+	const manifestPaths = await fg(patterns, globOpts)
+
+	if (!manifestPaths.includes(rootPyproject) && hasProjectMetadata(parsed)) {
+		manifestPaths.unshift(rootPyproject)
+	}
+
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * @param {import('smol-toml').TomlTable} parsedPyProject
+ * @returns {boolean}
+ */
+function hasProjectMetadata(parsedPyProject) {
+	try {
+		return typeof parsedPyProject?.project?.name === 'string' && parsedPyProject.project.name.trim() !== ''
+	} catch {
+		return false
 	}
 }

--- a/src/providers/python_uv.js
+++ b/src/providers/python_uv.js
@@ -5,7 +5,7 @@ import fg from 'fast-glob'
 import { parse as parseToml } from 'smol-toml'
 
 import { environmentVariableIsPopulated, getCustomPath, invokeCommand } from '../tools.js'
-import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
+import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore, toManifestGlobPatterns } from '../workspace.js'
 
 import Base_pyproject from './base_pyproject.js'
 import { evaluateMarker } from './marker_evaluator.js'
@@ -184,23 +184,6 @@ const DEFAULT_UV_DISCOVERY_IGNORE = [
 	'**/__pycache__/**',
 	'**/.venv/**',
 ]
-
-/**
- * Convert workspace glob patterns to manifest-file glob patterns,
- * correctly handling negation prefixes.
- *
- * @param {string[]} patterns - Workspace glob patterns (may include negations)
- * @param {string} manifestFileName - e.g. 'pyproject.toml'
- * @returns {string[]}
- */
-function toManifestGlobPatterns(patterns, manifestFileName) {
-	return patterns.map(p => {
-		if (p.startsWith('!')) {
-			return `!${p.slice(1)}/${manifestFileName}`
-		}
-		return `${p}/${manifestFileName}`
-	})
-}
 
 /**
  * Discover all pyproject.toml manifest paths in a uv workspace.

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -184,7 +184,7 @@ function parsePnpmPackages(content) {
  * @param {string} manifestFileName - e.g. 'package.json' or 'Cargo.toml'
  * @returns {string[]}
  */
-function toManifestGlobPatterns(patterns, manifestFileName) {
+export function toManifestGlobPatterns(patterns, manifestFileName) {
 	return patterns.map(p => {
 		if (p.startsWith('!')) {
 			return `!${p.slice(1)}/${manifestFileName}`

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -4,6 +4,7 @@ import path from 'node:path'
 import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
+import { parse as parseToml } from 'smol-toml'
 
 import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 
@@ -11,6 +12,8 @@ import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
+	'**/__pycache__/**',
+	'**/.venv/**',
 ]
 
 /**
@@ -268,4 +271,72 @@ export async function discoverWorkspaceCrates(workspaceRoot, opts = {}) {
 	}
 	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Discover all pyproject.toml manifest paths in a uv workspace.
+ * Parses `[tool.uv.workspace]` from root pyproject.toml and glob-expands member patterns.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pyproject.toml and uv.lock)
+ * @param {{ workspaceDiscoveryIgnore?: string[], TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE?: string, [key: string]: unknown }} [opts={}]
+ * @returns {Promise<string[]>} Paths to pyproject.toml files (absolute)
+ */
+export async function discoverUvWorkspaceMembers(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const rootPyproject = path.join(root, 'pyproject.toml')
+	const uvLock = path.join(root, 'uv.lock')
+
+	if (!fs.existsSync(rootPyproject) || !fs.existsSync(uvLock)) {
+		return []
+	}
+
+	let parsed
+	try {
+		parsed = parseToml(fs.readFileSync(rootPyproject, 'utf-8'))
+	} catch {
+		return []
+	}
+
+	const workspaceConfig = parsed?.tool?.uv?.workspace
+	if (!workspaceConfig) {
+		return []
+	}
+
+	const memberPatterns = workspaceConfig.members
+	if (!Array.isArray(memberPatterns) || memberPatterns.length === 0) {
+		return []
+	}
+
+	const excludePatterns = Array.isArray(workspaceConfig.exclude) ? workspaceConfig.exclude : []
+	const excludeGlobs = excludePatterns
+		.filter(p => typeof p === 'string' && p.trim())
+		.map(p => `${p.trim()}/pyproject.toml`)
+
+	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
+	const globOpts = buildWorkspaceDiscoveryGlobOptions(root, [...ignorePatterns, ...excludeGlobs])
+
+	const patterns = toManifestGlobPatterns(
+		memberPatterns.filter(p => typeof p === 'string'),
+		'pyproject.toml',
+	)
+	const manifestPaths = await fg(patterns, globOpts)
+
+	if (!manifestPaths.includes(rootPyproject) && hasProjectMetadata(rootPyproject)) {
+		manifestPaths.unshift(rootPyproject)
+	}
+
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * @param {string} pyprojectPath
+ * @returns {boolean}
+ */
+function hasProjectMetadata(pyprojectPath) {
+	try {
+		const content = parseToml(fs.readFileSync(pyprojectPath, 'utf-8'))
+		return typeof content?.project?.name === 'string' && content.project.name.trim() !== ''
+	} catch {
+		return false
+	}
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -4,7 +4,6 @@ import path from 'node:path'
 import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
-import { parse as parseToml } from 'smol-toml'
 
 import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 
@@ -12,8 +11,6 @@ import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
-	'**/__pycache__/**',
-	'**/.venv/**',
 ]
 
 /**
@@ -273,70 +270,3 @@ export async function discoverWorkspaceCrates(workspaceRoot, opts = {}) {
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
 }
 
-/**
- * Discover all pyproject.toml manifest paths in a uv workspace.
- * Parses `[tool.uv.workspace]` from root pyproject.toml and glob-expands member patterns.
- *
- * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pyproject.toml and uv.lock)
- * @param {{ workspaceDiscoveryIgnore?: string[], TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE?: string, [key: string]: unknown }} [opts={}]
- * @returns {Promise<string[]>} Paths to pyproject.toml files (absolute)
- */
-export async function discoverUvWorkspaceMembers(workspaceRoot, opts = {}) {
-	const root = path.resolve(workspaceRoot)
-	const rootPyproject = path.join(root, 'pyproject.toml')
-	const uvLock = path.join(root, 'uv.lock')
-
-	if (!fs.existsSync(rootPyproject) || !fs.existsSync(uvLock)) {
-		return []
-	}
-
-	let parsed
-	try {
-		parsed = parseToml(fs.readFileSync(rootPyproject, 'utf-8'))
-	} catch {
-		return []
-	}
-
-	const workspaceConfig = parsed?.tool?.uv?.workspace
-	if (!workspaceConfig) {
-		return []
-	}
-
-	const memberPatterns = workspaceConfig.members
-	if (!Array.isArray(memberPatterns) || memberPatterns.length === 0) {
-		return []
-	}
-
-	const excludePatterns = Array.isArray(workspaceConfig.exclude) ? workspaceConfig.exclude : []
-	const excludeGlobs = excludePatterns
-		.filter(p => typeof p === 'string' && p.trim())
-		.map(p => `${p.trim()}/pyproject.toml`)
-
-	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
-	const globOpts = buildWorkspaceDiscoveryGlobOptions(root, [...ignorePatterns, ...excludeGlobs])
-
-	const patterns = toManifestGlobPatterns(
-		memberPatterns.filter(p => typeof p === 'string'),
-		'pyproject.toml',
-	)
-	const manifestPaths = await fg(patterns, globOpts)
-
-	if (!manifestPaths.includes(rootPyproject) && hasProjectMetadata(rootPyproject)) {
-		manifestPaths.unshift(rootPyproject)
-	}
-
-	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-}
-
-/**
- * @param {string} pyprojectPath
- * @returns {boolean}
- */
-function hasProjectMetadata(pyprojectPath) {
-	try {
-		const content = parseToml(fs.readFileSync(pyprojectPath, 'utf-8'))
-		return typeof content?.project?.name === 'string' && content.project.name.trim() !== ''
-	} catch {
-		return false
-	}
-}

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/core/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/core/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "core"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/internal/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/internal/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "internal"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "exclude-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["packages/*"]
+exclude = ["packages/internal"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/apps/backend/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/apps/backend/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "backend"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/libs/core/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/libs/core/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "core"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "nested-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["apps/*", "libs/*"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/tst_manifests/pyproject/uv_workspace_no_config/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_no_config/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "no-config"
+version = "0.1.0"
+dependencies = ["requests>=2.0"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_no_config/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_no_config/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/tst_manifests/pyproject/uv_workspace_no_lock/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_no_lock/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "no-lock-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-a/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-a/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pkg-a"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-b/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-b/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pkg-b"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -7,8 +7,8 @@ import esmock from 'esmock'
 import { discoverGoWorkspaceModules } from '../../src/providers/golang_gomodules.js'
 import { discoverGradleSubprojects } from '../../src/providers/java_gradle.js'
 import { discoverMavenModules } from '../../src/providers/java_maven.js'
+import { discoverUvWorkspaceMembers } from '../../src/providers/python_uv.js'
 import {
-	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -8,6 +8,7 @@ import { discoverGoWorkspaceModules } from '../../src/providers/golang_gomodules
 import { discoverGradleSubprojects } from '../../src/providers/java_gradle.js'
 import { discoverMavenModules } from '../../src/providers/java_maven.js'
 import {
+	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -191,6 +192,73 @@ suite('discoverWorkspaceCrates', () => {
 	})
 })
 
+suite('discoverUvWorkspaceMembers', () => {
+	test('returns empty when no pyproject.toml at root', async () => {
+		const result = await discoverUvWorkspaceMembers('test/providers/tst_manifests/npm')
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('returns empty when pyproject.toml exists but no uv.lock', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_no_lock')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('returns empty when pyproject.toml has no [tool.uv.workspace]', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_no_config')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('discovers members from root-package workspace (includes root)', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result.every(p => p.endsWith('pyproject.toml'))).to.be.true
+		expect(result[0]).to.equal(path.join(root, 'pyproject.toml'))
+		expect(result.some(p => p.includes(path.join('packages', 'mid-pkg')))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'sub-pkg')))).to.be.true
+	})
+
+	test('discovers members from virtual workspace (excludes root)', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_virtual')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(2)
+		expect(result.every(p => p.endsWith('pyproject.toml'))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'pkg-a')))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'pkg-b')))).to.be.true
+		expect(result.every(p => p !== path.join(root, 'pyproject.toml'))).to.be.true
+	})
+
+	test('respects exclude patterns', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_exclude')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result.some(p => p.includes(path.join('packages', 'core')))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'internal')))).to.be.false
+	})
+
+	test('discovers members from multiple glob patterns', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_nested')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result.some(p => p.includes(path.join('apps', 'backend')))).to.be.true
+		expect(result.some(p => p.includes(path.join('libs', 'core')))).to.be.true
+	})
+
+	test('applies workspaceDiscoveryIgnore patterns', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_nested')
+		const result = await discoverUvWorkspaceMembers(root, {
+			workspaceDiscoveryIgnore: ['**/libs/**'],
+		})
+		expect(result.some(p => p.includes(path.join('apps', 'backend')))).to.be.true
+		expect(result.some(p => p.includes(path.join('libs', 'core')))).to.be.false
+	})
+})
 
 suite('discoverGradleSubprojects', () => {
 	test('returns empty when no settings.gradle at root', async () => {
@@ -198,7 +266,6 @@ suite('discoverGradleSubprojects', () => {
 		expect(result).to.be.an('array')
 		expect(result).to.have.lengthOf(0)
 	})
-
 	test('discovers multi-project build', async () => {
 		const root = path.resolve('test/providers/tst_manifests/gradle/gradle_multi_project')
 		const result = await discoverGradleSubprojects(root)


### PR DESCRIPTION
## Summary
- Add `discoverUvWorkspaceMembers()` for discovering workspace members in uv/Python monorepos
- Parses `pyproject.toml` for `[tool.uv.workspace]` member globs and resolves via `fast-glob` — no `uv` CLI needed
- Handles virtual workspaces (no `[project]` in root → exclude root) vs root-package workspaces (include root)
- Respects uv's `exclude` patterns and `TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE`
- Adds `__pycache__` and `.venv` to default ignore patterns
- Detection order: Cargo → Maven → Gradle → Go → **uv** → JavaScript

## Test plan
- [x] 8 new tests covering: no pyproject.toml, missing uv.lock, missing workspace config, root-package workspace, virtual workspace, exclude patterns, multiple glob patterns, ignore pattern filtering
- [x] All 42 workspace tests passing
- [x] ESLint clean

## Jira
TC-4265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend workspace manifest discovery to support additional ecosystems and uv-based Python monorepos.

New Features:
- Add Maven multi-module workspace discovery based on pom.xml and mvn project.modules.
- Add Gradle multi-project workspace discovery using an init script to list subprojects and their build files.
- Add Go workspace discovery using go.work metadata to locate module go.mod files.
- Add uv-based Python workspace discovery by parsing pyproject.toml [tool.uv.workspace] configuration and respecting uv.lock presence.

Enhancements:
- Broaden workspace detection to classify workspaces as Maven, Gradle, Go modules, or uv/pyproject in addition to Cargo and JavaScript.
- Extend default workspace discovery ignore patterns to cover common build and cache directories across ecosystems.
- Export new workspace discovery helpers from the public index for external use.
- Improve the batch analysis error message to reference all supported workspace types.

Tests:
- Add comprehensive unit tests and fixture projects for Maven, Gradle, Go, and uv workspace discovery, including edge cases, nested structures, wrapper preference, and ignore/exclude handling.