### PR TITLE
fix(go): remove directDepPaths filtering that drops direct dependencies

### DIFF
--- a/src/providers/golang_gomodules.js
+++ b/src/providers/golang_gomodules.js
@@ -249,15 +249,6 @@ async function getSBOM(manifest, opts = {}, includeTransitive) {
 	let rows = goGraphOutput.split(getLineSeparatorGolang()).filter(line => !line.includes(' go@'));
 	let root = goModEditOutput['Module']['Path']
 
-	// Build set of direct dependency paths from go mod edit -json
-	let directDepPaths = new Set()
-	if (goModEditOutput['Require']) {
-		goModEditOutput['Require'].forEach(req => {
-			if (!req['Indirect']) {
-				directDepPaths.add(req['Path'])
-			}
-		})
-	}
 	let matchManifestVersions = getCustom("MATCH_MANIFEST_VERSIONS", "false", opts);
 	if(matchManifestVersions === "true") {
 		performManifestVersionsCheck(root, rows, manifestContent, parser, requireQuery)
@@ -281,9 +272,6 @@ async function getSBOM(manifest, opts = {}, includeTransitive) {
 			}
 			let child = getChildVertexFromEdge(row)
 			let target = toPurl(child, "@");
-			if (getParentVertexFromEdge(row) === root && !directDepPaths.has(getPackageName(child))) {
-				return;
-			}
 			sbom.addDependency(source, target)
 
 		})
@@ -296,9 +284,7 @@ async function getSBOM(manifest, opts = {}, includeTransitive) {
 			let child = getChildVertexFromEdge(pair)
 			let target = toPurl(child, "@");
 			if(dependencyNotIgnored(ignoredDeps, target)) {
-				if (directDepPaths.has(getPackageName(child))) {
-					sbom.addDependency(mainModule, target)
-				}
+				sbom.addDependency(mainModule, target)
 			}
 		})
 		enforceRemovingIgnoredDepsInCaseOfAutomaticVersionUpdate(ignoredDeps, sbom)

--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -58,6 +58,15 @@ suite('testing the golang-go-modules data provider', () => {
 
 	});
 
+	test('verify go_mod_no_ignore component analysis includes all root-level deps from go mod graph', async () => {
+		let providedData = await golangGoModules.provideComponent('test/providers/tst_manifests/golang/go_mod_no_ignore/go.mod')
+		let sbom = JSON.parse(providedData.content)
+		let rootDeps = sbom.dependencies.find(d => d.dependsOn && d.dependsOn.length > 0)
+		expect(rootDeps.dependsOn).to.have.lengthOf(45,
+			'Component analysis should include all root-level edges from go mod graph as direct deps. ' +
+			'A lower count indicates the directDepPaths filtering is incorrectly excluding indirect require entries.')
+	}).timeout(process.env.GITHUB_ACTIONS ? 15000 : 10000);
+
 	[
 		"go_mod_mvs_versions"
 

--- a/test/providers/golang_gomodules.test.js
+++ b/test/providers/golang_gomodules.test.js
@@ -27,41 +27,26 @@ suite('testing the golang-go-modules data provider', () => {
 		"go_mod_empty"
 	].forEach(testCase => {
 		let scenario = testCase.replace('go_mod_', '').replaceAll('_', ' ')
-		test(`verify go.mod sbom provided for stack analysis with scenario ${scenario}`, async () => {
-			// load the expected graph for the scenario
-			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/golang/${testCase}/expected_sbom_stack_analysis.json`).toString()
-			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
-			// invoke sut stack analysis for scenario manifest
-			let providedDataForStack = await golangGoModules.provideStack(`test/providers/tst_manifests/golang/${testCase}/go.mod`)
-			// new(year: number, month: number, date?: number, hours?: number, minutes?: number, seconds?: number, ms?: number): Date
-
-			// providedDataForStack.content = providedDataForStack.content.replaceAll("\"timestamp\":\"[a-zA-Z0-9\\-\\:]+\"","")
-			// verify returned data matches expectation
-			expect(providedDataForStack.ecosystem).equal('golang')
-			expect(providedDataForStack.contentType).equal('application/vnd.cyclonedx+json')
-			expect(JSON.stringify(JSON.parse(providedDataForStack.content),null, 4).trim()).to.deep.equal(expectedSbom.trim())
-		// these test cases takes ~2500-2700 ms each pr >10000 in CI (for the first test-case)
-		}).timeout(process.env.GITHUB_ACTIONS ? 30000 : 10000)
-
-		test(`verify go.mod sbom provided for component analysis with scenario ${scenario}`, async () => {
-			// load the expected list for the scenario
-			let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/golang/${testCase}/expected_sbom_component_analysis.json`).toString().trimEnd()
-			expectedSbom = JSON.stringify(JSON.parse(expectedSbom),null, 4)
-			// invoke sut stack analysis for scenario manifest
-			let providedDataForComponent = await golangGoModules.provideComponent(`test/providers/tst_manifests/golang/${testCase}/go.mod`)
-			// verify returned data matches expectation
-			expect(providedDataForComponent.ecosystem).equal('golang')
-			expect(providedDataForComponent.contentType).equal('application/vnd.cyclonedx+json')
-			expect(JSON.stringify(JSON.parse(providedDataForComponent.content),null,4).trimEnd()).to.deep.equal(expectedSbom)
-			// these test cases takes ~1400-2000 ms each pr >10000 in CI (for the first test-case)
-		}).timeout(process.env.GITHUB_ACTIONS ? 15000 : 10000)
-
+		;[
+			{type: 'stack', method: 'provideStack', fixture: 'expected_sbom_stack_analysis.json', ciTimeout: 30000},
+			{type: 'component', method: 'provideComponent', fixture: 'expected_sbom_component_analysis.json', ciTimeout: 15000}
+		].forEach(({type, method, fixture, ciTimeout}) => {
+			test(`verify go.mod sbom provided for ${type} analysis with scenario ${scenario}`, async () => {
+				let expectedSbom = fs.readFileSync(`test/providers/tst_manifests/golang/${testCase}/${fixture}`).toString()
+				expectedSbom = JSON.stringify(JSON.parse(expectedSbom), null, 4)
+				let providedData = await golangGoModules[method](`test/providers/tst_manifests/golang/${testCase}/go.mod`)
+				expect(providedData.ecosystem).equal('golang')
+				expect(providedData.contentType).equal('application/vnd.cyclonedx+json')
+				expect(JSON.stringify(JSON.parse(providedData.content), null, 4).trimEnd()).to.deep.equal(expectedSbom.trimEnd())
+			}).timeout(process.env.GITHUB_ACTIONS ? ciTimeout : 10000)
+		})
 	});
 
 	test('verify go_mod_no_ignore component analysis includes all root-level deps from go mod graph', async () => {
 		let providedData = await golangGoModules.provideComponent('test/providers/tst_manifests/golang/go_mod_no_ignore/go.mod')
 		let sbom = JSON.parse(providedData.content)
-		let rootDeps = sbom.dependencies.find(d => d.dependsOn && d.dependsOn.length > 0)
+		let rootRef = sbom.metadata.component.purl
+		let rootDeps = sbom.dependencies.find(d => d.ref === rootRef)
 		expect(rootDeps.dependsOn).to.have.lengthOf(45,
 			'Component analysis should include all root-level edges from go mod graph as direct deps. ' +
 			'A lower count indicates the directDepPaths filtering is incorrectly excluding indirect require entries.')

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_component_analysis.json
@@ -29,6 +29,14 @@
             "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
         }
     ],
     "dependencies": [
@@ -36,7 +44,8 @@
             "ref": "pkg:golang/golang.org/x/example@v0.0.0",
             "dependsOn": [
                 "pkg:golang/github.com/spf13/cobra@v0.0.5",
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
             ]
         },
         {
@@ -45,6 +54,10 @@
         },
         {
             "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
             "dependsOn": []
         }
     ]

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
@@ -31,6 +31,14 @@
             "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
         },
         {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        },
+        {
             "group": "github.com/BurntSushi",
             "name": "toml",
             "version": "v0.3.1",
@@ -125,14 +133,6 @@
             "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "yaml.v3",
-            "version": "v3.0.1",
-            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
         },
         {
             "group": "gopkg.in",
@@ -316,7 +316,8 @@
             "ref": "pkg:golang/golang.org/x/example@v0.0.0",
             "dependsOn": [
                 "pkg:golang/github.com/spf13/cobra@v0.0.5",
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
             ]
         },
         {
@@ -339,6 +340,12 @@
                 "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
                 "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
                 "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
             ]
         },
         {
@@ -421,12 +428,6 @@
         {
             "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
             "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
-            ]
         },
         {
             "ref": "pkg:golang/gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",

--- a/test/providers/tst_manifests/golang/go_mod_mvs_versions/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_mvs_versions/expected_sbom_stack_analysis.json
@@ -15,12 +15,100 @@
     },
     "components": [
         {
+            "group": "github.com/davecgh",
+            "name": "go-spew",
+            "version": "v1.1.1",
+            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+        },
+        {
+            "group": "github.com/emicklei/go-restful",
+            "name": "v3",
+            "version": "v3.9.0",
+            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+        },
+        {
             "group": "github.com/gin-gonic",
             "name": "gin",
             "version": "v1.9.1",
             "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+        },
+        {
+            "group": "github.com/go-logr",
+            "name": "logr",
+            "version": "v1.2.3",
+            "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonpointer",
+            "version": "v0.19.5",
+            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonreference",
+            "version": "v0.20.0",
+            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "swag",
+            "version": "v0.19.14",
+            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+        },
+        {
+            "group": "github.com/gogo",
+            "name": "protobuf",
+            "version": "v1.3.2",
+            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "protobuf",
+            "version": "v1.5.2",
+            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gnostic",
+            "version": "v0.5.7-v3refs",
+            "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
+        },
+        {
+            "group": "github.com/google",
+            "name": "go-cmp",
+            "version": "v0.5.9",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gofuzz",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
         },
         {
             "group": "github.com/google",
@@ -31,12 +119,36 @@
             "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2"
         },
         {
+            "group": "github.com/imdario",
+            "name": "mergo",
+            "version": "v0.3.6",
+            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+        },
+        {
             "group": "github.com/jessevdk",
             "name": "go-flags",
             "version": "v1.5.0",
             "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
+        },
+        {
+            "group": "github.com/josharian",
+            "name": "intern",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
+        },
+        {
+            "group": "github.com/json-iterator",
+            "name": "go",
+            "version": "v1.1.12",
+            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
         },
         {
             "group": "github.com/kr",
@@ -47,12 +159,156 @@
             "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1"
         },
         {
+            "group": "github.com/kr",
+            "name": "text",
+            "version": "v0.2.0",
+            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
+        },
+        {
+            "group": "github.com/mailru",
+            "name": "easyjson",
+            "version": "v0.7.6",
+            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "concurrent",
+            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "reflect2",
+            "version": "v1.0.2",
+            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+        },
+        {
+            "group": "github.com/munnerz",
+            "name": "goautoneg",
+            "version": "v0.0.0-20191010083416-a7dc8b61c822",
+            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+        },
+        {
+            "group": "github.com/rogpeppe",
+            "name": "go-internal",
+            "version": "v1.9.0",
+            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+        },
+        {
+            "group": "github.com/spf13",
+            "name": "pflag",
+            "version": "v1.0.5",
+            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "net",
+            "version": "v0.10.0",
+            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "oauth2",
+            "version": "v0.0.0-20220223155221-ee480838109b",
+            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "term",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.9.0",
+            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "time",
+            "version": "v0.0.0-20220210224613-90d013bbcef8",
+            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "protobuf",
+            "version": "v1.30.0",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "inf.v0",
+            "version": "v0.9.1",
+            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+        },
+        {
             "group": "gopkg.in",
             "name": "yaml.v2",
             "version": "v2.4.0",
             "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "api",
+            "version": "v0.26.1",
+            "purl": "pkg:golang/k8s.io/api@v0.26.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
         },
         {
             "group": "k8s.io",
@@ -69,6 +325,54 @@
             "purl": "pkg:golang/k8s.io/client-go@v0.26.1",
             "type": "library",
             "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1"
+        },
+        {
+            "group": "k8s.io/klog",
+            "name": "v2",
+            "version": "v2.80.1",
+            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "kube-openapi",
+            "version": "v0.0.0-20221012153701-172d655c2280",
+            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+        },
+        {
+            "group": "k8s.io",
+            "name": "utils",
+            "version": "v0.0.0-20221107191617-1a15be271d1d",
+            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "json",
+            "version": "v0.0.0-20220713155537-f223a00ba0e2",
+            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+        },
+        {
+            "group": "sigs.k8s.io/structured-merge-diff",
+            "name": "v4",
+            "version": "v4.2.3",
+            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "yaml",
+            "version": "v1.3.0",
+            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         },
         {
             "group": "github.com/bytedance",
@@ -103,14 +407,6 @@
             "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2"
         },
         {
-            "group": "github.com/json-iterator",
-            "name": "go",
-            "version": "v1.1.12",
-            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
-        },
-        {
             "group": "github.com/mattn",
             "name": "go-isatty",
             "version": "v0.0.19",
@@ -143,44 +439,12 @@
             "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
         },
         {
-            "group": "golang.org/x",
-            "name": "net",
-            "version": "v0.10.0",
-            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
-        },
-        {
-            "group": "google.golang.org",
-            "name": "protobuf",
-            "version": "v1.30.0",
-            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "yaml.v3",
-            "version": "v3.0.1",
-            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-        },
-        {
             "group": "github.com/chenzhuoyu",
             "name": "base64x",
             "version": "v0.0.0-20221115062448-fe3a3abad311",
             "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-        },
-        {
-            "group": "github.com/davecgh",
-            "name": "go-spew",
-            "version": "v1.1.1",
-            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
         },
         {
             "group": "github.com/gabriel-vasile",
@@ -223,22 +487,6 @@
             "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
         },
         {
-            "group": "github.com/modern-go",
-            "name": "concurrent",
-            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-        },
-        {
-            "group": "github.com/modern-go",
-            "name": "reflect2",
-            "version": "v1.0.2",
-            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-        },
-        {
             "group": "github.com/pmezard",
             "name": "go-difflib",
             "version": "v1.0.0",
@@ -271,62 +519,6 @@
             "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0"
         },
         {
-            "group": "golang.org/x",
-            "name": "sys",
-            "version": "v0.8.0",
-            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "text",
-            "version": "v0.9.0",
-            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "jsonpointer",
-            "version": "v0.19.5",
-            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "swag",
-            "version": "v0.19.14",
-            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-        },
-        {
-            "group": "github.com/mailru",
-            "name": "easyjson",
-            "version": "v0.7.6",
-            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "jsonreference",
-            "version": "v0.20.0",
-            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-        },
-        {
-            "group": "github.com/kr",
-            "name": "text",
-            "version": "v0.2.0",
-            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
-        },
-        {
             "group": "github.com/niemeyer",
             "name": "pretty",
             "version": "v0.0.0-20200227124842-a10e7caefd8e",
@@ -341,14 +533,6 @@
             "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-        },
-        {
-            "group": "github.com/gogo",
-            "name": "protobuf",
-            "version": "v1.3.2",
-            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
         },
         {
             "group": "github.com/kisielk",
@@ -373,30 +557,6 @@
             "purl": "pkg:golang/golang.org/x/tools@v0.6.0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0"
-        },
-        {
-            "group": "github.com/golang",
-            "name": "protobuf",
-            "version": "v1.5.2",
-            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
-        },
-        {
-            "group": "github.com/google",
-            "name": "go-cmp",
-            "version": "v0.5.9",
-            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
-        },
-        {
-            "group": "github.com/google",
-            "name": "gnostic",
-            "version": "v0.5.7-v3refs",
-            "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
         },
         {
             "group": "github.com/docopt",
@@ -431,36 +591,12 @@
             "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
         },
         {
-            "group": "github.com/google",
-            "name": "gofuzz",
-            "version": "v1.1.0",
-            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
-        },
-        {
-            "group": "github.com/rogpeppe",
-            "name": "go-internal",
-            "version": "v1.9.0",
-            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-        },
-        {
             "group": "github.com/creack",
             "name": "pty",
             "version": "v1.1.9",
             "purl": "pkg:golang/github.com/creack/pty@v1.1.9",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9"
-        },
-        {
-            "group": "github.com/josharian",
-            "name": "intern",
-            "version": "v1.0.0",
-            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
         },
         {
             "group": "github.com/pkg",
@@ -471,22 +607,6 @@
             "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
         },
         {
-            "group": "golang.org/x",
-            "name": "term",
-            "version": "v0.8.0",
-            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "oauth2",
-            "version": "v0.0.0-20220223155221-ee480838109b",
-            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-        },
-        {
             "group": "cloud.google.com",
             "name": "go",
             "version": "v0.65.0",
@@ -495,92 +615,12 @@
             "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0"
         },
         {
-            "group": "google.golang.org",
-            "name": "appengine",
-            "version": "v1.6.7",
-            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
-        },
-        {
             "group": "golang.org/x",
             "name": "mod",
             "version": "v0.8.0",
             "purl": "pkg:golang/golang.org/x/mod@v0.8.0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0"
-        },
-        {
-            "group": "k8s.io",
-            "name": "api",
-            "version": "v0.26.1",
-            "purl": "pkg:golang/k8s.io/api@v0.26.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
-        },
-        {
-            "group": "github.com/go-logr",
-            "name": "logr",
-            "version": "v1.2.3",
-            "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3"
-        },
-        {
-            "group": "github.com/spf13",
-            "name": "pflag",
-            "version": "v1.0.5",
-            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "inf.v0",
-            "version": "v0.9.1",
-            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-        },
-        {
-            "group": "k8s.io/klog",
-            "name": "v2",
-            "version": "v2.80.1",
-            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
-        },
-        {
-            "group": "k8s.io",
-            "name": "utils",
-            "version": "v0.0.0-20221107191617-1a15be271d1d",
-            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-        },
-        {
-            "group": "sigs.k8s.io",
-            "name": "json",
-            "version": "v0.0.0-20220713155537-f223a00ba0e2",
-            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-        },
-        {
-            "group": "sigs.k8s.io/structured-merge-diff",
-            "name": "v4",
-            "version": "v4.2.3",
-            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-        },
-        {
-            "group": "sigs.k8s.io",
-            "name": "yaml",
-            "version": "v1.3.0",
-            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         },
         {
             "group": "github.com/armon",
@@ -623,14 +663,6 @@
             "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
         },
         {
-            "group": "k8s.io",
-            "name": "kube-openapi",
-            "version": "v0.0.0-20221012153701-172d655c2280",
-            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-        },
-        {
             "group": "github.com/onsi/ginkgo",
             "name": "v2",
             "version": "v2.4.0",
@@ -671,14 +703,6 @@
             "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
         },
         {
-            "group": "github.com/imdario",
-            "name": "mergo",
-            "version": "v0.3.6",
-            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
-        },
-        {
             "group": "github.com/peterbourgon",
             "name": "diskv",
             "version": "v2.0.1+incompatible",
@@ -687,36 +711,12 @@
             "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
         },
         {
-            "group": "golang.org/x",
-            "name": "time",
-            "version": "v0.0.0-20220210224613-90d013bbcef8",
-            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-        },
-        {
-            "group": "github.com/emicklei/go-restful",
-            "name": "v3",
-            "version": "v3.9.0",
-            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-        },
-        {
             "group": "github.com/google",
             "name": "btree",
             "version": "v1.0.1",
             "purl": "pkg:golang/github.com/google/btree@v1.0.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1"
-        },
-        {
-            "group": "github.com/munnerz",
-            "name": "goautoneg",
-            "version": "v0.0.0-20191010083416-a7dc8b61c822",
-            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
         },
         {
             "group": "github.com/NYTimes",
@@ -1122,14 +1122,60 @@
         {
             "ref": "pkg:golang/github.com/RHEcosystemAppEng/SaaSi/deployer@v0.0.0",
             "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
                 "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3",
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
                 "pkg:golang/github.com/google/uuid@v1.1.2",
+                "pkg:golang/github.com/imdario/mergo@v0.3.6",
                 "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+                "pkg:golang/github.com/josharian/intern@v1.0.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
                 "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+                "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
                 "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/api@v0.26.1",
                 "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/k8s.io/client-go@v0.26.1"
+                "pkg:golang/k8s.io/client-go@v0.26.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
+        },
+        {
+            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "dependsOn": []
         },
         {
             "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
@@ -1164,13 +1210,105 @@
             ]
         },
         {
+            "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "dependsOn": [
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "dependsOn": [
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3",
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/github.com/kr/pretty@v0.3.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "dependsOn": [
+                "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+                "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": [
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
             "dependsOn": []
         },
         {
             "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
             "dependsOn": [
                 "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
             ]
         },
         {
@@ -1181,9 +1319,143 @@
             ]
         },
         {
+            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+            "dependsOn": [
+                "pkg:golang/github.com/creack/pty@v1.1.9",
+                "pkg:golang/github.com/kr/pty@v1.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "dependsOn": [
+                "pkg:golang/github.com/josharian/intern@v1.0.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "dependsOn": [
+                "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+                "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/crypto@v0.9.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.65.0",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/crypto@v0.9.0",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "dependsOn": [
                 "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+            ]
+        },
+        {
+            "ref": "pkg:golang/k8s.io/api@v0.26.1",
+            "dependsOn": [
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3",
+                "pkg:golang/k8s.io/apimachinery@v0.26.1",
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
         },
         {
@@ -1282,470 +1554,10 @@
             ]
         },
         {
-            "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/stretchr/objx@v0.1.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/term@v0.8.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/crypto@v0.9.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-            ]
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/net@v0.10.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/golang.org/x/sys@v0.8.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-            "dependsOn": [
-                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/kr/text@v0.2.0",
-                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-                "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3",
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/github.com/kr/pretty@v0.3.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-            "dependsOn": [
-                "pkg:golang/github.com/josharian/intern@v1.0.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-            "dependsOn": [
-                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
-            "dependsOn": [
-                "pkg:golang/github.com/creack/pty@v1.1.9",
-                "pkg:golang/github.com/kr/pty@v1.1.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-            "dependsOn": [
-                "pkg:golang/github.com/kr/text@v0.2.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-            "dependsOn": [
-                "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-                "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-            "dependsOn": [
-                "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/appengine@v1.6.7"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "dependsOn": [
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/kr/pretty@v0.3.1",
-                "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-            "dependsOn": [
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/google.golang.org/grpc@v1.31.0",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-            "dependsOn": [
-                "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-                "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go@v0.65.0",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-                "pkg:golang/github.com/golang/mock@v1.4.4",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/github.com/google/martian/v3@v3.0.0",
-                "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-                "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-                "pkg:golang/go.opencensus.io@v0.22.4",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/api@v0.30.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-                "pkg:golang/google.golang.org/grpc@v1.31.0",
-                "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-                "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-                "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-                "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/github.com/google/btree@v1.0.1",
-                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-                "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/crypto@v0.9.0",
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/crypto@v0.9.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/k8s.io/api@v0.26.1",
-            "dependsOn": [
-                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3",
-                "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/go-logr/logr@v1.2.3",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/json-iterator/go@v1.1.12",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/spf13/pflag@v1.0.5",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/k8s.io/klog/v2@v2.80.1",
-                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
             "dependsOn": [
                 "pkg:golang/github.com/go-logr/logr@v1.2.3"
             ]
-        },
-        {
-            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/k8s.io/klog/v2@v2.80.1",
-                "pkg:golang/github.com/go-logr/logr@v1.2.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/json-iterator/go@v1.1.12",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-            ]
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-            "dependsOn": []
         },
         {
             "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
@@ -1793,6 +1605,248 @@
             ]
         },
         {
+            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+            ]
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/stretchr/objx@v0.1.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/net@v0.10.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+            "dependsOn": [
+                "pkg:golang/github.com/kr/text@v0.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+            "dependsOn": [
+                "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/appengine@v1.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+            "dependsOn": [
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/google.golang.org/grpc@v1.31.0",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+                "pkg:golang/github.com/golang/mock@v1.4.4",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/martian/v3@v3.0.0",
+                "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+                "pkg:golang/go.opencensus.io@v0.22.4",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/api@v0.30.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+                "pkg:golang/google.golang.org/grpc@v1.31.0",
+                "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+                "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+                "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+                "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/github.com/google/btree@v1.0.1",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/crypto@v0.9.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
             "dependsOn": []
         },
@@ -1813,27 +1867,11 @@
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/google/btree@v1.0.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
             "dependsOn": []
         },
         {

--- a/test/providers/tst_manifests/golang/go_mod_no_ignore/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_no_ignore/expected_sbom_component_analysis.json
@@ -15,12 +15,100 @@
     },
     "components": [
         {
+            "group": "github.com/davecgh",
+            "name": "go-spew",
+            "version": "v1.1.1",
+            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+        },
+        {
+            "group": "github.com/emicklei/go-restful",
+            "name": "v3",
+            "version": "v3.9.0",
+            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+        },
+        {
             "group": "github.com/gin-gonic",
             "name": "gin",
             "version": "v1.9.1",
             "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+        },
+        {
+            "group": "github.com/go-logr",
+            "name": "logr",
+            "version": "v1.2.3",
+            "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonpointer",
+            "version": "v0.19.5",
+            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonreference",
+            "version": "v0.20.0",
+            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "swag",
+            "version": "v0.19.14",
+            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+        },
+        {
+            "group": "github.com/gogo",
+            "name": "protobuf",
+            "version": "v1.3.2",
+            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "protobuf",
+            "version": "v1.5.2",
+            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gnostic",
+            "version": "v0.5.7-v3refs",
+            "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
+        },
+        {
+            "group": "github.com/google",
+            "name": "go-cmp",
+            "version": "v0.5.9",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gofuzz",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
         },
         {
             "group": "github.com/google",
@@ -31,12 +119,36 @@
             "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2"
         },
         {
+            "group": "github.com/imdario",
+            "name": "mergo",
+            "version": "v0.3.6",
+            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+        },
+        {
             "group": "github.com/jessevdk",
             "name": "go-flags",
             "version": "v1.5.0",
             "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
+        },
+        {
+            "group": "github.com/josharian",
+            "name": "intern",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
+        },
+        {
+            "group": "github.com/json-iterator",
+            "name": "go",
+            "version": "v1.1.12",
+            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
         },
         {
             "group": "github.com/kr",
@@ -47,12 +159,156 @@
             "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1"
         },
         {
+            "group": "github.com/kr",
+            "name": "text",
+            "version": "v0.2.0",
+            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
+        },
+        {
+            "group": "github.com/mailru",
+            "name": "easyjson",
+            "version": "v0.7.6",
+            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "concurrent",
+            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "reflect2",
+            "version": "v1.0.2",
+            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+        },
+        {
+            "group": "github.com/munnerz",
+            "name": "goautoneg",
+            "version": "v0.0.0-20191010083416-a7dc8b61c822",
+            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+        },
+        {
+            "group": "github.com/rogpeppe",
+            "name": "go-internal",
+            "version": "v1.9.0",
+            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+        },
+        {
+            "group": "github.com/spf13",
+            "name": "pflag",
+            "version": "v1.0.5",
+            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "net",
+            "version": "v0.10.0",
+            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "oauth2",
+            "version": "v0.0.0-20220223155221-ee480838109b",
+            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "term",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.9.0",
+            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "time",
+            "version": "v0.0.0-20220210224613-90d013bbcef8",
+            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "protobuf",
+            "version": "v1.30.0",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "inf.v0",
+            "version": "v0.9.1",
+            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+        },
+        {
             "group": "gopkg.in",
             "name": "yaml.v2",
             "version": "v2.4.0",
             "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "api",
+            "version": "v0.26.1",
+            "purl": "pkg:golang/k8s.io/api@v0.26.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
         },
         {
             "group": "k8s.io",
@@ -69,23 +325,153 @@
             "purl": "pkg:golang/k8s.io/client-go@v0.26.1",
             "type": "library",
             "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1"
+        },
+        {
+            "group": "k8s.io/klog",
+            "name": "v2",
+            "version": "v2.80.1",
+            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "kube-openapi",
+            "version": "v0.0.0-20221012153701-172d655c2280",
+            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+        },
+        {
+            "group": "k8s.io",
+            "name": "utils",
+            "version": "v0.0.0-20221107191617-1a15be271d1d",
+            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "json",
+            "version": "v0.0.0-20220713155537-f223a00ba0e2",
+            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+        },
+        {
+            "group": "sigs.k8s.io/structured-merge-diff",
+            "name": "v4",
+            "version": "v4.2.3",
+            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "yaml",
+            "version": "v1.3.0",
+            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         }
     ],
     "dependencies": [
         {
             "ref": "pkg:golang/github.com/RHEcosystemAppEng/SaaSi/deployer@v0.0.0",
             "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
                 "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3",
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
                 "pkg:golang/github.com/google/uuid@v1.1.2",
+                "pkg:golang/github.com/imdario/mergo@v0.3.6",
                 "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+                "pkg:golang/github.com/josharian/intern@v1.0.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
                 "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+                "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
                 "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/api@v0.26.1",
                 "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/k8s.io/client-go@v0.26.1"
+                "pkg:golang/k8s.io/client-go@v0.26.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
         },
         {
+            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
             "dependsOn": []
         },
         {
@@ -93,7 +479,19 @@
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
             "dependsOn": []
         },
         {
@@ -101,7 +499,79 @@
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/api@v0.26.1",
             "dependsOn": []
         },
         {
@@ -110,6 +580,30 @@
         },
         {
             "ref": "pkg:golang/k8s.io/client-go@v0.26.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
             "dependsOn": []
         }
     ]

--- a/test/providers/tst_manifests/golang/go_mod_no_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_no_ignore/expected_sbom_stack_analysis.json
@@ -15,12 +15,100 @@
     },
     "components": [
         {
+            "group": "github.com/davecgh",
+            "name": "go-spew",
+            "version": "v1.1.1",
+            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+        },
+        {
+            "group": "github.com/emicklei/go-restful",
+            "name": "v3",
+            "version": "v3.9.0",
+            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+        },
+        {
             "group": "github.com/gin-gonic",
             "name": "gin",
             "version": "v1.9.1",
             "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+        },
+        {
+            "group": "github.com/go-logr",
+            "name": "logr",
+            "version": "v1.2.3",
+            "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonpointer",
+            "version": "v0.19.5",
+            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonreference",
+            "version": "v0.20.0",
+            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "swag",
+            "version": "v0.19.14",
+            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+        },
+        {
+            "group": "github.com/gogo",
+            "name": "protobuf",
+            "version": "v1.3.2",
+            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "protobuf",
+            "version": "v1.5.2",
+            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gnostic",
+            "version": "v0.5.7-v3refs",
+            "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
+        },
+        {
+            "group": "github.com/google",
+            "name": "go-cmp",
+            "version": "v0.5.9",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gofuzz",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
         },
         {
             "group": "github.com/google",
@@ -31,12 +119,36 @@
             "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2"
         },
         {
+            "group": "github.com/imdario",
+            "name": "mergo",
+            "version": "v0.3.6",
+            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+        },
+        {
             "group": "github.com/jessevdk",
             "name": "go-flags",
             "version": "v1.5.0",
             "purl": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0"
+        },
+        {
+            "group": "github.com/josharian",
+            "name": "intern",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
+        },
+        {
+            "group": "github.com/json-iterator",
+            "name": "go",
+            "version": "v1.1.12",
+            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
         },
         {
             "group": "github.com/kr",
@@ -47,12 +159,156 @@
             "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1"
         },
         {
+            "group": "github.com/kr",
+            "name": "text",
+            "version": "v0.2.0",
+            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
+        },
+        {
+            "group": "github.com/mailru",
+            "name": "easyjson",
+            "version": "v0.7.6",
+            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "concurrent",
+            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "reflect2",
+            "version": "v1.0.2",
+            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+        },
+        {
+            "group": "github.com/munnerz",
+            "name": "goautoneg",
+            "version": "v0.0.0-20191010083416-a7dc8b61c822",
+            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+        },
+        {
+            "group": "github.com/rogpeppe",
+            "name": "go-internal",
+            "version": "v1.9.0",
+            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+        },
+        {
+            "group": "github.com/spf13",
+            "name": "pflag",
+            "version": "v1.0.5",
+            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "net",
+            "version": "v0.10.0",
+            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "oauth2",
+            "version": "v0.0.0-20220223155221-ee480838109b",
+            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "term",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.9.0",
+            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "time",
+            "version": "v0.0.0-20220210224613-90d013bbcef8",
+            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "protobuf",
+            "version": "v1.30.0",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "inf.v0",
+            "version": "v0.9.1",
+            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+        },
+        {
             "group": "gopkg.in",
             "name": "yaml.v2",
             "version": "v2.4.0",
             "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "api",
+            "version": "v0.26.1",
+            "purl": "pkg:golang/k8s.io/api@v0.26.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
         },
         {
             "group": "k8s.io",
@@ -69,6 +325,54 @@
             "purl": "pkg:golang/k8s.io/client-go@v0.26.1",
             "type": "library",
             "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1"
+        },
+        {
+            "group": "k8s.io/klog",
+            "name": "v2",
+            "version": "v2.80.1",
+            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "kube-openapi",
+            "version": "v0.0.0-20221012153701-172d655c2280",
+            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+        },
+        {
+            "group": "k8s.io",
+            "name": "utils",
+            "version": "v0.0.0-20221107191617-1a15be271d1d",
+            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "json",
+            "version": "v0.0.0-20220713155537-f223a00ba0e2",
+            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+        },
+        {
+            "group": "sigs.k8s.io/structured-merge-diff",
+            "name": "v4",
+            "version": "v4.2.3",
+            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "yaml",
+            "version": "v1.3.0",
+            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         },
         {
             "group": "github.com/bytedance",
@@ -103,14 +407,6 @@
             "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2"
         },
         {
-            "group": "github.com/json-iterator",
-            "name": "go",
-            "version": "v1.1.12",
-            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
-        },
-        {
             "group": "github.com/mattn",
             "name": "go-isatty",
             "version": "v0.0.19",
@@ -143,44 +439,12 @@
             "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
         },
         {
-            "group": "golang.org/x",
-            "name": "net",
-            "version": "v0.10.0",
-            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
-        },
-        {
-            "group": "google.golang.org",
-            "name": "protobuf",
-            "version": "v1.30.0",
-            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "yaml.v3",
-            "version": "v3.0.1",
-            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-        },
-        {
             "group": "github.com/chenzhuoyu",
             "name": "base64x",
             "version": "v0.0.0-20221115062448-fe3a3abad311",
             "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-        },
-        {
-            "group": "github.com/davecgh",
-            "name": "go-spew",
-            "version": "v1.1.1",
-            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
         },
         {
             "group": "github.com/gabriel-vasile",
@@ -223,22 +487,6 @@
             "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
         },
         {
-            "group": "github.com/modern-go",
-            "name": "concurrent",
-            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-        },
-        {
-            "group": "github.com/modern-go",
-            "name": "reflect2",
-            "version": "v1.0.2",
-            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-        },
-        {
             "group": "github.com/pmezard",
             "name": "go-difflib",
             "version": "v1.0.0",
@@ -271,62 +519,6 @@
             "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0"
         },
         {
-            "group": "golang.org/x",
-            "name": "sys",
-            "version": "v0.8.0",
-            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "text",
-            "version": "v0.9.0",
-            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "jsonpointer",
-            "version": "v0.19.5",
-            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "swag",
-            "version": "v0.19.14",
-            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-        },
-        {
-            "group": "github.com/mailru",
-            "name": "easyjson",
-            "version": "v0.7.6",
-            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "jsonreference",
-            "version": "v0.20.0",
-            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-        },
-        {
-            "group": "github.com/kr",
-            "name": "text",
-            "version": "v0.2.0",
-            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
-        },
-        {
             "group": "github.com/niemeyer",
             "name": "pretty",
             "version": "v0.0.0-20200227124842-a10e7caefd8e",
@@ -341,14 +533,6 @@
             "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-        },
-        {
-            "group": "github.com/gogo",
-            "name": "protobuf",
-            "version": "v1.3.2",
-            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
         },
         {
             "group": "github.com/kisielk",
@@ -373,30 +557,6 @@
             "purl": "pkg:golang/golang.org/x/tools@v0.6.0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0"
-        },
-        {
-            "group": "github.com/golang",
-            "name": "protobuf",
-            "version": "v1.5.2",
-            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
-        },
-        {
-            "group": "github.com/google",
-            "name": "go-cmp",
-            "version": "v0.5.9",
-            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
-        },
-        {
-            "group": "github.com/google",
-            "name": "gnostic",
-            "version": "v0.5.7-v3refs",
-            "purl": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs"
         },
         {
             "group": "github.com/docopt",
@@ -431,36 +591,12 @@
             "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
         },
         {
-            "group": "github.com/google",
-            "name": "gofuzz",
-            "version": "v1.1.0",
-            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
-        },
-        {
-            "group": "github.com/rogpeppe",
-            "name": "go-internal",
-            "version": "v1.9.0",
-            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-        },
-        {
             "group": "github.com/creack",
             "name": "pty",
             "version": "v1.1.9",
             "purl": "pkg:golang/github.com/creack/pty@v1.1.9",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9"
-        },
-        {
-            "group": "github.com/josharian",
-            "name": "intern",
-            "version": "v1.0.0",
-            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
         },
         {
             "group": "github.com/pkg",
@@ -471,22 +607,6 @@
             "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
         },
         {
-            "group": "golang.org/x",
-            "name": "term",
-            "version": "v0.8.0",
-            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "oauth2",
-            "version": "v0.0.0-20220223155221-ee480838109b",
-            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-        },
-        {
             "group": "cloud.google.com",
             "name": "go",
             "version": "v0.65.0",
@@ -495,92 +615,12 @@
             "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0"
         },
         {
-            "group": "google.golang.org",
-            "name": "appengine",
-            "version": "v1.6.7",
-            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
-        },
-        {
             "group": "golang.org/x",
             "name": "mod",
             "version": "v0.8.0",
             "purl": "pkg:golang/golang.org/x/mod@v0.8.0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0"
-        },
-        {
-            "group": "k8s.io",
-            "name": "api",
-            "version": "v0.26.1",
-            "purl": "pkg:golang/k8s.io/api@v0.26.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
-        },
-        {
-            "group": "github.com/go-logr",
-            "name": "logr",
-            "version": "v1.2.3",
-            "purl": "pkg:golang/github.com/go-logr/logr@v1.2.3",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-logr/logr@v1.2.3"
-        },
-        {
-            "group": "github.com/spf13",
-            "name": "pflag",
-            "version": "v1.0.5",
-            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "inf.v0",
-            "version": "v0.9.1",
-            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-        },
-        {
-            "group": "k8s.io/klog",
-            "name": "v2",
-            "version": "v2.80.1",
-            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
-        },
-        {
-            "group": "k8s.io",
-            "name": "utils",
-            "version": "v0.0.0-20221107191617-1a15be271d1d",
-            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-        },
-        {
-            "group": "sigs.k8s.io",
-            "name": "json",
-            "version": "v0.0.0-20220713155537-f223a00ba0e2",
-            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-        },
-        {
-            "group": "sigs.k8s.io/structured-merge-diff",
-            "name": "v4",
-            "version": "v4.2.3",
-            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-        },
-        {
-            "group": "sigs.k8s.io",
-            "name": "yaml",
-            "version": "v1.3.0",
-            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         },
         {
             "group": "github.com/armon",
@@ -623,14 +663,6 @@
             "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
         },
         {
-            "group": "k8s.io",
-            "name": "kube-openapi",
-            "version": "v0.0.0-20221012153701-172d655c2280",
-            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-        },
-        {
             "group": "github.com/onsi/ginkgo",
             "name": "v2",
             "version": "v2.4.0",
@@ -671,14 +703,6 @@
             "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
         },
         {
-            "group": "github.com/imdario",
-            "name": "mergo",
-            "version": "v0.3.6",
-            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
-        },
-        {
             "group": "github.com/peterbourgon",
             "name": "diskv",
             "version": "v2.0.1+incompatible",
@@ -687,36 +711,12 @@
             "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
         },
         {
-            "group": "golang.org/x",
-            "name": "time",
-            "version": "v0.0.0-20220210224613-90d013bbcef8",
-            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-        },
-        {
-            "group": "github.com/emicklei/go-restful",
-            "name": "v3",
-            "version": "v3.9.0",
-            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-        },
-        {
             "group": "github.com/google",
             "name": "btree",
             "version": "v1.0.1",
             "purl": "pkg:golang/github.com/google/btree@v1.0.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1"
-        },
-        {
-            "group": "github.com/munnerz",
-            "name": "goautoneg",
-            "version": "v0.0.0-20191010083416-a7dc8b61c822",
-            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
         },
         {
             "group": "github.com/NYTimes",
@@ -1122,14 +1122,60 @@
         {
             "ref": "pkg:golang/github.com/RHEcosystemAppEng/SaaSi/deployer@v0.0.0",
             "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
                 "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3",
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
                 "pkg:golang/github.com/google/uuid@v1.1.2",
+                "pkg:golang/github.com/imdario/mergo@v0.3.6",
                 "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
+                "pkg:golang/github.com/josharian/intern@v1.0.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
                 "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+                "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
                 "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/api@v0.26.1",
                 "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/k8s.io/client-go@v0.26.1"
+                "pkg:golang/k8s.io/client-go@v0.26.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
+        },
+        {
+            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "dependsOn": []
         },
         {
             "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
@@ -1164,13 +1210,105 @@
             ]
         },
         {
+            "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "dependsOn": [
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "dependsOn": [
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3",
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/github.com/kr/pretty@v0.3.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "dependsOn": [
+                "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+                "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": [
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
             "dependsOn": []
         },
         {
             "ref": "pkg:golang/github.com/jessevdk/go-flags@v1.5.0",
             "dependsOn": [
                 "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
             ]
         },
         {
@@ -1181,9 +1319,143 @@
             ]
         },
         {
+            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+            "dependsOn": [
+                "pkg:golang/github.com/creack/pty@v1.1.9",
+                "pkg:golang/github.com/kr/pty@v1.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "dependsOn": [
+                "pkg:golang/github.com/josharian/intern@v1.0.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "dependsOn": [
+                "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+                "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/crypto@v0.9.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.65.0",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/crypto@v0.9.0",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "dependsOn": [
                 "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+            ]
+        },
+        {
+            "ref": "pkg:golang/k8s.io/api@v0.26.1",
+            "dependsOn": [
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3",
+                "pkg:golang/k8s.io/apimachinery@v0.26.1",
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
         },
         {
@@ -1282,470 +1554,10 @@
             ]
         },
         {
-            "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/stretchr/objx@v0.1.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/term@v0.8.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/crypto@v0.9.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-            ]
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/net@v0.10.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/golang.org/x/sys@v0.8.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-            "dependsOn": [
-                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/kr/text@v0.2.0",
-                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-                "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3",
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/github.com/kr/pretty@v0.3.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-            "dependsOn": [
-                "pkg:golang/github.com/josharian/intern@v1.0.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-            "dependsOn": [
-                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
-            "dependsOn": [
-                "pkg:golang/github.com/creack/pty@v1.1.9",
-                "pkg:golang/github.com/kr/pty@v1.1.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-            "dependsOn": [
-                "pkg:golang/github.com/kr/text@v0.2.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-            "dependsOn": [
-                "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-                "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-            "dependsOn": [
-                "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/appengine@v1.6.7"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "dependsOn": [
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/gnostic@v0.5.7-v3refs",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/kr/pretty@v0.3.1",
-                "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-            "dependsOn": [
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/google.golang.org/grpc@v1.31.0",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-            "dependsOn": [
-                "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-                "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go@v0.65.0",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-                "pkg:golang/github.com/golang/mock@v1.4.4",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/github.com/google/martian/v3@v3.0.0",
-                "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-                "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-                "pkg:golang/go.opencensus.io@v0.22.4",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/api@v0.30.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-                "pkg:golang/google.golang.org/grpc@v1.31.0",
-                "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-                "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-                "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-                "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/github.com/google/btree@v1.0.1",
-                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-                "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/crypto@v0.9.0",
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/crypto@v0.9.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/k8s.io/api@v0.26.1",
-            "dependsOn": [
-                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3",
-                "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/go-logr/logr@v1.2.3",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/json-iterator/go@v1.1.12",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/spf13/pflag@v1.0.5",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/k8s.io/klog/v2@v2.80.1",
-                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-logr/logr@v1.2.3",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
             "dependsOn": [
                 "pkg:golang/github.com/go-logr/logr@v1.2.3"
             ]
-        },
-        {
-            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/k8s.io/klog/v2@v2.80.1",
-                "pkg:golang/github.com/go-logr/logr@v1.2.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/json-iterator/go@v1.1.12",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-            ]
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
-            "dependsOn": []
         },
         {
             "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
@@ -1793,6 +1605,248 @@
             ]
         },
         {
+            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/github.com/go-logr/logr@v1.2.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+            ]
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/stretchr/objx@v0.1.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/net@v0.10.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+            "dependsOn": [
+                "pkg:golang/github.com/kr/text@v0.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+            "dependsOn": [
+                "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/appengine@v1.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+            "dependsOn": [
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/google.golang.org/grpc@v1.31.0",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+                "pkg:golang/github.com/golang/mock@v1.4.4",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/martian/v3@v3.0.0",
+                "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+                "pkg:golang/go.opencensus.io@v0.22.4",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/api@v0.30.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+                "pkg:golang/google.golang.org/grpc@v1.31.0",
+                "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+                "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+                "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+                "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/github.com/google/btree@v1.0.1",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/crypto@v0.9.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
             "dependsOn": []
         },
@@ -1813,27 +1867,11 @@
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/google/btree@v1.0.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
             "dependsOn": []
         },
         {

--- a/test/providers/tst_manifests/golang/go_mod_test_ignore/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_test_ignore/expected_sbom_component_analysis.json
@@ -15,12 +15,44 @@
     },
     "components": [
         {
+            "group": "cloud.google.com",
+            "name": "go",
+            "version": "v0.100.2",
+            "purl": "pkg:golang/cloud.google.com/go@v0.100.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go@v0.100.2"
+        },
+        {
+            "group": "cloud.google.com/go",
+            "name": "compute",
+            "version": "v1.6.1",
+            "purl": "pkg:golang/cloud.google.com/go/compute@v1.6.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go/compute@v1.6.1"
+        },
+        {
+            "group": "cloud.google.com/go",
+            "name": "monitoring",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0"
+        },
+        {
             "group": "cloud.google.com/go",
             "name": "profiler",
             "version": "v0.3.0",
             "purl": "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
             "type": "library",
             "bom-ref": "pkg:golang/cloud.google.com/go/profiler@v0.3.0"
+        },
+        {
+            "group": "cloud.google.com/go",
+            "name": "trace",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/cloud.google.com/go/trace@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go/trace@v1.0.0"
         },
         {
             "group": "contrib.go.opencensus.io/exporter",
@@ -39,12 +71,92 @@
             "bom-ref": "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12"
         },
         {
+            "group": "github.com/aws",
+            "name": "aws-sdk-go",
+            "version": "v1.43.31",
+            "purl": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31"
+        },
+        {
+            "group": "github.com/census-instrumentation",
+            "name": "opencensus-proto",
+            "version": "v0.3.0",
+            "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0"
+        },
+        {
+            "group": "github.com/cespare",
+            "name": "xxhash",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0"
+        },
+        {
+            "group": "github.com/cncf/udpa",
+            "name": "go",
+            "version": "v0.0.0-20210930031921-04548b0d99d4",
+            "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4"
+        },
+        {
+            "group": "github.com/cncf/xds",
+            "name": "go",
+            "version": "v0.0.0-20211011173535-cb28da3451f1",
+            "purl": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1"
+        },
+        {
+            "group": "github.com/envoyproxy",
+            "name": "go-control-plane",
+            "version": "v0.10.2-0.20220325020618-49ff273808a1",
+            "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1"
+        },
+        {
+            "group": "github.com/envoyproxy",
+            "name": "protoc-gen-validate",
+            "version": "v0.1.0",
+            "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "groupcache",
+            "version": "v0.0.0-20210331224755-41bb18bfe9da",
+            "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+        },
+        {
             "group": "github.com/golang",
             "name": "protobuf",
             "version": "v1.5.2",
             "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+        },
+        {
+            "group": "github.com/google",
+            "name": "go-cmp",
+            "version": "v0.5.8",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.8",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.8"
+        },
+        {
+            "group": "github.com/google",
+            "name": "pprof",
+            "version": "v0.0.0-20220412212628-83db2b799d1f",
+            "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f"
         },
         {
             "group": "github.com/google",
@@ -55,12 +167,44 @@
             "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0"
         },
         {
+            "group": "github.com/googleapis/gax-go",
+            "name": "v2",
+            "version": "v2.4.0",
+            "purl": "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0"
+        },
+        {
+            "group": "github.com/jmespath",
+            "name": "go-jmespath",
+            "version": "v0.4.0",
+            "purl": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0"
+        },
+        {
+            "group": "github.com/prometheus",
+            "name": "prometheus",
+            "version": "v2.5.0+incompatible",
+            "purl": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible"
+        },
+        {
             "group": "github.com/sirupsen",
             "name": "logrus",
             "version": "v1.8.1",
             "purl": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1"
+        },
+        {
+            "group": "github.com/uber",
+            "name": "jaeger-client-go",
+            "version": "v2.25.0+incompatible",
+            "purl": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible"
         },
         {
             "group": "golang.org/x",
@@ -71,30 +215,127 @@
             "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b"
         },
         {
+            "group": "golang.org/x",
+            "name": "oauth2",
+            "version": "v0.0.0-20220411215720-9780585627b5",
+            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sync",
+            "version": "v0.0.0-20210220032951-036812b2e83c",
+            "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.3.7",
+            "purl": "pkg:golang/golang.org/x/text@v0.3.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.3.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "api",
+            "version": "v0.78.0",
+            "purl": "pkg:golang/google.golang.org/api@v0.78.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/api@v0.78.0"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "genproto",
+            "version": "v0.0.0-20220518221133-4f43b3371335",
+            "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335"
+        },
+        {
             "group": "google.golang.org",
             "name": "grpc",
             "version": "v1.48.0",
             "purl": "pkg:golang/google.golang.org/grpc@v1.48.0",
             "type": "library",
             "bom-ref": "pkg:golang/google.golang.org/grpc@v1.48.0"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "protobuf",
+            "version": "v1.28.0",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.28.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.28.0"
         }
     ],
     "dependencies": [
         {
             "ref": "pkg:golang/github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice@v0.0.0",
             "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.100.2",
+                "pkg:golang/cloud.google.com/go/compute@v1.6.1",
+                "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
                 "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
+                "pkg:golang/cloud.google.com/go/trace@v1.0.0",
                 "pkg:golang/contrib.go.opencensus.io/exporter/jaeger@v0.2.1",
                 "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12",
+                "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
+                "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+                "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+                "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
+                "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+                "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
+                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
                 "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
                 "pkg:golang/github.com/google/uuid@v1.3.0",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+                "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
+                "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
                 "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
+                "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
                 "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/google.golang.org/grpc@v1.48.0"
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
+                "pkg:golang/golang.org/x/text@v0.3.7",
+                "pkg:golang/google.golang.org/api@v0.78.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0"
             ]
         },
         {
+            "ref": "pkg:golang/cloud.google.com/go@v0.100.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go/compute@v1.6.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go/trace@v1.0.0",
             "dependsOn": []
         },
         {
@@ -106,7 +347,47 @@
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
             "dependsOn": []
         },
         {
@@ -114,7 +395,23 @@
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
             "dependsOn": []
         },
         {
@@ -122,7 +419,35 @@
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.3.7",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/api@v0.78.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/google.golang.org/grpc@v1.48.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/protobuf@v1.28.0",
             "dependsOn": []
         }
     ]

--- a/test/providers/tst_manifests/golang/go_mod_test_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_test_ignore/expected_sbom_stack_analysis.json
@@ -15,12 +15,44 @@
     },
     "components": [
         {
+            "group": "cloud.google.com",
+            "name": "go",
+            "version": "v0.100.2",
+            "purl": "pkg:golang/cloud.google.com/go@v0.100.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go@v0.100.2"
+        },
+        {
+            "group": "cloud.google.com/go",
+            "name": "compute",
+            "version": "v1.6.1",
+            "purl": "pkg:golang/cloud.google.com/go/compute@v1.6.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go/compute@v1.6.1"
+        },
+        {
+            "group": "cloud.google.com/go",
+            "name": "monitoring",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0"
+        },
+        {
             "group": "cloud.google.com/go",
             "name": "profiler",
             "version": "v0.3.0",
             "purl": "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
             "type": "library",
             "bom-ref": "pkg:golang/cloud.google.com/go/profiler@v0.3.0"
+        },
+        {
+            "group": "cloud.google.com/go",
+            "name": "trace",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/cloud.google.com/go/trace@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/cloud.google.com/go/trace@v1.0.0"
         },
         {
             "group": "contrib.go.opencensus.io/exporter",
@@ -39,60 +71,76 @@
             "bom-ref": "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12"
         },
         {
+            "group": "github.com/aws",
+            "name": "aws-sdk-go",
+            "version": "v1.43.31",
+            "purl": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31"
+        },
+        {
+            "group": "github.com/census-instrumentation",
+            "name": "opencensus-proto",
+            "version": "v0.3.0",
+            "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0"
+        },
+        {
+            "group": "github.com/cespare",
+            "name": "xxhash",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0"
+        },
+        {
+            "group": "github.com/cncf/udpa",
+            "name": "go",
+            "version": "v0.0.0-20210930031921-04548b0d99d4",
+            "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4"
+        },
+        {
+            "group": "github.com/cncf/xds",
+            "name": "go",
+            "version": "v0.0.0-20211011173535-cb28da3451f1",
+            "purl": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1"
+        },
+        {
+            "group": "github.com/envoyproxy",
+            "name": "go-control-plane",
+            "version": "v0.10.2-0.20220325020618-49ff273808a1",
+            "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1"
+        },
+        {
+            "group": "github.com/envoyproxy",
+            "name": "protoc-gen-validate",
+            "version": "v0.1.0",
+            "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "groupcache",
+            "version": "v0.0.0-20210331224755-41bb18bfe9da",
+            "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
+        },
+        {
             "group": "github.com/golang",
             "name": "protobuf",
             "version": "v1.5.2",
             "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
-        },
-        {
-            "group": "github.com/google",
-            "name": "uuid",
-            "version": "v1.3.0",
-            "purl": "pkg:golang/github.com/google/uuid@v1.3.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0"
-        },
-        {
-            "group": "github.com/sirupsen",
-            "name": "logrus",
-            "version": "v1.8.1",
-            "purl": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "net",
-            "version": "v0.0.0-20220802222814-0bcc04d9c69b",
-            "purl": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b"
-        },
-        {
-            "group": "google.golang.org",
-            "name": "grpc",
-            "version": "v1.48.0",
-            "purl": "pkg:golang/google.golang.org/grpc@v1.48.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/grpc@v1.48.0"
-        },
-        {
-            "group": "cloud.google.com",
-            "name": "go",
-            "version": "v0.100.2",
-            "purl": "pkg:golang/cloud.google.com/go@v0.100.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/cloud.google.com/go@v0.100.2"
-        },
-        {
-            "group": "cloud.google.com/go",
-            "name": "compute",
-            "version": "v1.6.1",
-            "purl": "pkg:golang/cloud.google.com/go/compute@v1.6.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/cloud.google.com/go/compute@v1.6.1"
         },
         {
             "group": "github.com/google",
@@ -103,12 +151,20 @@
             "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.8"
         },
         {
-            "group": "github.com/google/martian",
-            "name": "v3",
-            "version": "v3.2.1",
-            "purl": "pkg:golang/github.com/google/martian/v3@v3.2.1",
+            "group": "github.com/google",
+            "name": "pprof",
+            "version": "v0.0.0-20220412212628-83db2b799d1f",
+            "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
             "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/martian/v3@v3.2.1"
+            "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f"
+        },
+        {
+            "group": "github.com/google",
+            "name": "uuid",
+            "version": "v1.3.0",
+            "purl": "pkg:golang/github.com/google/uuid@v1.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/uuid@v1.3.0"
         },
         {
             "group": "github.com/googleapis/gax-go",
@@ -119,11 +175,44 @@
             "bom-ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0"
         },
         {
-            "name": "go.opencensus.io",
-            "version": "v0.23.0",
-            "purl": "pkg:golang/go.opencensus.io@v0.23.0",
+            "group": "github.com/jmespath",
+            "name": "go-jmespath",
+            "version": "v0.4.0",
+            "purl": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
             "type": "library",
-            "bom-ref": "pkg:golang/go.opencensus.io@v0.23.0"
+            "bom-ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0"
+        },
+        {
+            "group": "github.com/prometheus",
+            "name": "prometheus",
+            "version": "v2.5.0+incompatible",
+            "purl": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible"
+        },
+        {
+            "group": "github.com/sirupsen",
+            "name": "logrus",
+            "version": "v1.8.1",
+            "purl": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1"
+        },
+        {
+            "group": "github.com/uber",
+            "name": "jaeger-client-go",
+            "version": "v2.25.0+incompatible",
+            "purl": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "net",
+            "version": "v0.0.0-20220802222814-0bcc04d9c69b",
+            "purl": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b"
         },
         {
             "group": "golang.org/x",
@@ -135,11 +224,19 @@
         },
         {
             "group": "golang.org/x",
-            "name": "xerrors",
-            "version": "v0.0.0-20220411194840-2f41105eb62f",
-            "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f",
+            "name": "sync",
+            "version": "v0.0.0-20210220032951-036812b2e83c",
+            "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
             "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f"
+            "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.3.7",
+            "purl": "pkg:golang/golang.org/x/text@v0.3.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.3.7"
         },
         {
             "group": "google.golang.org",
@@ -151,11 +248,27 @@
         },
         {
             "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
             "name": "genproto",
             "version": "v0.0.0-20220518221133-4f43b3371335",
             "purl": "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
             "type": "library",
             "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "grpc",
+            "version": "v1.48.0",
+            "purl": "pkg:golang/google.golang.org/grpc@v1.48.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/grpc@v1.48.0"
         },
         {
             "group": "google.golang.org",
@@ -166,12 +279,27 @@
             "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.28.0"
         },
         {
-            "group": "cloud.google.com/go",
-            "name": "monitoring",
-            "version": "v1.1.0",
-            "purl": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+            "group": "github.com/google/martian",
+            "name": "v3",
+            "version": "v3.2.1",
+            "purl": "pkg:golang/github.com/google/martian/v3@v3.2.1",
             "type": "library",
-            "bom-ref": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0"
+            "bom-ref": "pkg:golang/github.com/google/martian/v3@v3.2.1"
+        },
+        {
+            "name": "go.opencensus.io",
+            "version": "v0.23.0",
+            "purl": "pkg:golang/go.opencensus.io@v0.23.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/go.opencensus.io@v0.23.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "xerrors",
+            "version": "v0.0.0-20220411194840-2f41105eb62f",
+            "purl": "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f"
         },
         {
             "group": "cloud.google.com/go",
@@ -190,68 +318,12 @@
             "bom-ref": "pkg:golang/github.com/golang/mock@v1.6.0"
         },
         {
-            "group": "github.com/google",
-            "name": "pprof",
-            "version": "v0.0.0-20220412212628-83db2b799d1f",
-            "purl": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f"
-        },
-        {
-            "group": "cloud.google.com/go",
-            "name": "trace",
-            "version": "v1.0.0",
-            "purl": "pkg:golang/cloud.google.com/go/trace@v1.0.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/cloud.google.com/go/trace@v1.0.0"
-        },
-        {
-            "group": "github.com/uber",
-            "name": "jaeger-client-go",
-            "version": "v2.25.0+incompatible",
-            "purl": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "sync",
-            "version": "v0.0.0-20210220032951-036812b2e83c",
-            "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c"
-        },
-        {
-            "group": "github.com/aws",
-            "name": "aws-sdk-go",
-            "version": "v1.43.31",
-            "purl": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31"
-        },
-        {
-            "group": "github.com/census-instrumentation",
-            "name": "opencensus-proto",
-            "version": "v0.3.0",
-            "purl": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0"
-        },
-        {
             "group": "github.com/jstemmer",
             "name": "go-junit-report",
             "version": "v0.9.1",
             "purl": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1"
-        },
-        {
-            "group": "github.com/prometheus",
-            "name": "prometheus",
-            "version": "v2.5.0+incompatible",
-            "purl": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible"
         },
         {
             "group": "golang.org/x",
@@ -278,28 +350,12 @@
             "bom-ref": "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
         },
         {
-            "group": "github.com/jmespath",
-            "name": "go-jmespath",
-            "version": "v0.4.0",
-            "purl": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0"
-        },
-        {
             "group": "github.com/pkg",
             "name": "errors",
             "version": "v0.9.1",
             "purl": "pkg:golang/github.com/pkg/errors@v0.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/pkg/errors@v0.9.1"
-        },
-        {
-            "group": "github.com/cespare",
-            "name": "xxhash",
-            "version": "v1.1.0",
-            "purl": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0"
         },
         {
             "group": "github.com/OneOfOne",
@@ -316,38 +372,6 @@
             "purl": "pkg:golang/github.com/spaolacci/murmur3@v0.0.0-20180118202830-f09979ecbc72",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/spaolacci/murmur3@v0.0.0-20180118202830-f09979ecbc72"
-        },
-        {
-            "group": "github.com/cncf/udpa",
-            "name": "go",
-            "version": "v0.0.0-20210930031921-04548b0d99d4",
-            "purl": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4"
-        },
-        {
-            "group": "github.com/cncf/xds",
-            "name": "go",
-            "version": "v0.0.0-20211011173535-cb28da3451f1",
-            "purl": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1"
-        },
-        {
-            "group": "github.com/envoyproxy",
-            "name": "protoc-gen-validate",
-            "version": "v0.1.0",
-            "purl": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0"
-        },
-        {
-            "group": "github.com/envoyproxy",
-            "name": "go-control-plane",
-            "version": "v0.10.2-0.20220325020618-49ff273808a1",
-            "purl": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1"
         },
         {
             "group": "github.com/prometheus",
@@ -438,22 +462,6 @@
             "bom-ref": "pkg:golang/golang.org/x/term@v0.0.0-20210927222741-03fcf44c2211"
         },
         {
-            "group": "golang.org/x",
-            "name": "text",
-            "version": "v0.3.7",
-            "purl": "pkg:golang/golang.org/x/text@v0.3.7",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/text@v0.3.7"
-        },
-        {
-            "group": "google.golang.org",
-            "name": "appengine",
-            "version": "v1.6.7",
-            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
-        },
-        {
             "group": "github.com/cespare/xxhash",
             "name": "v2",
             "version": "v2.1.1",
@@ -484,14 +492,6 @@
             "purl": "pkg:golang/google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0",
             "type": "library",
             "bom-ref": "pkg:golang/google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0"
-        },
-        {
-            "group": "github.com/golang",
-            "name": "groupcache",
-            "version": "v0.0.0-20210331224755-41bb18bfe9da",
-            "purl": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da"
         },
         {
             "group": "cloud.google.com/go",
@@ -810,119 +810,39 @@
         {
             "ref": "pkg:golang/github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice@v0.0.0",
             "dependsOn": [
-                "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
-                "pkg:golang/contrib.go.opencensus.io/exporter/jaeger@v0.2.1",
-                "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/uuid@v1.3.0",
-                "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/google.golang.org/grpc@v1.48.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
-            "dependsOn": [
                 "pkg:golang/cloud.google.com/go@v0.100.2",
                 "pkg:golang/cloud.google.com/go/compute@v1.6.1",
-                "pkg:golang/cloud.google.com/go/storage@v1.22.1",
-                "pkg:golang/github.com/golang/mock@v1.6.0",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
-                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
-                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
-                "pkg:golang/google.golang.org/api@v0.78.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
-                "pkg:golang/google.golang.org/grpc@v1.48.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/contrib.go.opencensus.io/exporter/jaeger@v0.2.1",
-            "dependsOn": [
-                "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
-                "pkg:golang/go.opencensus.io@v0.23.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
-                "pkg:golang/google.golang.org/api@v0.78.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go@v0.100.2",
                 "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+                "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
                 "pkg:golang/cloud.google.com/go/trace@v1.0.0",
+                "pkg:golang/contrib.go.opencensus.io/exporter/jaeger@v0.2.1",
+                "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12",
                 "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
                 "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.8",
-                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-                "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
-                "pkg:golang/go.opencensus.io@v0.23.0",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20210508222113-6edffad5e616",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
-                "pkg:golang/golang.org/x/tools@v0.1.5",
-                "pkg:golang/google.golang.org/api@v0.78.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
-                "pkg:golang/google.golang.org/grpc@v1.48.0",
-                "pkg:golang/google.golang.org/protobuf@v1.28.0",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "dependsOn": [
-                "pkg:golang/github.com/google/go-cmp@v0.5.8",
-                "pkg:golang/google.golang.org/protobuf@v1.28.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/uuid@v1.3.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/stretchr/testify@v1.7.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/term@v0.0.0-20210927222741-03fcf44c2211",
-                "pkg:golang/golang.org/x/text@v0.3.7",
-                "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/grpc@v1.48.0",
-            "dependsOn": [
-                "pkg:golang/github.com/cespare/xxhash/v2@v2.1.1",
+                "pkg:golang/github.com/cespare/xxhash@v1.1.0",
                 "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
                 "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
                 "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
-                "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
                 "pkg:golang/github.com/golang/protobuf@v1.5.2",
                 "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
                 "pkg:golang/github.com/google/uuid@v1.3.0",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+                "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
+                "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
+                "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
+                "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
                 "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
                 "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
-                "pkg:golang/google.golang.org/protobuf@v1.28.0",
-                "pkg:golang/github.com/cespare/xxhash@v1.1.0",
-                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-                "pkg:golang/github.com/golang/mock@v1.6.0",
-                "pkg:golang/cloud.google.com/go@v0.100.2",
-                "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
-                "pkg:golang/github.com/client9/misspell@v0.3.4",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20210508222113-6edffad5e616",
                 "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
-                "pkg:golang/golang.org/x/tools@v0.1.5",
+                "pkg:golang/golang.org/x/text@v0.3.7",
+                "pkg:golang/google.golang.org/api@v0.78.0",
                 "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/golang.org/x/text@v0.3.7"
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0"
             ]
         },
         {
@@ -977,21 +897,165 @@
             ]
         },
         {
+            "ref": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.100.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+                "pkg:golang/google.golang.org/api@v0.78.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go/profiler@v0.3.0",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.100.2",
+                "pkg:golang/cloud.google.com/go/compute@v1.6.1",
+                "pkg:golang/cloud.google.com/go/storage@v1.22.1",
+                "pkg:golang/github.com/golang/mock@v1.6.0",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
+                "pkg:golang/google.golang.org/api@v0.78.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go/trace@v1.0.0",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.100.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
+                "pkg:golang/google.golang.org/api@v0.78.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/contrib.go.opencensus.io/exporter/jaeger@v0.2.1",
+            "dependsOn": [
+                "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
+                "pkg:golang/go.opencensus.io@v0.23.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
+                "pkg:golang/google.golang.org/api@v0.78.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/contrib.go.opencensus.io/exporter/stackdriver@v0.13.12",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.100.2",
+                "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+                "pkg:golang/cloud.google.com/go/trace@v1.0.0",
+                "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
+                "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+                "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
+                "pkg:golang/go.opencensus.io@v0.23.0",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20210508222113-6edffad5e616",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
+                "pkg:golang/golang.org/x/tools@v0.1.5",
+                "pkg:golang/google.golang.org/api@v0.78.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
+            "dependsOn": [
+                "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
+                "pkg:golang/github.com/pkg/errors@v0.9.1",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+            "dependsOn": [
+                "pkg:golang/github.com/OneOfOne/xxhash@v1.2.2",
+                "pkg:golang/github.com/spaolacci/murmur3@v0.0.0-20180118202830-f09979ecbc72"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
+            "dependsOn": [
+                "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/google.golang.org/grpc@v1.48.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+            "dependsOn": [
+                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/google.golang.org/grpc@v1.48.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
+            "dependsOn": [
+                "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
+                "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
+                "pkg:golang/github.com/stretchr/testify@v1.7.0",
+                "pkg:golang/go.opentelemetry.io/proto/otlp@v0.7.0",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0",
+                "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": [
+                "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0"
+            ]
+        },
+        {
             "ref": "pkg:golang/github.com/google/go-cmp@v0.5.8",
             "dependsOn": [
                 "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f"
             ]
         },
         {
-            "ref": "pkg:golang/github.com/google/martian/v3@v3.2.1",
+            "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
             "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/golang/snappy@v0.0.3",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/google.golang.org/grpc@v1.48.0",
-                "pkg:golang/google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0",
-                "pkg:golang/google.golang.org/protobuf@v1.28.0"
+                "pkg:golang/github.com/chzyer/logex@v1.1.10",
+                "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
+                "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
+                "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20210905161508-09a460cdf81d"
             ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/uuid@v1.3.0",
+            "dependsOn": []
         },
         {
             "ref": "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
@@ -1004,17 +1068,33 @@
             ]
         },
         {
-            "ref": "pkg:golang/go.opencensus.io@v0.23.0",
+            "ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
             "dependsOn": [
-                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.8",
-                "pkg:golang/github.com/stretchr/testify@v1.7.0",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/github.com/jmespath/go-jmespath/internal/testify@v1.5.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/sirupsen/logrus@v1.8.1",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/stretchr/testify@v1.7.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/term@v0.0.0-20210927222741-03fcf44c2211",
                 "pkg:golang/golang.org/x/text@v0.3.7",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
-                "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+                "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9"
             ]
         },
         {
@@ -1027,8 +1107,14 @@
             ]
         },
         {
-            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f",
+            "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
             "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.3.7",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.1.5"
+            ]
         },
         {
             "ref": "pkg:golang/google.golang.org/api@v0.78.0",
@@ -1054,6 +1140,16 @@
             ]
         },
         {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+                "pkg:golang/golang.org/x/text@v0.3.7",
+                "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
+                "pkg:golang/golang.org/x/tools@v0.1.5"
+            ]
+        },
+        {
             "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
             "dependsOn": [
                 "pkg:golang/github.com/golang/protobuf@v1.5.2",
@@ -1069,6 +1165,35 @@
             ]
         },
         {
+            "ref": "pkg:golang/google.golang.org/grpc@v1.48.0",
+            "dependsOn": [
+                "pkg:golang/github.com/cespare/xxhash/v2@v2.1.1",
+                "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
+                "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
+                "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
+                "pkg:golang/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/github.com/google/uuid@v1.3.0",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220411215720-9780585627b5",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/google.golang.org/protobuf@v1.28.0",
+                "pkg:golang/github.com/cespare/xxhash@v1.1.0",
+                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
+                "pkg:golang/github.com/golang/mock@v1.6.0",
+                "pkg:golang/cloud.google.com/go@v0.100.2",
+                "pkg:golang/github.com/BurntSushi/toml@v0.3.1",
+                "pkg:golang/github.com/client9/misspell@v0.3.4",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20210508222113-6edffad5e616",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
+                "pkg:golang/golang.org/x/tools@v0.1.5",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/golang.org/x/text@v0.3.7"
+            ]
+        },
+        {
             "ref": "pkg:golang/google.golang.org/protobuf@v1.28.0",
             "dependsOn": [
                 "pkg:golang/github.com/golang/protobuf@v1.5.2",
@@ -1077,16 +1202,33 @@
             ]
         },
         {
-            "ref": "pkg:golang/cloud.google.com/go/monitoring@v1.1.0",
+            "ref": "pkg:golang/github.com/google/martian/v3@v3.2.1",
             "dependsOn": [
-                "pkg:golang/cloud.google.com/go@v0.100.2",
                 "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
-                "pkg:golang/google.golang.org/api@v0.78.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/github.com/golang/snappy@v0.0.3",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
                 "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0",
                 "pkg:golang/google.golang.org/protobuf@v1.28.0"
             ]
+        },
+        {
+            "ref": "pkg:golang/go.opencensus.io@v0.23.0",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.8",
+                "pkg:golang/github.com/stretchr/testify@v1.7.0",
+                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
+                "pkg:golang/google.golang.org/grpc@v1.48.0",
+                "pkg:golang/golang.org/x/text@v0.3.7",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
+                "pkg:golang/github.com/hashicorp/golang-lru@v0.5.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20220411194840-2f41105eb62f",
+            "dependsOn": []
         },
         {
             "ref": "pkg:golang/cloud.google.com/go/storage@v1.22.1",
@@ -1127,52 +1269,7 @@
             ]
         },
         {
-            "ref": "pkg:golang/github.com/google/pprof@v0.0.0-20220412212628-83db2b799d1f",
-            "dependsOn": [
-                "pkg:golang/github.com/chzyer/logex@v1.1.10",
-                "pkg:golang/github.com/chzyer/readline@v0.0.0-20180603132655-2972be24d48e",
-                "pkg:golang/github.com/chzyer/test@v0.0.0-20180213035817-a1ea475d72b1",
-                "pkg:golang/github.com/ianlancetaylor/demangle@v0.0.0-20210905161508-09a460cdf81d"
-            ]
-        },
-        {
-            "ref": "pkg:golang/cloud.google.com/go/trace@v1.0.0",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go@v0.100.2",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/googleapis/gax-go/v2@v2.4.0",
-                "pkg:golang/google.golang.org/api@v0.78.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
-                "pkg:golang/google.golang.org/grpc@v1.48.0",
-                "pkg:golang/google.golang.org/protobuf@v1.28.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/uber/jaeger-client-go@v2.25.0%2Bincompatible",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/aws/aws-sdk-go@v1.43.31",
-            "dependsOn": [
-                "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
-                "pkg:golang/github.com/pkg/errors@v0.9.1",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/prometheus/prometheus@v2.5.0%2Bincompatible",
             "dependsOn": []
         },
         {
@@ -1204,21 +1301,8 @@
             ]
         },
         {
-            "ref": "pkg:golang/github.com/jmespath/go-jmespath@v0.4.0",
-            "dependsOn": [
-                "pkg:golang/github.com/jmespath/go-jmespath/internal/testify@v1.5.1"
-            ]
-        },
-        {
             "ref": "pkg:golang/github.com/pkg/errors@v0.9.1",
             "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/cespare/xxhash@v1.1.0",
-            "dependsOn": [
-                "pkg:golang/github.com/OneOfOne/xxhash@v1.2.2",
-                "pkg:golang/github.com/spaolacci/murmur3@v0.0.0-20180118202830-f09979ecbc72"
-            ]
         },
         {
             "ref": "pkg:golang/github.com/OneOfOne/xxhash@v1.2.2",
@@ -1227,45 +1311,6 @@
         {
             "ref": "pkg:golang/github.com/spaolacci/murmur3@v0.0.0-20180118202830-f09979ecbc72",
             "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4",
-            "dependsOn": [
-                "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
-                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/google.golang.org/grpc@v1.48.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
-            "dependsOn": [
-                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/google.golang.org/grpc@v1.48.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/envoyproxy/go-control-plane@v0.10.2-0.20220325020618-49ff273808a1",
-            "dependsOn": [
-                "pkg:golang/github.com/census-instrumentation/opencensus-proto@v0.3.0",
-                "pkg:golang/github.com/cncf/xds/go@v0.0.0-20211011173535-cb28da3451f1",
-                "pkg:golang/github.com/envoyproxy/protoc-gen-validate@v0.1.0",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.8",
-                "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
-                "pkg:golang/github.com/stretchr/testify@v1.7.0",
-                "pkg:golang/go.opentelemetry.io/proto/otlp@v0.7.0",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20220518221133-4f43b3371335",
-                "pkg:golang/google.golang.org/grpc@v1.48.0",
-                "pkg:golang/google.golang.org/protobuf@v1.28.0",
-                "pkg:golang/github.com/cncf/udpa/go@v0.0.0-20210930031921-04548b0d99d4"
-            ]
         },
         {
             "ref": "pkg:golang/github.com/prometheus/client_model@v0.0.0-20190812154241-14fe0d1b01d4",
@@ -1331,22 +1376,6 @@
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/golang.org/x/text@v0.3.7",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.1.5"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/net@v0.0.0-20220802222814-0bcc04d9c69b",
-                "pkg:golang/golang.org/x/text@v0.3.7",
-                "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/tools@v0.1.5"
-            ]
-        },
-        {
             "ref": "pkg:golang/github.com/cespare/xxhash/v2@v2.1.1",
             "dependsOn": []
         },
@@ -1363,10 +1392,6 @@
             "dependsOn": [
                 "pkg:golang/google.golang.org/protobuf@v1.28.0"
             ]
-        },
-        {
-            "ref": "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-            "dependsOn": []
         },
         {
             "ref": "pkg:golang/cloud.google.com/go/iam@v0.3.0",

--- a/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_component_analysis.json
@@ -15,12 +15,84 @@
     },
     "components": [
         {
+            "group": "github.com/davecgh",
+            "name": "go-spew",
+            "version": "v1.1.1",
+            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+        },
+        {
+            "group": "github.com/emicklei/go-restful",
+            "name": "v3",
+            "version": "v3.9.0",
+            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+        },
+        {
             "group": "github.com/gin-gonic",
             "name": "gin",
             "version": "v1.9.1",
             "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonpointer",
+            "version": "v0.19.5",
+            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonreference",
+            "version": "v0.20.0",
+            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "swag",
+            "version": "v0.19.14",
+            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+        },
+        {
+            "group": "github.com/gogo",
+            "name": "protobuf",
+            "version": "v1.3.2",
+            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "protobuf",
+            "version": "v1.5.2",
+            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+        },
+        {
+            "group": "github.com/google",
+            "name": "go-cmp",
+            "version": "v0.5.9",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gofuzz",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
         },
         {
             "group": "github.com/google",
@@ -31,6 +103,30 @@
             "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2"
         },
         {
+            "group": "github.com/imdario",
+            "name": "mergo",
+            "version": "v0.3.6",
+            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+        },
+        {
+            "group": "github.com/josharian",
+            "name": "intern",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
+        },
+        {
+            "group": "github.com/json-iterator",
+            "name": "go",
+            "version": "v1.1.12",
+            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
+        },
+        {
             "group": "github.com/kr",
             "name": "pretty",
             "version": "v0.3.1",
@@ -39,12 +135,156 @@
             "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1"
         },
         {
+            "group": "github.com/kr",
+            "name": "text",
+            "version": "v0.2.0",
+            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
+        },
+        {
+            "group": "github.com/mailru",
+            "name": "easyjson",
+            "version": "v0.7.6",
+            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "concurrent",
+            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "reflect2",
+            "version": "v1.0.2",
+            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+        },
+        {
+            "group": "github.com/munnerz",
+            "name": "goautoneg",
+            "version": "v0.0.0-20191010083416-a7dc8b61c822",
+            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+        },
+        {
+            "group": "github.com/rogpeppe",
+            "name": "go-internal",
+            "version": "v1.9.0",
+            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+        },
+        {
+            "group": "github.com/spf13",
+            "name": "pflag",
+            "version": "v1.0.5",
+            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "net",
+            "version": "v0.10.0",
+            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "oauth2",
+            "version": "v0.0.0-20220223155221-ee480838109b",
+            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "term",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.9.0",
+            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "time",
+            "version": "v0.0.0-20220210224613-90d013bbcef8",
+            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "protobuf",
+            "version": "v1.30.0",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "inf.v0",
+            "version": "v0.9.1",
+            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+        },
+        {
             "group": "gopkg.in",
             "name": "yaml.v2",
             "version": "v2.4.0",
             "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "api",
+            "version": "v0.26.1",
+            "purl": "pkg:golang/k8s.io/api@v0.26.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
         },
         {
             "group": "k8s.io",
@@ -61,22 +301,142 @@
             "purl": "pkg:golang/k8s.io/client-go@v0.26.1",
             "type": "library",
             "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1"
+        },
+        {
+            "group": "k8s.io/klog",
+            "name": "v2",
+            "version": "v2.80.1",
+            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "kube-openapi",
+            "version": "v0.0.0-20221012153701-172d655c2280",
+            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+        },
+        {
+            "group": "k8s.io",
+            "name": "utils",
+            "version": "v0.0.0-20221107191617-1a15be271d1d",
+            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "json",
+            "version": "v0.0.0-20220713155537-f223a00ba0e2",
+            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+        },
+        {
+            "group": "sigs.k8s.io/structured-merge-diff",
+            "name": "v4",
+            "version": "v4.2.3",
+            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "yaml",
+            "version": "v1.3.0",
+            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         }
     ],
     "dependencies": [
         {
             "ref": "pkg:golang/github.com/RHEcosystemAppEng/SaaSi/deployer@v0.0.0",
             "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
                 "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
                 "pkg:golang/github.com/google/uuid@v1.1.2",
+                "pkg:golang/github.com/imdario/mergo@v0.3.6",
+                "pkg:golang/github.com/josharian/intern@v1.0.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
                 "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+                "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
                 "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/api@v0.26.1",
                 "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/k8s.io/client-go@v0.26.1"
+                "pkg:golang/k8s.io/client-go@v0.26.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
         },
         {
+            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
             "dependsOn": []
         },
         {
@@ -84,11 +444,95 @@
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
             "dependsOn": []
         },
         {
+            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/api@v0.26.1",
             "dependsOn": []
         },
         {
@@ -97,6 +541,30 @@
         },
         {
             "ref": "pkg:golang/k8s.io/client-go@v0.26.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
             "dependsOn": []
         }
     ]

--- a/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_with_ignore/expected_sbom_stack_analysis.json
@@ -15,12 +15,84 @@
     },
     "components": [
         {
+            "group": "github.com/davecgh",
+            "name": "go-spew",
+            "version": "v1.1.1",
+            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
+        },
+        {
+            "group": "github.com/emicklei/go-restful",
+            "name": "v3",
+            "version": "v3.9.0",
+            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
+        },
+        {
             "group": "github.com/gin-gonic",
             "name": "gin",
             "version": "v1.9.1",
             "purl": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonpointer",
+            "version": "v0.19.5",
+            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "jsonreference",
+            "version": "v0.20.0",
+            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
+        },
+        {
+            "group": "github.com/go-openapi",
+            "name": "swag",
+            "version": "v0.19.14",
+            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
+        },
+        {
+            "group": "github.com/gogo",
+            "name": "protobuf",
+            "version": "v1.3.2",
+            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
+        },
+        {
+            "group": "github.com/golang",
+            "name": "protobuf",
+            "version": "v1.5.2",
+            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
+        },
+        {
+            "group": "github.com/google",
+            "name": "go-cmp",
+            "version": "v0.5.9",
+            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
+        },
+        {
+            "group": "github.com/google",
+            "name": "gofuzz",
+            "version": "v1.1.0",
+            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
         },
         {
             "group": "github.com/google",
@@ -31,6 +103,30 @@
             "bom-ref": "pkg:golang/github.com/google/uuid@v1.1.2"
         },
         {
+            "group": "github.com/imdario",
+            "name": "mergo",
+            "version": "v0.3.6",
+            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
+        },
+        {
+            "group": "github.com/josharian",
+            "name": "intern",
+            "version": "v1.0.0",
+            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
+        },
+        {
+            "group": "github.com/json-iterator",
+            "name": "go",
+            "version": "v1.1.12",
+            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
+        },
+        {
             "group": "github.com/kr",
             "name": "pretty",
             "version": "v0.3.1",
@@ -39,12 +135,156 @@
             "bom-ref": "pkg:golang/github.com/kr/pretty@v0.3.1"
         },
         {
+            "group": "github.com/kr",
+            "name": "text",
+            "version": "v0.2.0",
+            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
+        },
+        {
+            "group": "github.com/mailru",
+            "name": "easyjson",
+            "version": "v0.7.6",
+            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "concurrent",
+            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
+            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+        },
+        {
+            "group": "github.com/modern-go",
+            "name": "reflect2",
+            "version": "v1.0.2",
+            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
+        },
+        {
+            "group": "github.com/munnerz",
+            "name": "goautoneg",
+            "version": "v0.0.0-20191010083416-a7dc8b61c822",
+            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
+        },
+        {
+            "group": "github.com/rogpeppe",
+            "name": "go-internal",
+            "version": "v1.9.0",
+            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
+        },
+        {
+            "group": "github.com/spf13",
+            "name": "pflag",
+            "version": "v1.0.5",
+            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "type": "library",
+            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "net",
+            "version": "v0.10.0",
+            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "oauth2",
+            "version": "v0.0.0-20220223155221-ee480838109b",
+            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "term",
+            "version": "v0.8.0",
+            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "text",
+            "version": "v0.9.0",
+            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "time",
+            "version": "v0.0.0-20220210224613-90d013bbcef8",
+            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "appengine",
+            "version": "v1.6.7",
+            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
+        },
+        {
+            "group": "google.golang.org",
+            "name": "protobuf",
+            "version": "v1.30.0",
+            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "inf.v0",
+            "version": "v0.9.1",
+            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
+        },
+        {
             "group": "gopkg.in",
             "name": "yaml.v2",
             "version": "v2.4.0",
             "purl": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+        },
+        {
+            "group": "gopkg.in",
+            "name": "yaml.v3",
+            "version": "v3.0.1",
+            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "api",
+            "version": "v0.26.1",
+            "purl": "pkg:golang/k8s.io/api@v0.26.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
         },
         {
             "group": "k8s.io",
@@ -61,6 +301,54 @@
             "purl": "pkg:golang/k8s.io/client-go@v0.26.1",
             "type": "library",
             "bom-ref": "pkg:golang/k8s.io/client-go@v0.26.1"
+        },
+        {
+            "group": "k8s.io/klog",
+            "name": "v2",
+            "version": "v2.80.1",
+            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
+        },
+        {
+            "group": "k8s.io",
+            "name": "kube-openapi",
+            "version": "v0.0.0-20221012153701-172d655c2280",
+            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
+        },
+        {
+            "group": "k8s.io",
+            "name": "utils",
+            "version": "v0.0.0-20221107191617-1a15be271d1d",
+            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "type": "library",
+            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "json",
+            "version": "v0.0.0-20220713155537-f223a00ba0e2",
+            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
+        },
+        {
+            "group": "sigs.k8s.io/structured-merge-diff",
+            "name": "v4",
+            "version": "v4.2.3",
+            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
+        },
+        {
+            "group": "sigs.k8s.io",
+            "name": "yaml",
+            "version": "v1.3.0",
+            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "type": "library",
+            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         },
         {
             "group": "github.com/bytedance",
@@ -95,14 +383,6 @@
             "bom-ref": "pkg:golang/github.com/goccy/go-json@v0.10.2"
         },
         {
-            "group": "github.com/json-iterator",
-            "name": "go",
-            "version": "v1.1.12",
-            "purl": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/json-iterator/go@v1.1.12"
-        },
-        {
             "group": "github.com/mattn",
             "name": "go-isatty",
             "version": "v0.0.19",
@@ -135,44 +415,12 @@
             "bom-ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11"
         },
         {
-            "group": "golang.org/x",
-            "name": "net",
-            "version": "v0.10.0",
-            "purl": "pkg:golang/golang.org/x/net@v0.10.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/net@v0.10.0"
-        },
-        {
-            "group": "google.golang.org",
-            "name": "protobuf",
-            "version": "v1.30.0",
-            "purl": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/protobuf@v1.30.0"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "yaml.v3",
-            "version": "v3.0.1",
-            "purl": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1"
-        },
-        {
             "group": "github.com/chenzhuoyu",
             "name": "base64x",
             "version": "v0.0.0-20221115062448-fe3a3abad311",
             "purl": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311"
-        },
-        {
-            "group": "github.com/davecgh",
-            "name": "go-spew",
-            "version": "v1.1.1",
-            "purl": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1"
         },
         {
             "group": "github.com/gabriel-vasile",
@@ -215,22 +463,6 @@
             "bom-ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4"
         },
         {
-            "group": "github.com/modern-go",
-            "name": "concurrent",
-            "version": "v0.0.0-20180306012644-bacd9c7ef1dd",
-            "purl": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-        },
-        {
-            "group": "github.com/modern-go",
-            "name": "reflect2",
-            "version": "v1.0.2",
-            "purl": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2"
-        },
-        {
             "group": "github.com/pmezard",
             "name": "go-difflib",
             "version": "v1.0.0",
@@ -263,62 +495,6 @@
             "bom-ref": "pkg:golang/golang.org/x/crypto@v0.9.0"
         },
         {
-            "group": "golang.org/x",
-            "name": "sys",
-            "version": "v0.8.0",
-            "purl": "pkg:golang/golang.org/x/sys@v0.8.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/sys@v0.8.0"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "text",
-            "version": "v0.9.0",
-            "purl": "pkg:golang/golang.org/x/text@v0.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/text@v0.9.0"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "jsonpointer",
-            "version": "v0.19.5",
-            "purl": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "swag",
-            "version": "v0.19.14",
-            "purl": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14"
-        },
-        {
-            "group": "github.com/mailru",
-            "name": "easyjson",
-            "version": "v0.7.6",
-            "purl": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6"
-        },
-        {
-            "group": "github.com/go-openapi",
-            "name": "jsonreference",
-            "version": "v0.20.0",
-            "purl": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0"
-        },
-        {
-            "group": "github.com/kr",
-            "name": "text",
-            "version": "v0.2.0",
-            "purl": "pkg:golang/github.com/kr/text@v0.2.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/kr/text@v0.2.0"
-        },
-        {
             "group": "github.com/niemeyer",
             "name": "pretty",
             "version": "v0.0.0-20200227124842-a10e7caefd8e",
@@ -333,14 +509,6 @@
             "purl": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
             "type": "library",
             "bom-ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-        },
-        {
-            "group": "github.com/gogo",
-            "name": "protobuf",
-            "version": "v1.3.2",
-            "purl": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2"
         },
         {
             "group": "github.com/kisielk",
@@ -365,22 +533,6 @@
             "purl": "pkg:golang/golang.org/x/tools@v0.6.0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/tools@v0.6.0"
-        },
-        {
-            "group": "github.com/golang",
-            "name": "protobuf",
-            "version": "v1.5.2",
-            "purl": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/golang/protobuf@v1.5.2"
-        },
-        {
-            "group": "github.com/google",
-            "name": "go-cmp",
-            "version": "v0.5.9",
-            "purl": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/go-cmp@v0.5.9"
         },
         {
             "group": "github.com/docopt",
@@ -415,36 +567,12 @@
             "bom-ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
         },
         {
-            "group": "github.com/google",
-            "name": "gofuzz",
-            "version": "v1.1.0",
-            "purl": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/google/gofuzz@v1.1.0"
-        },
-        {
-            "group": "github.com/rogpeppe",
-            "name": "go-internal",
-            "version": "v1.9.0",
-            "purl": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0"
-        },
-        {
             "group": "github.com/creack",
             "name": "pty",
             "version": "v1.1.9",
             "purl": "pkg:golang/github.com/creack/pty@v1.1.9",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/creack/pty@v1.1.9"
-        },
-        {
-            "group": "github.com/josharian",
-            "name": "intern",
-            "version": "v1.0.0",
-            "purl": "pkg:golang/github.com/josharian/intern@v1.0.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/josharian/intern@v1.0.0"
         },
         {
             "group": "github.com/pkg",
@@ -455,22 +583,6 @@
             "bom-ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e"
         },
         {
-            "group": "golang.org/x",
-            "name": "term",
-            "version": "v0.8.0",
-            "purl": "pkg:golang/golang.org/x/term@v0.8.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/term@v0.8.0"
-        },
-        {
-            "group": "golang.org/x",
-            "name": "oauth2",
-            "version": "v0.0.0-20220223155221-ee480838109b",
-            "purl": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b"
-        },
-        {
             "group": "cloud.google.com",
             "name": "go",
             "version": "v0.65.0",
@@ -479,84 +591,12 @@
             "bom-ref": "pkg:golang/cloud.google.com/go@v0.65.0"
         },
         {
-            "group": "google.golang.org",
-            "name": "appengine",
-            "version": "v1.6.7",
-            "purl": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "type": "library",
-            "bom-ref": "pkg:golang/google.golang.org/appengine@v1.6.7"
-        },
-        {
             "group": "golang.org/x",
             "name": "mod",
             "version": "v0.8.0",
             "purl": "pkg:golang/golang.org/x/mod@v0.8.0",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/mod@v0.8.0"
-        },
-        {
-            "group": "k8s.io",
-            "name": "api",
-            "version": "v0.26.1",
-            "purl": "pkg:golang/k8s.io/api@v0.26.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/api@v0.26.1"
-        },
-        {
-            "group": "github.com/spf13",
-            "name": "pflag",
-            "version": "v1.0.5",
-            "purl": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/spf13/pflag@v1.0.5"
-        },
-        {
-            "group": "gopkg.in",
-            "name": "inf.v0",
-            "version": "v0.9.1",
-            "purl": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1"
-        },
-        {
-            "group": "k8s.io/klog",
-            "name": "v2",
-            "version": "v2.80.1",
-            "purl": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/klog/v2@v2.80.1"
-        },
-        {
-            "group": "k8s.io",
-            "name": "utils",
-            "version": "v0.0.0-20221107191617-1a15be271d1d",
-            "purl": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d"
-        },
-        {
-            "group": "sigs.k8s.io",
-            "name": "json",
-            "version": "v0.0.0-20220713155537-f223a00ba0e2",
-            "purl": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2"
-        },
-        {
-            "group": "sigs.k8s.io/structured-merge-diff",
-            "name": "v4",
-            "version": "v4.2.3",
-            "purl": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3"
-        },
-        {
-            "group": "sigs.k8s.io",
-            "name": "yaml",
-            "version": "v1.3.0",
-            "purl": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
         },
         {
             "group": "github.com/armon",
@@ -599,14 +639,6 @@
             "bom-ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f"
         },
         {
-            "group": "k8s.io",
-            "name": "kube-openapi",
-            "version": "v0.0.0-20221012153701-172d655c2280",
-            "purl": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
-            "type": "library",
-            "bom-ref": "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280"
-        },
-        {
             "group": "github.com/onsi/ginkgo",
             "name": "v2",
             "version": "v2.4.0",
@@ -647,14 +679,6 @@
             "bom-ref": "pkg:golang/github.com/gregjones/httpcache@v0.0.0-20180305231024-9cad4c3443a7"
         },
         {
-            "group": "github.com/imdario",
-            "name": "mergo",
-            "version": "v0.3.6",
-            "purl": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/imdario/mergo@v0.3.6"
-        },
-        {
             "group": "github.com/peterbourgon",
             "name": "diskv",
             "version": "v2.0.1+incompatible",
@@ -663,36 +687,12 @@
             "bom-ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible"
         },
         {
-            "group": "golang.org/x",
-            "name": "time",
-            "version": "v0.0.0-20220210224613-90d013bbcef8",
-            "purl": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8"
-        },
-        {
-            "group": "github.com/emicklei/go-restful",
-            "name": "v3",
-            "version": "v3.9.0",
-            "purl": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0"
-        },
-        {
             "group": "github.com/google",
             "name": "btree",
             "version": "v1.0.1",
             "purl": "pkg:golang/github.com/google/btree@v1.0.1",
             "type": "library",
             "bom-ref": "pkg:golang/github.com/google/btree@v1.0.1"
-        },
-        {
-            "group": "github.com/munnerz",
-            "name": "goautoneg",
-            "version": "v0.0.0-20191010083416-a7dc8b61c822",
-            "purl": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
-            "type": "library",
-            "bom-ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822"
         },
         {
             "group": "github.com/NYTimes",
@@ -1098,13 +1098,57 @@
         {
             "ref": "pkg:golang/github.com/RHEcosystemAppEng/SaaSi/deployer@v0.0.0",
             "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
                 "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
                 "pkg:golang/github.com/google/uuid@v1.1.2",
+                "pkg:golang/github.com/imdario/mergo@v0.3.6",
+                "pkg:golang/github.com/josharian/intern@v1.0.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
                 "pkg:golang/github.com/kr/pretty@v0.3.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+                "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
                 "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/api@v0.26.1",
                 "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/k8s.io/client-go@v0.26.1"
+                "pkg:golang/k8s.io/client-go@v0.26.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/kube-openapi@v0.0.0-20221012153701-172d655c2280",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
+        },
+        {
+            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
+            "dependsOn": []
         },
         {
             "ref": "pkg:golang/github.com/gin-gonic/gin@v1.9.1",
@@ -1139,8 +1183,80 @@
             ]
         },
         {
+            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+            "dependsOn": [
+                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
+            "dependsOn": [
+                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/kr/text@v0.2.0",
+                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+                "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3",
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/github.com/kr/pretty@v0.3.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+            "dependsOn": [
+                "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+                "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
+            "dependsOn": [
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/google/uuid@v1.1.2",
             "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
         },
         {
             "ref": "pkg:golang/github.com/kr/pretty@v0.3.1",
@@ -1150,9 +1266,142 @@
             ]
         },
         {
+            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
+            "dependsOn": [
+                "pkg:golang/github.com/creack/pty@v1.1.9",
+                "pkg:golang/github.com/kr/pty@v1.1.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
+            "dependsOn": [
+                "pkg:golang/github.com/josharian/intern@v1.0.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
+            "dependsOn": [
+                "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+                "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/term@v0.8.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/crypto@v0.9.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go@v0.65.0",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/golang.org/x/sys@v0.8.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/crypto@v0.9.0",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
             "dependsOn": [
                 "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
+            ]
+        },
+        {
+            "ref": "pkg:golang/k8s.io/api@v0.26.1",
+            "dependsOn": [
+                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
+                "pkg:golang/github.com/stretchr/testify@v1.8.3",
+                "pkg:golang/k8s.io/apimachinery@v0.26.1",
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
+                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/spf13/pflag@v1.0.5",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1",
+                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
             ]
         },
         {
@@ -1247,445 +1496,7 @@
             ]
         },
         {
-            "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/json-iterator/go@v1.1.12",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/stretchr/objx@v0.1.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/net@v0.10.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/term@v0.8.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/crypto@v0.9.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/protobuf@v1.30.0",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154"
-            ]
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/net@v0.10.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/sys@v0.8.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/text@v0.9.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/golang.org/x/sys@v0.8.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-            "dependsOn": [
-                "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/swag@v0.19.14",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/kr/text@v0.2.0",
-                "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-                "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3",
-                "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/github.com/kr/pretty@v0.3.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/mailru/easyjson@v0.7.6",
-            "dependsOn": [
-                "pkg:golang/github.com/josharian/intern@v1.0.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/go-openapi/jsonreference@v0.20.0",
-            "dependsOn": [
-                "pkg:golang/github.com/go-openapi/jsonpointer@v0.19.5",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kr/text@v0.2.0",
-            "dependsOn": [
-                "pkg:golang/github.com/creack/pty@v1.1.9",
-                "pkg:golang/github.com/kr/pty@v1.1.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
-            "dependsOn": [
-                "pkg:golang/github.com/kr/text@v0.2.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-            "dependsOn": [
-                "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-                "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
-            "dependsOn": [
-                "pkg:golang/github.com/yuin/goldmark@v1.2.1",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/appengine@v1.6.7"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/golang/protobuf@v1.5.2",
-            "dependsOn": [
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/go-cmp@v0.5.9",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
-            "dependsOn": [
-                "pkg:golang/github.com/stretchr/testify@v1.8.3"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/google.golang.org/grpc@v1.31.0",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/google/gofuzz@v1.1.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/rogpeppe/go-internal@v1.9.0",
-            "dependsOn": [
-                "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-                "pkg:golang/gopkg.in/errgo.v2@v2.1.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/josharian/intern@v1.0.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/term@v0.8.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/sys@v0.8.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go@v0.65.0",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
-            ]
-        },
-        {
-            "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
-            "dependsOn": [
-                "pkg:golang/cloud.google.com/go/storage@v1.10.0",
-                "pkg:golang/github.com/golang/mock@v1.4.4",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/github.com/google/martian/v3@v3.0.0",
-                "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
-                "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
-                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
-                "pkg:golang/go.opencensus.io@v0.22.4",
-                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
-                "pkg:golang/google.golang.org/api@v0.30.0",
-                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
-                "pkg:golang/google.golang.org/grpc@v1.31.0",
-                "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
-                "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
-                "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
-                "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
-                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/google.golang.org/appengine@v1.6.7",
-                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
-                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
-                "pkg:golang/golang.org/x/mod@v0.8.0",
-                "pkg:golang/github.com/google/btree@v1.0.1",
-                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-                "pkg:golang/rsc.io/binaryregexp@v0.2.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/google.golang.org/appengine@v1.6.7",
-            "dependsOn": [
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/golang.org/x/crypto@v0.9.0",
-                "pkg:golang/golang.org/x/sys@v0.8.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
-            "dependsOn": [
-                "pkg:golang/golang.org/x/crypto@v0.9.0",
-                "pkg:golang/golang.org/x/tools@v0.6.0",
-                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/k8s.io/api@v0.26.1",
-            "dependsOn": [
-                "pkg:golang/github.com/gogo/protobuf@v1.3.2",
-                "pkg:golang/github.com/stretchr/testify@v1.8.3",
-                "pkg:golang/k8s.io/apimachinery@v0.26.1",
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/github.com/golang/protobuf@v1.5.2",
-                "pkg:golang/github.com/google/go-cmp@v0.5.9",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/json-iterator/go@v1.1.12",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd",
-                "pkg:golang/github.com/modern-go/reflect2@v1.0.2",
-                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
-                "pkg:golang/github.com/spf13/pflag@v1.0.5",
-                "pkg:golang/golang.org/x/net@v0.10.0",
-                "pkg:golang/golang.org/x/text@v0.9.0",
-                "pkg:golang/google.golang.org/protobuf@v1.30.0",
-                "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
-                "pkg:golang/k8s.io/klog/v2@v2.80.1",
-                "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-                "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-                "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-                "pkg:golang/sigs.k8s.io/yaml@v1.3.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/spf13/pflag@v1.0.5",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/gopkg.in/inf.v0@v0.9.1",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/k8s.io/klog/v2@v2.80.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/k8s.io/klog/v2@v2.80.1"
-            ]
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
-            "dependsOn": [
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
-                "pkg:golang/github.com/google/gofuzz@v1.1.0",
-                "pkg:golang/github.com/json-iterator/go@v1.1.12",
-                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
-            ]
-        },
-        {
-            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
-            "dependsOn": [
-                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
-                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
-            ]
-        },
-        {
-            "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
             "dependsOn": []
         },
         {
@@ -1732,6 +1543,247 @@
             ]
         },
         {
+            "ref": "pkg:golang/k8s.io/utils@v0.0.0-20221107191617-1a15be271d1d",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/k8s.io/klog/v2@v2.80.1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/structured-merge-diff/v4@v4.2.3",
+            "dependsOn": [
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0",
+                "pkg:golang/github.com/google/gofuzz@v1.1.0",
+                "pkg:golang/github.com/json-iterator/go@v1.1.12",
+                "pkg:golang/github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd"
+            ]
+        },
+        {
+            "ref": "pkg:golang/sigs.k8s.io/yaml@v1.3.0",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/bytedance/sonic@v1.9.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gin-contrib/sse@v0.1.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/validator/v10@v10.14.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/goccy/go-json@v0.10.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mattn/go-isatty@v0.0.19",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pelletier/go-toml/v2@v2.0.8",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/stretchr/testify@v1.8.3",
+            "dependsOn": [
+                "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+                "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+                "pkg:golang/github.com/stretchr/objx@v0.1.0",
+                "pkg:golang/gopkg.in/yaml.v3@v3.0.1",
+                "pkg:golang/gopkg.in/yaml.v2@v2.4.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/ugorji/go/codec@v1.2.11",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/chenzhuoyu/base64x@v0.0.0-20221115062448-fe3a3abad311",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/gabriel-vasile/mimetype@v1.4.2",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/locales@v0.14.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/go-playground/universal-translator@v0.18.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/klauspost/cpuid/v2@v2.2.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/leodido/go-urn@v1.2.4",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pmezard/go-difflib@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/twitchyliquid64/golang-asm@v0.15.1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/arch@v0.3.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/crypto@v0.9.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/golang.org/x/net@v0.10.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/niemeyer/pretty@v0.0.0-20200227124842-a10e7caefd8e",
+            "dependsOn": [
+                "pkg:golang/github.com/kr/text@v0.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/gopkg.in/check.v1@v1.0.0-20200227125254-8fa46927fb4f",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/kisielk/errcheck@v1.5.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/tools@v0.6.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/kisielk/gotool@v1.0.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/tools@v0.6.0",
+            "dependsOn": [
+                "pkg:golang/github.com/yuin/goldmark@v1.2.1",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/appengine@v1.6.7"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/docopt/docopt-go@v0.0.0-20180111231733-ee0de3bc6815",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/stoewer/go-strcase@v1.2.0",
+            "dependsOn": [
+                "pkg:golang/github.com/stretchr/testify@v1.8.3"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+            "dependsOn": [
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/google.golang.org/grpc@v1.31.0",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/creack/pty@v1.1.9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/pkg/diff@v0.0.0-20210226163009-20ebb0f2a09e",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/cloud.google.com/go@v0.65.0",
+            "dependsOn": [
+                "pkg:golang/cloud.google.com/go/storage@v1.10.0",
+                "pkg:golang/github.com/golang/mock@v1.4.4",
+                "pkg:golang/github.com/golang/protobuf@v1.5.2",
+                "pkg:golang/github.com/google/go-cmp@v0.5.9",
+                "pkg:golang/github.com/google/martian/v3@v3.0.0",
+                "pkg:golang/github.com/google/pprof@v0.0.0-20200708004538-1a94d8640e99",
+                "pkg:golang/github.com/googleapis/gax-go/v2@v2.0.5",
+                "pkg:golang/github.com/jstemmer/go-junit-report@v0.9.1",
+                "pkg:golang/go.opencensus.io@v0.22.4",
+                "pkg:golang/golang.org/x/lint@v0.0.0-20200302205851-738671d3881b",
+                "pkg:golang/golang.org/x/net@v0.10.0",
+                "pkg:golang/golang.org/x/oauth2@v0.0.0-20220223155221-ee480838109b",
+                "pkg:golang/golang.org/x/text@v0.9.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1",
+                "pkg:golang/google.golang.org/api@v0.30.0",
+                "pkg:golang/google.golang.org/genproto@v0.0.0-20201019141844-1ed22bb0c154",
+                "pkg:golang/google.golang.org/grpc@v1.31.0",
+                "pkg:golang/cloud.google.com/go/bigquery@v1.8.0",
+                "pkg:golang/cloud.google.com/go/datastore@v1.1.0",
+                "pkg:golang/cloud.google.com/go/pubsub@v1.3.1",
+                "pkg:golang/github.com/google/martian@v2.1.0%2Bincompatible",
+                "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/sys@v0.8.0",
+                "pkg:golang/google.golang.org/appengine@v1.6.7",
+                "pkg:golang/honnef.co/go/tools@v0.0.1-2020.1.4",
+                "pkg:golang/google.golang.org/protobuf@v1.30.0",
+                "pkg:golang/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da",
+                "pkg:golang/golang.org/x/exp@v0.0.0-20200224162631-6cc2880d07d6",
+                "pkg:golang/golang.org/x/mod@v0.8.0",
+                "pkg:golang/github.com/google/btree@v1.0.1",
+                "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
+                "pkg:golang/rsc.io/binaryregexp@v0.2.0"
+            ]
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/mod@v0.8.0",
+            "dependsOn": [
+                "pkg:golang/golang.org/x/crypto@v0.9.0",
+                "pkg:golang/golang.org/x/tools@v0.6.0",
+                "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
+            ]
+        },
+        {
+            "ref": "pkg:golang/github.com/armon/go-socks5@v0.0.0-20160902184237-e75332964ef5",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/elazarl/goproxy@v0.0.0-20180725130230-947c36da3153",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/evanphx/json-patch@v4.12.0%2Bincompatible",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/moby/spdystream@v0.2.0",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/github.com/mxk/go-flowrate@v0.0.0-20140419014527-cca7078d478f",
+            "dependsOn": []
+        },
+        {
             "ref": "pkg:golang/github.com/onsi/ginkgo/v2@v2.4.0",
             "dependsOn": []
         },
@@ -1752,27 +1804,11 @@
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/github.com/imdario/mergo@v0.3.6",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/peterbourgon/diskv@v2.0.1%2Bincompatible",
             "dependsOn": []
         },
         {
-            "ref": "pkg:golang/golang.org/x/time@v0.0.0-20220210224613-90d013bbcef8",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/emicklei/go-restful/v3@v3.9.0",
-            "dependsOn": []
-        },
-        {
             "ref": "pkg:golang/github.com/google/btree@v1.0.1",
-            "dependsOn": []
-        },
-        {
-            "ref": "pkg:golang/github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822",
             "dependsOn": []
         },
         {


### PR DESCRIPTION
## Summary

- Removes the `directDepPaths` filtering introduced in de12f6a that used `go mod edit -json` Indirect flags to exclude root-level edges from `go mod graph`, causing an 84% drop in reported direct dependencies (45→7 for `go_mod_no_ignore`)
- Adds a reproducer test verifying `go_mod_no_ignore` component analysis reports all 45 root-level deps from `go mod graph`
- Regenerates 9 expected SBOM fixtures to match corrected dependency counts

Fixes [TC-4275](https://redhat.atlassian.net/browse/TC-4275)
Part of [TC-3818](https://redhat.atlassian.net/browse/TC-3818)

## Root Cause

Commit de12f6a built a `directDepPaths` Set from `go mod edit -json` entries where `Indirect === false`, then filtered root-level edges from `go mod graph` against it. Since `go mod graph` reports edges after MVS resolution while `go mod edit -json` reflects go.mod's `// indirect` markers, valid direct dependencies were incorrectly excluded.

The Java client treats ALL root-level edges from `go mod graph` as direct dependencies and never performs this filtering — restoring that behavior here aligns cross-client parity.

## Test plan

- [x] Reproducer test: `go_mod_no_ignore` component analysis asserts 45 root-level deps (failed with 7 before fix)
- [x] All 7 Go module test scenarios pass (stack + component analysis): 16 passing
- [x] ESLint: 0 errors, 0 warnings
- [x] Cross-client parity: `go_mod_no_ignore` stack=138 components, `go_mod_mvs_versions` stack=138 components (matching Java client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4275]: https://redhat.atlassian.net/browse/TC-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-3818]: https://redhat.atlassian.net/browse/TC-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Restore reporting of all root-level Go module dependencies in SBOM generation and update tests/fixtures accordingly.

Bug Fixes:
- Stop filtering out direct Go module dependencies based on go mod edit Indirect flags so all root-level edges from go mod graph are treated as direct dependencies.

Tests:
- Add a regression test to ensure go_mod_no_ignore component analysis reports all root-level dependencies from go mod graph.
- Regenerate Go module SBOM fixture files to reflect the corrected dependency counts for component and stack analysis.