### PR TITLE
fix: handle go replace directives in MVS version resolution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import analysis from './analysis.js'
 import fs from 'node:fs'
 import { getCustom } from "./tools.js";
 import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
+import { discoverUvWorkspaceMembers } from './providers/python_uv.js'
 import {
-	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -100,7 +100,7 @@ export {
  * @param {any} valueToBePrinted - The value to log.
  * @private
  */
-function logOptionsAndEnvironmentsVariables(alongsideText,valueToBePrinted) {
+function logOptionsAndEnvironmentsVariables(alongsideText, valueToBePrinted) {
 	if (process.env["TRUSTIFY_DA_DEBUG"] === "true") {
 		console.log(`${alongsideText}: ${valueToBePrinted} ${EOL}`)
 	}
@@ -112,9 +112,9 @@ function logOptionsAndEnvironmentsVariables(alongsideText,valueToBePrinted) {
  */
 function readAndPrintVersionFromPackageJson() {
 	let dirName
-// new ESM way in nodeJS ( since node version 22 ) to bring module directory.
+	// new ESM way in nodeJS ( since node version 22 ) to bring module directory.
 	dirName = import.meta.dirname
-// old ESM way in nodeJS ( before node versions 22.00 to bring module directory)
+	// old ESM way in nodeJS ( before node versions 22.00 to bring module directory)
 	if (!dirName) {
 		dirName = url.fileURLToPath(new URL('.', import.meta.url));
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import fs from 'node:fs'
 import { getCustom } from "./tools.js";
 import { resolveBatchMetadata, resolveContinueOnError } from './batch_opts.js'
 import {
+	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -23,6 +24,7 @@ export { getProjectLicense, findLicenseFilePath, identifyLicense, getLicenseDeta
 
 export default { componentAnalysis, stackAnalysis, stackAnalysisBatch, imageAnalysis, validateToken, generateSbom }
 export {
+	discoverUvWorkspaceMembers,
 	discoverWorkspacePackages,
 	discoverWorkspaceCrates,
 	validatePackageJson,
@@ -83,7 +85,7 @@ export {
 /**
  * @typedef {{
  *   workspaceRoot: string,
- *   ecosystem: 'javascript' | 'cargo' | 'unknown',
+ *   ecosystem: 'javascript' | 'cargo' | 'pyproject' | 'unknown',
  *   total: number,
  *   successful: number,
  *   failed: number,
@@ -319,7 +321,7 @@ async function generateOneSbom(manifestPath, workspaceOpts) {
  *
  * @param {string} root - Resolved workspace root
  * @param {Options} opts
- * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'unknown', manifestPaths: string[] }>}
+ * @returns {Promise<{ ecosystem: 'javascript' | 'cargo' | 'pyproject' | 'unknown', manifestPaths: string[] }>}
  * @private
  */
 async function detectWorkspaceManifests(root, opts) {
@@ -329,6 +331,13 @@ async function detectWorkspaceManifests(root, opts) {
 
 	if (fs.existsSync(cargoToml) && fs.existsSync(cargoLock)) {
 		return { ecosystem: 'cargo', manifestPaths: await discoverWorkspaceCrates(root, opts) }
+	}
+
+	if (fs.existsSync(path.join(root, 'pyproject.toml')) && fs.existsSync(path.join(root, 'uv.lock'))) {
+		const manifestPaths = await discoverUvWorkspaceMembers(root, opts)
+		if (manifestPaths.length > 0) {
+			return { ecosystem: 'pyproject', manifestPaths }
+		}
 	}
 
 	const hasJsLock = fs.existsSync(path.join(root, 'pnpm-lock.yaml'))
@@ -489,7 +498,7 @@ async function stackAnalysisBatch(workspaceRoot, html = false, opts = {}) {
 	}
 
 	if (manifestPaths.length === 0) {
-		throw new Error(`No workspace manifests found at ${root}. Ensure Cargo.toml+Cargo.lock or package.json+lock file exist.`)
+		throw new Error(`No workspace manifests found at ${root}. Ensure a supported workspace root exists (Cargo.toml+Cargo.lock, pyproject.toml+uv.lock, or package.json+lock file).`)
 	}
 
 	const workspaceOpts = { ...opts, TRUSTIFY_DA_WORKSPACE_DIR: root }

--- a/src/providers/golang_gomodules.js
+++ b/src/providers/golang_gomodules.js
@@ -353,13 +353,7 @@ function getFinalPackagesVersionsForModule(rows, manifestPath, goBin) {
 		throw new Error('failed to list all modules', {cause: error})
 	}
 
-	let finalVersionModules = new Map()
-	finalVersionsForAllModules.split(getLineSeparatorGolang()).filter(string => string.trim()!== "")
-		.filter(string => string.trim().split(" ").length === 2)
-		.forEach((dependency) => {
-			let dep = dependency.split(" ")
-			finalVersionModules[dep[0]] = dep[1]
-		})
+	let finalVersionModules = parseModuleVersions(finalVersionsForAllModules)
 	let finalVersionModulesArray = new Array()
 	rows.filter(string => string.trim()!== "").forEach( module => {
 		let child = getChildVertexFromEdge(module)
@@ -421,6 +415,20 @@ function isSpecialGoModule(moduleName) {
 function getVersionOfPackage(fullPackage) {
 	let parts = fullPackage.split("@")
 	return parts.length > 1 ? parts[1] : undefined
+}
+
+function parseModuleVersions(goListOutput) {
+	let modules = new Map()
+	goListOutput.split(getLineSeparatorGolang()).filter(string => string.trim() !== "")
+		.forEach((line) => {
+			let parts = line.trim().split(" ")
+			if (parts.length === 2) {
+				modules[parts[0]] = parts[1]
+			} else if (parts.length >= 4 && parts[2] === "=>") {
+				modules[parts[0]] = parts[parts.length - 1]
+			}
+		})
+	return modules
 }
 
 function getLineSeparatorGolang() {

--- a/src/providers/python_uv.js
+++ b/src/providers/python_uv.js
@@ -1,9 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import fg from 'fast-glob'
 import { parse as parseToml } from 'smol-toml'
 
 import { environmentVariableIsPopulated, getCustomPath, invokeCommand } from '../tools.js'
+import { filterManifestPathsByDiscoveryIgnore, resolveWorkspaceDiscoveryIgnore } from '../workspace.js'
 
 import Base_pyproject from './base_pyproject.js'
 import { getParser, getPinnedVersionQuery } from './requirements_parser.js'
@@ -163,5 +165,100 @@ export default class Python_uv extends Base_pyproject {
 		}
 
 		return { directDeps, graph }
+	}
+}
+
+const DEFAULT_UV_DISCOVERY_IGNORE = [
+	'**/__pycache__/**',
+	'**/.venv/**',
+]
+
+/**
+ * Convert workspace glob patterns to manifest-file glob patterns,
+ * correctly handling negation prefixes.
+ *
+ * @param {string[]} patterns - Workspace glob patterns (may include negations)
+ * @param {string} manifestFileName - e.g. 'pyproject.toml'
+ * @returns {string[]}
+ */
+function toManifestGlobPatterns(patterns, manifestFileName) {
+	return patterns.map(p => {
+		if (p.startsWith('!')) {
+			return `!${p.slice(1)}/${manifestFileName}`
+		}
+		return `${p}/${manifestFileName}`
+	})
+}
+
+/**
+ * Discover all pyproject.toml manifest paths in a uv workspace.
+ * Parses `[tool.uv.workspace]` from root pyproject.toml and glob-expands member patterns.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pyproject.toml and uv.lock)
+ * @param {{ workspaceDiscoveryIgnore?: string[], TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE?: string, [key: string]: unknown }} [opts={}]
+ * @returns {Promise<string[]>} Paths to pyproject.toml files (absolute)
+ */
+export async function discoverUvWorkspaceMembers(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const rootPyproject = path.join(root, 'pyproject.toml')
+	const uvLock = path.join(root, 'uv.lock')
+
+	if (!fs.existsSync(rootPyproject) || !fs.existsSync(uvLock)) {
+		return []
+	}
+
+	let parsed
+	try {
+		parsed = parseToml(fs.readFileSync(rootPyproject, 'utf-8'))
+	} catch {
+		return []
+	}
+
+	const workspaceConfig = parsed?.tool?.uv?.workspace
+	if (!workspaceConfig) {
+		return []
+	}
+
+	const memberPatterns = workspaceConfig.members
+	if (!Array.isArray(memberPatterns) || memberPatterns.length === 0) {
+		return []
+	}
+
+	const excludePatterns = Array.isArray(workspaceConfig.exclude) ? workspaceConfig.exclude : []
+	const excludeGlobs = excludePatterns
+		.filter(p => typeof p === 'string' && p.trim())
+		.map(p => `${p.trim()}/pyproject.toml`)
+
+	const ignorePatterns = [...resolveWorkspaceDiscoveryIgnore(opts), ...DEFAULT_UV_DISCOVERY_IGNORE]
+	const globOpts = {
+		cwd: root,
+		absolute: true,
+		onlyFiles: true,
+		ignore: [...ignorePatterns, ...excludeGlobs],
+		followSymbolicLinks: false,
+	}
+
+	const patterns = toManifestGlobPatterns(
+		memberPatterns.filter(p => typeof p === 'string'),
+		'pyproject.toml',
+	)
+	const manifestPaths = await fg(patterns, globOpts)
+
+	if (!manifestPaths.includes(rootPyproject) && hasProjectMetadata(parsed)) {
+		manifestPaths.unshift(rootPyproject)
+	}
+
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * @param {import('smol-toml').TomlTable} parsedPyProject
+ * @returns {boolean}
+ */
+function hasProjectMetadata(parsedPyProject) {
+	try {
+		return typeof parsedPyProject?.project?.name === 'string' && parsedPyProject.project.name.trim() !== ''
+	} catch {
+		return false
 	}
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -4,6 +4,7 @@ import path from 'node:path'
 import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
+import { parse as parseToml } from 'smol-toml'
 
 import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 
@@ -11,6 +12,8 @@ import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
+	'**/__pycache__/**',
+	'**/.venv/**',
 ]
 
 /**
@@ -268,4 +271,72 @@ export async function discoverWorkspaceCrates(workspaceRoot, opts = {}) {
 	}
 	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * Discover all pyproject.toml manifest paths in a uv workspace.
+ * Parses `[tool.uv.workspace]` from root pyproject.toml and glob-expands member patterns.
+ *
+ * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pyproject.toml and uv.lock)
+ * @param {{ workspaceDiscoveryIgnore?: string[], TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE?: string, [key: string]: unknown }} [opts={}]
+ * @returns {Promise<string[]>} Paths to pyproject.toml files (absolute)
+ */
+export async function discoverUvWorkspaceMembers(workspaceRoot, opts = {}) {
+	const root = path.resolve(workspaceRoot)
+	const rootPyproject = path.join(root, 'pyproject.toml')
+	const uvLock = path.join(root, 'uv.lock')
+
+	if (!fs.existsSync(rootPyproject) || !fs.existsSync(uvLock)) {
+		return []
+	}
+
+	let parsed
+	try {
+		parsed = parseToml(fs.readFileSync(rootPyproject, 'utf-8'))
+	} catch {
+		return []
+	}
+
+	const workspaceConfig = parsed?.tool?.uv?.workspace
+	if (!workspaceConfig) {
+		return []
+	}
+
+	const memberPatterns = workspaceConfig.members
+	if (!Array.isArray(memberPatterns) || memberPatterns.length === 0) {
+		return []
+	}
+
+	const excludePatterns = Array.isArray(workspaceConfig.exclude) ? workspaceConfig.exclude : []
+	const excludeGlobs = excludePatterns
+		.filter(p => typeof p === 'string' && p.trim())
+		.map(p => `${p.trim()}/pyproject.toml`)
+
+	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
+	const globOpts = buildWorkspaceDiscoveryGlobOptions(root, [...ignorePatterns, ...excludeGlobs])
+
+	const patterns = toManifestGlobPatterns(
+		memberPatterns.filter(p => typeof p === 'string'),
+		'pyproject.toml',
+	)
+	const manifestPaths = await fg(patterns, globOpts)
+
+	if (!manifestPaths.includes(rootPyproject) && hasProjectMetadata(rootPyproject)) {
+		manifestPaths.unshift(rootPyproject)
+	}
+
+	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
+}
+
+/**
+ * @param {string} pyprojectPath
+ * @returns {boolean}
+ */
+function hasProjectMetadata(pyprojectPath) {
+	try {
+		const content = parseToml(fs.readFileSync(pyprojectPath, 'utf-8'))
+		return typeof content?.project?.name === 'string' && content.project.name.trim() !== ''
+	} catch {
+		return false
+	}
 }

--- a/src/workspace.js
+++ b/src/workspace.js
@@ -4,7 +4,6 @@ import path from 'node:path'
 import fg from 'fast-glob'
 import { load as yamlLoad } from 'js-yaml'
 import micromatch from 'micromatch'
-import { parse as parseToml } from 'smol-toml'
 
 import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 
@@ -12,8 +11,6 @@ import { getCustom, getCustomPath, invokeCommand } from './tools.js'
 const DEFAULT_WORKSPACE_DISCOVERY_IGNORE = [
 	'**/node_modules/**',
 	'**/.git/**',
-	'**/__pycache__/**',
-	'**/.venv/**',
 ]
 
 /**
@@ -273,70 +270,3 @@ export async function discoverWorkspaceCrates(workspaceRoot, opts = {}) {
 	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
 }
 
-/**
- * Discover all pyproject.toml manifest paths in a uv workspace.
- * Parses `[tool.uv.workspace]` from root pyproject.toml and glob-expands member patterns.
- *
- * @param {string} workspaceRoot - Absolute or relative path to workspace root (must contain pyproject.toml and uv.lock)
- * @param {{ workspaceDiscoveryIgnore?: string[], TRUSTIFY_DA_WORKSPACE_DISCOVERY_IGNORE?: string, [key: string]: unknown }} [opts={}]
- * @returns {Promise<string[]>} Paths to pyproject.toml files (absolute)
- */
-export async function discoverUvWorkspaceMembers(workspaceRoot, opts = {}) {
-	const root = path.resolve(workspaceRoot)
-	const rootPyproject = path.join(root, 'pyproject.toml')
-	const uvLock = path.join(root, 'uv.lock')
-
-	if (!fs.existsSync(rootPyproject) || !fs.existsSync(uvLock)) {
-		return []
-	}
-
-	let parsed
-	try {
-		parsed = parseToml(fs.readFileSync(rootPyproject, 'utf-8'))
-	} catch {
-		return []
-	}
-
-	const workspaceConfig = parsed?.tool?.uv?.workspace
-	if (!workspaceConfig) {
-		return []
-	}
-
-	const memberPatterns = workspaceConfig.members
-	if (!Array.isArray(memberPatterns) || memberPatterns.length === 0) {
-		return []
-	}
-
-	const excludePatterns = Array.isArray(workspaceConfig.exclude) ? workspaceConfig.exclude : []
-	const excludeGlobs = excludePatterns
-		.filter(p => typeof p === 'string' && p.trim())
-		.map(p => `${p.trim()}/pyproject.toml`)
-
-	const ignorePatterns = resolveWorkspaceDiscoveryIgnore(opts)
-	const globOpts = buildWorkspaceDiscoveryGlobOptions(root, [...ignorePatterns, ...excludeGlobs])
-
-	const patterns = toManifestGlobPatterns(
-		memberPatterns.filter(p => typeof p === 'string'),
-		'pyproject.toml',
-	)
-	const manifestPaths = await fg(patterns, globOpts)
-
-	if (!manifestPaths.includes(rootPyproject) && hasProjectMetadata(rootPyproject)) {
-		manifestPaths.unshift(rootPyproject)
-	}
-
-	return filterManifestPathsByDiscoveryIgnore(manifestPaths, root, ignorePatterns)
-}
-
-/**
- * @param {string} pyprojectPath
- * @returns {boolean}
- */
-function hasProjectMetadata(pyprojectPath) {
-	try {
-		const content = parseToml(fs.readFileSync(pyprojectPath, 'utf-8'))
-		return typeof content?.project?.name === 'string' && content.project.name.trim() !== ''
-	} catch {
-		return false
-	}
-}

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
@@ -25,10 +25,10 @@
         {
             "group": "golang.org/x",
             "name": "tools",
-            "version": "v0.0.0-20210112183307-1e6ecd4bf1b0",
-            "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+            "version": "v0.1.0",
+            "purl": "pkg:golang/golang.org/x/tools@v0.1.0",
             "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+            "bom-ref": "pkg:golang/golang.org/x/tools@v0.1.0"
         },
         {
             "group": "github.com/BurntSushi",
@@ -117,6 +117,14 @@
             "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.0.0-20210119212857-b64e53b001e4",
+            "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4"
         },
         {
             "group": "golang.org/x",
@@ -280,14 +288,6 @@
         },
         {
             "group": "golang.org/x",
-            "name": "sys",
-            "version": "v0.0.0-20200930185726-fdedc70b468f",
-            "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
-        },
-        {
-            "group": "golang.org/x",
             "name": "text",
             "version": "v0.3.3",
             "purl": "pkg:golang/golang.org/x/text@v0.3.3",
@@ -316,7 +316,7 @@
             "ref": "pkg:golang/golang.org/x/example@v0.0.0",
             "dependsOn": [
                 "pkg:golang/github.com/spf13/cobra@v0.0.5",
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+                "pkg:golang/golang.org/x/tools@v0.1.0"
             ]
         },
         {
@@ -332,12 +332,13 @@
             ]
         },
         {
-            "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+            "ref": "pkg:golang/golang.org/x/tools@v0.1.0",
             "dependsOn": [
                 "pkg:golang/github.com/yuin/goldmark@v1.2.1",
                 "pkg:golang/golang.org/x/mod@v0.3.0",
                 "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
                 "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
                 "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
             ]
         },
@@ -383,7 +384,7 @@
                 "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
                 "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
                 "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
                 "pkg:golang/golang.org/x/text@v0.3.3",
                 "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
             ]
@@ -402,7 +403,7 @@
             "ref": "pkg:golang/golang.org/x/mod@v0.3.0",
             "dependsOn": [
                 "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+                "pkg:golang/golang.org/x/tools@v0.1.0",
                 "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
             ]
         },
@@ -410,12 +411,16 @@
             "ref": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
             "dependsOn": [
                 "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
                 "pkg:golang/golang.org/x/text@v0.3.3"
             ]
         },
         {
             "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
             "dependsOn": []
         },
         {
@@ -506,17 +511,13 @@
             "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
             "dependsOn": [
                 "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-                "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4"
             ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-            "dependsOn": []
         },
         {
             "ref": "pkg:golang/golang.org/x/text@v0.3.3",
             "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+                "pkg:golang/golang.org/x/tools@v0.1.0"
             ]
         },
         {

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.mod
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.mod
@@ -7,4 +7,4 @@ require github.com/spf13/cobra v0.0.5
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect
 
-
+replace golang.org/x/tools v0.0.0-20210112183307-1e6ecd4bf1b0 => golang.org/x/tools v0.1.0

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.sum
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.sum
@@ -38,11 +38,13 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210112183307-1e6ecd4bf1b0/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/core/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/core/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "core"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/internal/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/packages/internal/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "internal"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "exclude-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["packages/*"]
+exclude = ["packages/internal"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_exclude/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_exclude/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/apps/backend/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/apps/backend/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "backend"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/libs/core/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/libs/core/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "core"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "nested-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["apps/*", "libs/*"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_nested/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_nested/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/tst_manifests/pyproject/uv_workspace_no_config/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_no_config/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "no-config"
+version = "0.1.0"
+dependencies = ["requests>=2.0"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_no_config/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_no_config/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/tst_manifests/pyproject/uv_workspace_no_lock/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_no_lock/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "no-lock-workspace"
+version = "0.1.0"
+dependencies = []
+
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-a/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-a/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pkg-a"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-b/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/packages/pkg-b/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "pkg-b"
+version = "0.1.0"
+dependencies = []

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/pyproject.toml
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.uv.workspace]
+members = ["packages/*"]

--- a/test/providers/tst_manifests/pyproject/uv_workspace_virtual/uv.lock
+++ b/test/providers/tst_manifests/pyproject/uv_workspace_virtual/uv.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -4,8 +4,8 @@ import path from 'node:path'
 import { expect } from 'chai'
 import esmock from 'esmock'
 
+import { discoverUvWorkspaceMembers } from '../../src/providers/python_uv.js'
 import {
-	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,

--- a/test/providers/workspace.test.js
+++ b/test/providers/workspace.test.js
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 import esmock from 'esmock'
 
 import {
+	discoverUvWorkspaceMembers,
 	discoverWorkspaceCrates,
 	discoverWorkspacePackages,
 	filterManifestPathsByDiscoveryIgnore,
@@ -185,5 +186,73 @@ suite('discoverWorkspaceCrates', () => {
 		expect(result.every(p => p.endsWith('Cargo.toml'))).to.be.true
 		expect(result.some(p => p.includes('crate-a'))).to.be.true
 		expect(result.some(p => p.includes('crate-b'))).to.be.true
+	})
+})
+
+suite('discoverUvWorkspaceMembers', () => {
+	test('returns empty when no pyproject.toml at root', async () => {
+		const result = await discoverUvWorkspaceMembers('test/providers/tst_manifests/npm')
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('returns empty when pyproject.toml exists but no uv.lock', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_no_lock')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('returns empty when pyproject.toml has no [tool.uv.workspace]', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_no_config')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(0)
+	})
+
+	test('discovers members from root-package workspace (includes root)', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(3)
+		expect(result.every(p => p.endsWith('pyproject.toml'))).to.be.true
+		expect(result[0]).to.equal(path.join(root, 'pyproject.toml'))
+		expect(result.some(p => p.includes(path.join('packages', 'mid-pkg')))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'sub-pkg')))).to.be.true
+	})
+
+	test('discovers members from virtual workspace (excludes root)', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_virtual')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result).to.have.lengthOf(2)
+		expect(result.every(p => p.endsWith('pyproject.toml'))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'pkg-a')))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'pkg-b')))).to.be.true
+		expect(result.every(p => p !== path.join(root, 'pyproject.toml'))).to.be.true
+	})
+
+	test('respects exclude patterns', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_exclude')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result.some(p => p.includes(path.join('packages', 'core')))).to.be.true
+		expect(result.some(p => p.includes(path.join('packages', 'internal')))).to.be.false
+	})
+
+	test('discovers members from multiple glob patterns', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_nested')
+		const result = await discoverUvWorkspaceMembers(root)
+		expect(result).to.be.an('array')
+		expect(result.some(p => p.includes(path.join('apps', 'backend')))).to.be.true
+		expect(result.some(p => p.includes(path.join('libs', 'core')))).to.be.true
+	})
+
+	test('applies workspaceDiscoveryIgnore patterns', async () => {
+		const root = path.resolve('test/providers/tst_manifests/pyproject/uv_workspace_nested')
+		const result = await discoverUvWorkspaceMembers(root, {
+			workspaceDiscoveryIgnore: ['**/libs/**'],
+		})
+		expect(result.some(p => p.includes(path.join('apps', 'backend')))).to.be.true
+		expect(result.some(p => p.includes(path.join('libs', 'core')))).to.be.false
 	})
 })


### PR DESCRIPTION
## Summary
- Fix `go list -m all` output parsing to handle modules with `replace` directives, which have 5 space-separated parts (`A v1 => B v2`) instead of 2
- Extract parsing into `parseModuleVersions()` function that maps original module names to their replacement versions
- Add a version-changing `replace` directive to the `go_mod_light_no_ignore` test manifest and update expected SBOM output to verify the fix

## Context
[TC-4346] The JavaScript client was silently dropping replaced modules from the MVS version map, causing them to resolve to `undefined` versions in the SBOM. This could lead to missed CVEs when `replace` directives change dependency versions.

## Test plan
- [x] All 15 existing Go module tests pass
- [x] `go_mod_light_no_ignore` stack analysis SBOM now correctly shows `golang.org/x/tools@v0.1.0` (the replaced version) instead of the original `v0.0.0-20210112183307-1e6ecd4bf1b0`
- [x] Transitive dependency versions (e.g. `golang.org/x/sys`) are updated to match the replacement's dependency graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4346]: https://redhat.atlassian.net/browse/TC-4346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle Go module replace directives correctly in MVS version resolution and add support for discovering Python uv workspaces in workspace-based SBOM generation.

New Features:
- Add discovery of uv-based Python workspaces by parsing [tool.uv.workspace] from pyproject.toml and locating member manifests.
- Expose uv workspace discovery through the main public API and extend workspace manifest detection to recognize pyproject+uv.lock roots.

Bug Fixes:
- Fix Go module version mapping to correctly parse go list -m all output, including modules with replace directives so replaced versions are used in SBOMs.

Enhancements:
- Improve workspace detection error messaging to mention all supported workspace types, including uv-based pyproject workspaces.

Tests:
- Add unit tests and fixture pyproject/uv.lock workspaces to cover uv workspace member discovery, exclusion patterns, and ignore behavior.
- Update Go module test fixtures and expected SBOM output to validate correct handling of replace directives in version resolution.