### PR TITLE
fix: suppress dependabot for non-production ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,70 +30,100 @@ updates:
         patterns:
           - "*"
 
-  # ── Test fixture manifests (suppress all updates including security) ─
-  # These directories contain intentionally pinned dependencies used as
-  # test fixtures. They must NOT be updated by dependabot.
-  - package-ecosystem: "npm"
-    directories:
-      - "/test/providers/tst_manifests/npm/**"
-      - "/test/providers/tst_manifests/pnpm/**"
-      - "/test/providers/tst_manifests/yarn-berry/**"
-      - "/test/providers/tst_manifests/yarn-classic/**"
-      - "/test/providers/tst_manifests/js-common/**"
-      - "/test/providers/provider_manifests/npm/**"
-      - "/test/providers/provider_manifests/pnpm/**"
-      - "/test/providers/provider_manifests/yarn-berry/**"
-      - "/test/providers/provider_manifests/yarn-classic/**"
+  # ── Non-production ecosystems (no real deps, suppress everything) ────
+  # The repo has no production maven/pip/go/gradle/cargo dependencies.
+  # A root-level ignore-all entry ensures security updates are also
+  # suppressed, since per-directory entries with globs don't reliably
+  # block them.
+  - package-ecosystem: "maven"
+    directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     labels: []
     ignore:
       - dependency-name: "*"
   - package-ecosystem: "pip"
-    directories:
-      - "/test/providers/tst_manifests/pip/**"
-      - "/test/providers/tst_manifests/pyproject/**"
+    directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     labels: []
     ignore:
       - dependency-name: "*"
   - package-ecosystem: "uv"
-    directories:
-      - "/test/providers/tst_manifests/pyproject/**"
+    directory: "/"
     schedule:
       interval: "monthly"
-    labels: []
-    ignore:
-      - dependency-name: "*"
-  - package-ecosystem: "maven"
-    directories:
-      - "/test/providers/tst_manifests/maven/**"
-    schedule:
-      interval: "monthly"
-    labels: []
-    ignore:
-      - dependency-name: "*"
-  - package-ecosystem: "gradle"
-    directories:
-      - "/test/providers/tst_manifests/gradle/**"
-    schedule:
-      interval: "monthly"
-    labels: []
-    ignore:
-      - dependency-name: "*"
-  - package-ecosystem: "cargo"
-    directories:
-      - "/test/providers/tst_manifests/cargo/**"
-      - "/test/providers/provider_manifests/cargo/**"
-    schedule:
-      interval: "monthly"
+    open-pull-requests-limit: 0
     labels: []
     ignore:
       - dependency-name: "*"
   - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    labels: []
+    ignore:
+      - dependency-name: "*"
+
+  # ── Test fixture manifests (npm only) ───────────────────────────────
+  # npm is the production ecosystem so it cannot use a root-level
+  # ignore-all. Glob patterns (/**) don't reliably match nested
+  # subdirectories for security updates, so every directory containing
+  # a package.json is listed explicitly. Update this list when adding
+  # new test fixtures.
+  - package-ecosystem: "npm"
     directories:
-      - "/test/providers/tst_manifests/golang/**"
+      - "/test/providers/provider_manifests/npm/with_lock_file"
+      - "/test/providers/provider_manifests/npm/without_lock_file"
+      - "/test/providers/provider_manifests/npm/workspace_member_with_lock"
+      - "/test/providers/provider_manifests/npm/workspace_member_with_lock/packages/module-a"
+      - "/test/providers/provider_manifests/npm/workspace_member_without_lock"
+      - "/test/providers/provider_manifests/npm/workspace_member_without_lock/packages/module-a"
+      - "/test/providers/provider_manifests/pnpm/with_lock_file"
+      - "/test/providers/provider_manifests/pnpm/without_lock_file"
+      - "/test/providers/provider_manifests/pnpm/workspace_member_without_lock"
+      - "/test/providers/provider_manifests/pnpm/workspace_member_without_lock/packages/module-a"
+      - "/test/providers/provider_manifests/yarn-berry/with_lock_file"
+      - "/test/providers/provider_manifests/yarn-berry/without_lock_file"
+      - "/test/providers/provider_manifests/yarn-classic/with_lock_file"
+      - "/test/providers/provider_manifests/yarn-classic/without_lock_file"
+      - "/test/providers/tst_manifests/npm/package_json_deps_with_exhortignore_object"
+      - "/test/providers/tst_manifests/npm/package_json_deps_with_mixed_dep_types"
+      - "/test/providers/tst_manifests/npm/package_json_deps_without_exhortignore_object"
+      - "/test/providers/tst_manifests/npm/workspace_member"
+      - "/test/providers/tst_manifests/npm/workspace_member/packages/member-a"
+      - "/test/providers/tst_manifests/pnpm/package_json_deps_with_exhortignore_object"
+      - "/test/providers/tst_manifests/pnpm/package_json_deps_with_mixed_dep_types"
+      - "/test/providers/tst_manifests/pnpm/package_json_deps_without_exhortignore_object"
+      - "/test/providers/tst_manifests/pnpm/workspace_member"
+      - "/test/providers/tst_manifests/pnpm/workspace_member/packages/member-a"
+      - "/test/providers/tst_manifests/yarn-berry/package_json_deps_with_exhortignore_object"
+      - "/test/providers/tst_manifests/yarn-berry/package_json_deps_with_mixed_dep_types"
+      - "/test/providers/tst_manifests/yarn-berry/package_json_deps_without_exhortignore_object"
+      - "/test/providers/tst_manifests/yarn-berry/workspace_member"
+      - "/test/providers/tst_manifests/yarn-berry/workspace_member/packages/member-a"
+      - "/test/providers/tst_manifests/yarn-classic/package_json_deps_with_exhortignore_object"
+      - "/test/providers/tst_manifests/yarn-classic/package_json_deps_with_mixed_dep_types"
+      - "/test/providers/tst_manifests/yarn-classic/package_json_deps_without_exhortignore_object"
     schedule:
       interval: "monthly"
     labels: []

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -90,6 +90,10 @@ test/
 - DCO (Developer Certificate of Origin) required
 - Semantic versioning (`0.3.0` in package.json)
 
+## Test Fixtures
+
+- **Dependabot suppression**: Test fixture directories contain intentionally pinned (sometimes vulnerable) dependencies. When adding a new test fixture directory with a manifest file, review `.github/dependabot.yml` to ensure the new path is covered. Non-npm ecosystems are suppressed via root-level `ignore: [{dependency-name: "*"}]` entries. npm fixtures use per-directory entries with `/**` globs; add the parent directory if a new npm/pnpm/yarn fixture tree is introduced.
+
 ## Dependencies
 
 - **Package manager**: npm with `package-lock.json`

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,6 +1,6 @@
 # Coding Conventions
 
-<!-- This file documents project-specific coding standards for exhort-javascript-api. -->
+<!-- This file documents project-specific coding standards for trustify-da-javascript-client. -->
 
 ## Language and Framework
 


### PR DESCRIPTION
## Summary
- Add root-level `ignore: [{dependency-name: "*"}]` entries for all ecosystems with no production dependencies (maven, pip, uv, gomod, gradle, cargo)
- Replace `/**` glob patterns with explicit directory listings for npm test fixture entries, since globs don't reliably match nested subdirectories for security updates
- Add test fixture dependabot guidance to CONVENTIONS.md

## Context
Per-directory entries with `/**` globs don't reliably suppress Dependabot security updates for nested subdirectories (e.g., workspace member `packages/member-a`). Root-level `ignore: *` reliably blocks both version and security updates for non-production ecosystems (proven in the Java client). For npm (production ecosystem), explicit directory listings replace unreliable globs.

## Test plan
- [ ] Verify no new Dependabot security PRs appear for test fixture directories
- [ ] Verify production npm dependency updates still work normally
- [ ] Verify maven/pip/cargo/go/gradle/uv test fixture PRs are fully suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Dependabot configuration to fully suppress updates for non-production ecosystems and test fixtures while preserving production npm updates, and document the conventions for managing these fixtures.

Build:
- Configure root-level Dependabot entries for maven, pip, uv, gomod, gradle, and cargo to ignore all dependencies and prevent opening pull requests.
- Refine npm Dependabot configuration to enumerate all test fixture directories explicitly instead of using glob patterns, ensuring their dependencies are not updated.

Documentation:
- Add documentation describing how test fixture directories are handled by Dependabot and what to update when adding new fixtures.