### PR TITLE
fix: handle go replace directives in MVS version resolution

### DIFF
--- a/src/providers/golang_gomodules.js
+++ b/src/providers/golang_gomodules.js
@@ -353,13 +353,7 @@ function getFinalPackagesVersionsForModule(rows, manifestPath, goBin) {
 		throw new Error('failed to list all modules', {cause: error})
 	}
 
-	let finalVersionModules = new Map()
-	finalVersionsForAllModules.split(getLineSeparatorGolang()).filter(string => string.trim()!== "")
-		.filter(string => string.trim().split(" ").length === 2)
-		.forEach((dependency) => {
-			let dep = dependency.split(" ")
-			finalVersionModules[dep[0]] = dep[1]
-		})
+	let finalVersionModules = parseModuleVersions(finalVersionsForAllModules)
 	let finalVersionModulesArray = new Array()
 	rows.filter(string => string.trim()!== "").forEach( module => {
 		let child = getChildVertexFromEdge(module)
@@ -421,6 +415,20 @@ function isSpecialGoModule(moduleName) {
 function getVersionOfPackage(fullPackage) {
 	let parts = fullPackage.split("@")
 	return parts.length > 1 ? parts[1] : undefined
+}
+
+function parseModuleVersions(goListOutput) {
+	let modules = {}
+	goListOutput.split(getLineSeparatorGolang()).filter(string => string.trim() !== "")
+		.forEach((line) => {
+			let parts = line.trim().split(" ")
+			if (parts.length === 2) {
+				modules[parts[0]] = parts[1]
+			} else if (parts.length >= 4 && parts[2] === "=>") {
+				modules[parts[0]] = parts[parts.length - 1]
+			}
+		})
+	return modules
 }
 
 function getLineSeparatorGolang() {

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/expected_sbom_stack_analysis.json
@@ -25,10 +25,10 @@
         {
             "group": "golang.org/x",
             "name": "tools",
-            "version": "v0.0.0-20210112183307-1e6ecd4bf1b0",
-            "purl": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+            "version": "v0.1.0",
+            "purl": "pkg:golang/golang.org/x/tools@v0.1.0",
             "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+            "bom-ref": "pkg:golang/golang.org/x/tools@v0.1.0"
         },
         {
             "group": "github.com/BurntSushi",
@@ -117,6 +117,14 @@
             "purl": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
             "type": "library",
             "bom-ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9"
+        },
+        {
+            "group": "golang.org/x",
+            "name": "sys",
+            "version": "v0.0.0-20210119212857-b64e53b001e4",
+            "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
+            "type": "library",
+            "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4"
         },
         {
             "group": "golang.org/x",
@@ -280,14 +288,6 @@
         },
         {
             "group": "golang.org/x",
-            "name": "sys",
-            "version": "v0.0.0-20200930185726-fdedc70b468f",
-            "purl": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-            "type": "library",
-            "bom-ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
-        },
-        {
-            "group": "golang.org/x",
             "name": "text",
             "version": "v0.3.3",
             "purl": "pkg:golang/golang.org/x/text@v0.3.3",
@@ -316,7 +316,7 @@
             "ref": "pkg:golang/golang.org/x/example@v0.0.0",
             "dependsOn": [
                 "pkg:golang/github.com/spf13/cobra@v0.0.5",
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+                "pkg:golang/golang.org/x/tools@v0.1.0"
             ]
         },
         {
@@ -332,12 +332,13 @@
             ]
         },
         {
-            "ref": "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+            "ref": "pkg:golang/golang.org/x/tools@v0.1.0",
             "dependsOn": [
                 "pkg:golang/github.com/yuin/goldmark@v1.2.1",
                 "pkg:golang/golang.org/x/mod@v0.3.0",
                 "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
                 "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
                 "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
             ]
         },
@@ -383,7 +384,7 @@
                 "pkg:golang/github.com/ugorji/go/codec@v0.0.0-20181204163529-d75b2dcb6bc8",
                 "pkg:golang/github.com/xordataexchange/crypt@v0.0.3-0.20170626215501-b2862e3d0a77",
                 "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
                 "pkg:golang/golang.org/x/text@v0.3.3",
                 "pkg:golang/gopkg.in/yaml.v2@v2.2.2"
             ]
@@ -402,7 +403,7 @@
             "ref": "pkg:golang/golang.org/x/mod@v0.3.0",
             "dependsOn": [
                 "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0",
+                "pkg:golang/golang.org/x/tools@v0.1.0",
                 "pkg:golang/golang.org/x/xerrors@v0.0.0-20200804184101-5ec99f83aff1"
             ]
         },
@@ -410,12 +411,16 @@
             "ref": "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
             "dependsOn": [
                 "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
-                "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
                 "pkg:golang/golang.org/x/text@v0.3.3"
             ]
         },
         {
             "ref": "pkg:golang/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4",
             "dependsOn": []
         },
         {
@@ -506,17 +511,13 @@
             "ref": "pkg:golang/golang.org/x/crypto@v0.0.0-20200622213623-75b288015ac9",
             "dependsOn": [
                 "pkg:golang/golang.org/x/net@v0.0.0-20201021035429-f5854403a974",
-                "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f"
+                "pkg:golang/golang.org/x/sys@v0.0.0-20210119212857-b64e53b001e4"
             ]
-        },
-        {
-            "ref": "pkg:golang/golang.org/x/sys@v0.0.0-20200930185726-fdedc70b468f",
-            "dependsOn": []
         },
         {
             "ref": "pkg:golang/golang.org/x/text@v0.3.3",
             "dependsOn": [
-                "pkg:golang/golang.org/x/tools@v0.0.0-20210112183307-1e6ecd4bf1b0"
+                "pkg:golang/golang.org/x/tools@v0.1.0"
             ]
         },
         {

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.mod
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.mod
@@ -7,4 +7,4 @@ require github.com/spf13/cobra v0.0.5
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect
 
-
+replace golang.org/x/tools v0.0.0-20210112183307-1e6ecd4bf1b0 => golang.org/x/tools v0.1.0

--- a/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.sum
+++ b/test/providers/tst_manifests/golang/go_mod_light_no_ignore/go.sum
@@ -38,11 +38,13 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20210112183307-1e6ecd4bf1b0/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Summary
- Fix `go list -m all` output parsing to handle modules with `replace` directives, which have 5 space-separated parts (`A v1 => B v2`) instead of 2
- Extract parsing into `parseModuleVersions()` function that maps original module names to their replacement versions
- Add a version-changing `replace` directive to the `go_mod_light_no_ignore` test manifest and update expected SBOM output to verify the fix

## Context
[TC-4346] The JavaScript client was silently dropping replaced modules from the MVS version map, causing them to resolve to `undefined` versions in the SBOM. This could lead to missed CVEs when `replace` directives change dependency versions.

## Test plan
- [x] All 15 existing Go module tests pass
- [x] `go_mod_light_no_ignore` stack analysis SBOM now correctly shows `golang.org/x/tools@v0.1.0` (the replaced version) instead of the original `v0.0.0-20210112183307-1e6ecd4bf1b0`
- [x] Transitive dependency versions (e.g. `golang.org/x/sys`) are updated to match the replacement's dependency graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4346]: https://redhat.atlassian.net/browse/TC-4346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle Go module replace directives when resolving final module versions from `go list -m all` output.

Bug Fixes:
- Ensure modules with `replace` directives are included with their correct replacement versions in the MVS version map.

Enhancements:
- Extract module version parsing into a reusable `parseModuleVersions` helper that understands standard and replaced module lines.

Tests:
- Extend the `go_mod_light_no_ignore` Go manifest and expected SBOM to validate handling of version-changing replace directives.