### PR TITLE
fix(cargo): resolve workspace-inherited license in Cargo.toml

### DIFF
--- a/src/cyclone_dx_sbom.js
+++ b/src/cyclone_dx_sbom.js
@@ -47,12 +47,20 @@ function getComponent(component, type, scope, licenses, hashes) {
 	// Add licenses if provided (CycloneDX format). Callers must provide valid SPDX identifiers.
 	if (licenses) {
 		const licenseArray = Array.isArray(licenses) ? licenses : [licenses];
-		componentObject.licenses = licenseArray.map(lic => {
-			if (typeof lic === 'string') {
-				return { license: { id: lic } };
-			}
-			return lic;
-		});
+		const validLicenses = licenseArray
+			.map(lic => {
+				if (typeof lic === 'string') {
+					return { license: { id: lic } };
+				}
+				if (typeof lic === 'object' && lic !== null && ('license' in lic || 'expression' in lic)) {
+					return lic;
+				}
+				return null;
+			})
+			.filter(Boolean);
+		if (validLicenses.length > 0) {
+			componentObject.licenses = validLicenses;
+		}
 	}
 
 	// Add hashes if provided (CycloneDX 1.4 format).

--- a/src/provider.js
+++ b/src/provider.js
@@ -15,7 +15,7 @@ import Python_uv from './providers/python_uv.js'
 import rustCargoProvider from './providers/rust_cargo.js'
 
 /** @typedef {{ecosystem: string, contentType: string, content: string}} Provided */
-/** @typedef {{isSupported: function(string): boolean, validateLockFile: function(string, Object): void, provideComponent: function(string, {}): Provided | Promise<Provided>, provideStack: function(string, {}): Provided | Promise<Provided>, readLicenseFromManifest: function(string): string | null, packageManagerName: function(): string}} Provider */
+/** @typedef {{isSupported: function(string): boolean, validateLockFile: function(string, Object): void, provideComponent: function(string, {}): Provided | Promise<Provided>, provideStack: function(string, {}): Provided | Promise<Provided>, readLicenseFromManifest: function(string, Object=): string | null, packageManagerName: function(): string}} Provider */
 
 /**
  * MUST include all providers here.

--- a/src/providers/rust_cargo.js
+++ b/src/providers/rust_cargo.js
@@ -77,22 +77,50 @@ function isSupported(manifestName) {
  * Read project license from Cargo.toml, with fallback to LICENSE file.
  * Supports the `license` field under `[package]` (single crate / workspace
  * with root) and under `[workspace.package]` (virtual workspaces).
+ * When a member crate uses `license = { workspace = true }`, the actual
+ * license is resolved from the workspace root Cargo.toml.
  * @param {string} manifestPath - path to Cargo.toml
+ * @param {object} [metadata] - cargo metadata output (needed for workspace license resolution)
  * @returns {string|null} SPDX identifier or null
  */
-function readLicenseFromManifest(manifestPath) {
+function readLicenseFromManifest(manifestPath, metadata) {
 	let fromManifest = null
 	try {
 		let content = fs.readFileSync(manifestPath, 'utf-8')
 		let parsed = parseToml(content)
 
-		fromManifest = parsed.package?.license
+		let packageLicense = parsed.package?.license
+		if (typeof packageLicense === 'object' && packageLicense?.workspace === true) {
+			packageLicense = resolveWorkspaceLicense(parsed, metadata)
+		}
+
+		fromManifest = packageLicense
 			|| parsed.workspace?.package?.license
 			|| null
 	} catch (_) {
 		// leave fromManifest as null
 	}
 	return getLicense(fromManifest, manifestPath)
+}
+
+/**
+ * Resolve a workspace-inherited license from the workspace root Cargo.toml.
+ * @param {object} parsed - the parsed member crate Cargo.toml
+ * @param {object} [metadata] - cargo metadata output with workspace_root
+ * @returns {string|null} resolved license string or null
+ */
+function resolveWorkspaceLicense(parsed, metadata) {
+	if (metadata?.workspace_root) {
+		let cargoTomlPath = path.join(metadata.workspace_root, 'Cargo.toml')
+		try {
+			let content = fs.readFileSync(cargoTomlPath, 'utf-8')
+			let workspaceParsed = parseToml(content)
+			return workspaceParsed.workspace?.package?.license || null
+		} catch (_) {
+			// fall through
+		}
+	}
+	return parsed.workspace?.package?.license || null
 }
 
 /**
@@ -189,7 +217,7 @@ function getSBOM(manifest, opts = {}, includeTransitive) {
 	let metadata = executeCargoMetadata(cargoBin, manifestDir)
 	let ignoredDeps = getIgnoredDeps(manifest, metadata)
 	let crateType = detectCrateType(metadata)
-	let license = readLicenseFromManifest(manifest)
+	let license = readLicenseFromManifest(manifest, metadata)
 
 	let sbom
 	if (crateType === CrateType.WORKSPACE_VIRTUAL) {

--- a/test/cyclone_dx_sbom_hashes.test.js
+++ b/test/cyclone_dx_sbom_hashes.test.js
@@ -151,3 +151,35 @@ suite('CycloneDX SBOM hash support', () => {
 		expect(targetComponent).to.not.have.property('hashes')
 	})
 })
+
+suite('CycloneDX SBOM license validation', () => {
+
+	/** Verifies that non-CycloneDX license objects (e.g., { workspace: true }) are filtered out. */
+	test('addRoot filters out non-CycloneDX license objects', () => {
+		// Given a license value that is an unresolved workspace inheritance marker
+		const sbom = new CycloneDxSbom()
+		const root = new PackageURL('cargo', undefined, 'my-crate', '1.0.0', undefined, undefined)
+
+		// When adding a root with a non-CycloneDX license object
+		sbom.addRoot(root, { workspace: true })
+
+		// Then the root component should have no licenses field
+		expect(sbom.rootComponent).to.not.have.property('licenses')
+	})
+
+	/** Verifies that valid CycloneDX license objects are preserved. */
+	test('addRoot preserves valid CycloneDX license objects', () => {
+		const sbom = new CycloneDxSbom()
+		const root = new PackageURL('cargo', undefined, 'my-crate', '1.0.0', undefined, undefined)
+		sbom.addRoot(root, { license: { id: 'MIT' } })
+		expect(sbom.rootComponent.licenses).to.deep.equal([{ license: { id: 'MIT' } }])
+	})
+
+	/** Verifies that string licenses are wrapped in CycloneDX format. */
+	test('addRoot wraps string license in CycloneDX format', () => {
+		const sbom = new CycloneDxSbom()
+		const root = new PackageURL('cargo', undefined, 'my-crate', '1.0.0', undefined, undefined)
+		sbom.addRoot(root, 'Apache-2.0')
+		expect(sbom.rootComponent.licenses).to.deep.equal([{ license: { id: 'Apache-2.0' } }])
+	})
+})

--- a/test/providers/rust_cargo.test.js
+++ b/test/providers/rust_cargo.test.js
@@ -538,3 +538,23 @@ suite('testing rust-cargo license detection', () => {
 		expect(sbom.metadata.component.licenses).to.be.undefined
 	}).timeout(10000)
 }).beforeAll(() => clock = useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(() => clock.restore());
+
+suite('testing rust-cargo workspace license inheritance', () => {
+	const workspaceLicenseDir = 'test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license'
+
+	/** Verifies that workspace-inherited license resolves correctly in stack analysis SBOM. */
+	test('verify workspace-inherited license is resolved in SBOM (stack analysis)', async () => {
+		await assertSbomMatchesExpected(workspaceLicenseDir, 'stack')
+	}).timeout(10000)
+
+	/** Verifies that workspace-inherited license resolves correctly in component analysis SBOM. */
+	test('verify workspace-inherited license is resolved in SBOM (component analysis)', async () => {
+		await assertSbomMatchesExpected(workspaceLicenseDir, 'component')
+	}).timeout(10000)
+
+	/** Verifies the resolved license value is Apache-2.0 from [workspace.package]. */
+	test('verify resolved workspace license is Apache-2.0 in SBOM metadata', async () => {
+		let sbom = await getParsedSbom(workspaceLicenseDir, 'stack')
+		expect(sbom.metadata.component.licenses).to.deep.equal([{ license: { id: 'Apache-2.0' } }])
+	}).timeout(10000)
+}).beforeAll(() => clock = useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(() => clock.restore());

--- a/test/providers/rust_cargo.test.js
+++ b/test/providers/rust_cargo.test.js
@@ -557,4 +557,22 @@ suite('testing rust-cargo workspace license inheritance', () => {
 		let sbom = await getParsedSbom(workspaceLicenseDir, 'stack')
 		expect(sbom.metadata.component.licenses).to.deep.equal([{ license: { id: 'Apache-2.0' } }])
 	}).timeout(10000)
+
+	const workspaceLicenseMissingDir = 'test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing'
+
+	/** Verifies SBOM omits licenses when workspace_root exists but has no license field. */
+	test('verify SBOM omits licenses when workspace license is missing (stack analysis)', async () => {
+		await assertSbomMatchesExpected(workspaceLicenseMissingDir, 'stack')
+	}).timeout(10000)
+
+	/** Verifies SBOM omits licenses when workspace_root exists but has no license field. */
+	test('verify SBOM omits licenses when workspace license is missing (component analysis)', async () => {
+		await assertSbomMatchesExpected(workspaceLicenseMissingDir, 'component')
+	}).timeout(10000)
+
+	/** Verifies the licenses property is undefined when workspace license cannot be resolved. */
+	test('verify licenses is undefined when workspace license is missing', async () => {
+		let sbom = await getParsedSbom(workspaceLicenseMissingDir, 'stack')
+		expect(sbom.metadata.component.licenses).to.be.undefined
+	}).timeout(10000)
 }).beforeAll(() => clock = useFakeTimers(new Date('2023-08-07T00:00:00.000Z'))).afterAll(() => clock.restore());

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/Cargo.lock
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/Cargo.lock
@@ -1,0 +1,2 @@
+# This file is a placeholder for lock file validation.
+# The actual dependency resolution is done by `cargo metadata`.

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/Cargo.toml
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "my-test-crate"
+version = { workspace = true }
+edition = "2021"
+license = { workspace = true }
+
+[workspace]
+members = []
+
+[workspace.package]
+version = "0.1.0"
+license = "Apache-2.0"
+
+[dependencies]
+serde = "1.0.193"
+tokio = { version = "1.35.0", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.8.0"

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/cargo_metadata.json
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/cargo_metadata.json
@@ -1,0 +1,150 @@
+{
+    "packages": [
+        {
+            "name": "my-test-crate",
+            "version": "0.1.0",
+            "id": "path+file:///fake/path/my-test-crate#0.1.0",
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "kind": null
+                },
+                {
+                    "name": "tokio",
+                    "kind": null
+                },
+                {
+                    "name": "tempfile",
+                    "kind": "dev"
+                }
+            ]
+        },
+        {
+            "name": "serde",
+            "version": "1.0.193",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.193",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde_derive",
+                    "kind": null
+                }
+            ]
+        },
+        {
+            "name": "serde_derive",
+            "version": "1.0.193",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.193",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": []
+        },
+        {
+            "name": "tokio",
+            "version": "1.35.0",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.35.0",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "pin-project-lite",
+                    "kind": null
+                }
+            ]
+        },
+        {
+            "name": "pin-project-lite",
+            "version": "0.2.13",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.13",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": []
+        },
+        {
+            "name": "tempfile",
+            "version": "3.8.0",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.8.0",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": []
+        }
+    ],
+    "workspace_members": [
+        "path+file:///fake/path/my-test-crate#0.1.0"
+    ],
+    "workspace_root": "test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license",
+    "resolve": {
+        "root": "path+file:///fake/path/my-test-crate#0.1.0",
+        "nodes": [
+            {
+                "id": "path+file:///fake/path/my-test-crate#0.1.0",
+                "deps": [
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.193",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.35.0",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.8.0",
+                        "dep_kinds": [
+                            {
+                                "kind": "dev",
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.193",
+                "deps": [
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.193",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.193",
+                "deps": []
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.35.0",
+                "deps": [
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.13",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.13",
+                "deps": []
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.8.0",
+                "deps": []
+            }
+        ]
+    }
+}

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/expected_sbom_component_analysis.json
@@ -1,0 +1,55 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "name": "my-test-crate",
+            "version": "0.1.0",
+            "purl": "pkg:cargo/my-test-crate@0.1.0",
+            "type": "application",
+            "bom-ref": "pkg:cargo/my-test-crate@0.1.0",
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ]
+        }
+    },
+    "components": [
+        {
+            "name": "serde",
+            "version": "1.0.193",
+            "purl": "pkg:cargo/serde@1.0.193",
+            "type": "library",
+            "bom-ref": "pkg:cargo/serde@1.0.193"
+        },
+        {
+            "name": "tokio",
+            "version": "1.35.0",
+            "purl": "pkg:cargo/tokio@1.35.0",
+            "type": "library",
+            "bom-ref": "pkg:cargo/tokio@1.35.0"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:cargo/my-test-crate@0.1.0",
+            "dependsOn": [
+                "pkg:cargo/serde@1.0.193",
+                "pkg:cargo/tokio@1.35.0"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/serde@1.0.193",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:cargo/tokio@1.35.0",
+            "dependsOn": []
+        }
+    ]
+}

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license/expected_sbom_stack_analysis.json
@@ -1,0 +1,81 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "name": "my-test-crate",
+            "version": "0.1.0",
+            "purl": "pkg:cargo/my-test-crate@0.1.0",
+            "type": "application",
+            "bom-ref": "pkg:cargo/my-test-crate@0.1.0",
+            "licenses": [
+                {
+                    "license": {
+                        "id": "Apache-2.0"
+                    }
+                }
+            ]
+        }
+    },
+    "components": [
+        {
+            "name": "serde",
+            "version": "1.0.193",
+            "purl": "pkg:cargo/serde@1.0.193",
+            "type": "library",
+            "bom-ref": "pkg:cargo/serde@1.0.193"
+        },
+        {
+            "name": "serde_derive",
+            "version": "1.0.193",
+            "purl": "pkg:cargo/serde_derive@1.0.193",
+            "type": "library",
+            "bom-ref": "pkg:cargo/serde_derive@1.0.193"
+        },
+        {
+            "name": "tokio",
+            "version": "1.35.0",
+            "purl": "pkg:cargo/tokio@1.35.0",
+            "type": "library",
+            "bom-ref": "pkg:cargo/tokio@1.35.0"
+        },
+        {
+            "name": "pin-project-lite",
+            "version": "0.2.13",
+            "purl": "pkg:cargo/pin-project-lite@0.2.13",
+            "type": "library",
+            "bom-ref": "pkg:cargo/pin-project-lite@0.2.13"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:cargo/my-test-crate@0.1.0",
+            "dependsOn": [
+                "pkg:cargo/serde@1.0.193",
+                "pkg:cargo/tokio@1.35.0"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/serde@1.0.193",
+            "dependsOn": [
+                "pkg:cargo/serde_derive@1.0.193"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/serde_derive@1.0.193",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:cargo/tokio@1.35.0",
+            "dependsOn": [
+                "pkg:cargo/pin-project-lite@0.2.13"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/pin-project-lite@0.2.13",
+            "dependsOn": []
+        }
+    ]
+}

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/Cargo.lock
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/Cargo.lock
@@ -1,0 +1,2 @@
+# This file is a placeholder for lock file validation.
+# The actual dependency resolution is done by `cargo metadata`.

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/Cargo.toml
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "my-test-crate"
+version = { workspace = true }
+edition = "2021"
+license = { workspace = true }
+
+[workspace]
+members = []
+
+[workspace.package]
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0.193"
+tokio = { version = "1.35.0", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.8.0"

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/cargo_metadata.json
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/cargo_metadata.json
@@ -1,0 +1,150 @@
+{
+    "packages": [
+        {
+            "name": "my-test-crate",
+            "version": "0.1.0",
+            "id": "path+file:///fake/path/my-test-crate#0.1.0",
+            "source": null,
+            "dependencies": [
+                {
+                    "name": "serde",
+                    "kind": null
+                },
+                {
+                    "name": "tokio",
+                    "kind": null
+                },
+                {
+                    "name": "tempfile",
+                    "kind": "dev"
+                }
+            ]
+        },
+        {
+            "name": "serde",
+            "version": "1.0.193",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.193",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "serde_derive",
+                    "kind": null
+                }
+            ]
+        },
+        {
+            "name": "serde_derive",
+            "version": "1.0.193",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.193",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": []
+        },
+        {
+            "name": "tokio",
+            "version": "1.35.0",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.35.0",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": [
+                {
+                    "name": "pin-project-lite",
+                    "kind": null
+                }
+            ]
+        },
+        {
+            "name": "pin-project-lite",
+            "version": "0.2.13",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.13",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": []
+        },
+        {
+            "name": "tempfile",
+            "version": "3.8.0",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.8.0",
+            "source": "registry+https://github.com/rust-lang/crates.io-index",
+            "dependencies": []
+        }
+    ],
+    "workspace_members": [
+        "path+file:///fake/path/my-test-crate#0.1.0"
+    ],
+    "workspace_root": "test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing",
+    "resolve": {
+        "root": "path+file:///fake/path/my-test-crate#0.1.0",
+        "nodes": [
+            {
+                "id": "path+file:///fake/path/my-test-crate#0.1.0",
+                "deps": [
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.193",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.35.0",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    },
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.8.0",
+                        "dep_kinds": [
+                            {
+                                "kind": "dev",
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde@1.0.193",
+                "deps": [
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.193",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#serde_derive@1.0.193",
+                "deps": []
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tokio@1.35.0",
+                "deps": [
+                    {
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.13",
+                        "dep_kinds": [
+                            {
+                                "kind": null,
+                                "target": null
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#pin-project-lite@0.2.13",
+                "deps": []
+            },
+            {
+                "id": "registry+https://github.com/rust-lang/crates.io-index#tempfile@3.8.0",
+                "deps": []
+            }
+        ]
+    }
+}

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/expected_sbom_component_analysis.json
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/expected_sbom_component_analysis.json
@@ -1,0 +1,48 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "name": "my-test-crate",
+            "version": "0.1.0",
+            "purl": "pkg:cargo/my-test-crate@0.1.0",
+            "type": "application",
+            "bom-ref": "pkg:cargo/my-test-crate@0.1.0"
+        }
+    },
+    "components": [
+        {
+            "name": "serde",
+            "version": "1.0.193",
+            "purl": "pkg:cargo/serde@1.0.193",
+            "type": "library",
+            "bom-ref": "pkg:cargo/serde@1.0.193"
+        },
+        {
+            "name": "tokio",
+            "version": "1.35.0",
+            "purl": "pkg:cargo/tokio@1.35.0",
+            "type": "library",
+            "bom-ref": "pkg:cargo/tokio@1.35.0"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:cargo/my-test-crate@0.1.0",
+            "dependsOn": [
+                "pkg:cargo/serde@1.0.193",
+                "pkg:cargo/tokio@1.35.0"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/serde@1.0.193",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:cargo/tokio@1.35.0",
+            "dependsOn": []
+        }
+    ]
+}

--- a/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/expected_sbom_stack_analysis.json
+++ b/test/providers/tst_manifests/cargo/cargo_single_crate_workspace_license_missing/expected_sbom_stack_analysis.json
@@ -1,0 +1,74 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "metadata": {
+        "timestamp": "2023-08-07T00:00:00.000Z",
+        "component": {
+            "name": "my-test-crate",
+            "version": "0.1.0",
+            "purl": "pkg:cargo/my-test-crate@0.1.0",
+            "type": "application",
+            "bom-ref": "pkg:cargo/my-test-crate@0.1.0"
+        }
+    },
+    "components": [
+        {
+            "name": "serde",
+            "version": "1.0.193",
+            "purl": "pkg:cargo/serde@1.0.193",
+            "type": "library",
+            "bom-ref": "pkg:cargo/serde@1.0.193"
+        },
+        {
+            "name": "serde_derive",
+            "version": "1.0.193",
+            "purl": "pkg:cargo/serde_derive@1.0.193",
+            "type": "library",
+            "bom-ref": "pkg:cargo/serde_derive@1.0.193"
+        },
+        {
+            "name": "tokio",
+            "version": "1.35.0",
+            "purl": "pkg:cargo/tokio@1.35.0",
+            "type": "library",
+            "bom-ref": "pkg:cargo/tokio@1.35.0"
+        },
+        {
+            "name": "pin-project-lite",
+            "version": "0.2.13",
+            "purl": "pkg:cargo/pin-project-lite@0.2.13",
+            "type": "library",
+            "bom-ref": "pkg:cargo/pin-project-lite@0.2.13"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:cargo/my-test-crate@0.1.0",
+            "dependsOn": [
+                "pkg:cargo/serde@1.0.193",
+                "pkg:cargo/tokio@1.35.0"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/serde@1.0.193",
+            "dependsOn": [
+                "pkg:cargo/serde_derive@1.0.193"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/serde_derive@1.0.193",
+            "dependsOn": []
+        },
+        {
+            "ref": "pkg:cargo/tokio@1.35.0",
+            "dependsOn": [
+                "pkg:cargo/pin-project-lite@0.2.13"
+            ]
+        },
+        {
+            "ref": "pkg:cargo/pin-project-lite@0.2.13",
+            "dependsOn": []
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- Detect Cargo workspace license inheritance (`license = { workspace = true }`) and resolve the actual license from the workspace root `Cargo.toml` via `cargo metadata`'s `workspace_root` field
- Add defensive guard in `CycloneDxSbom.getComponent()` to filter out non-CycloneDX license objects, preventing invalid SBOM JSON
- Add test fixtures and tests for workspace license resolution in both stack and component analysis

Fixes: [TC-4528](https://redhat.atlassian.net/browse/TC-4528)
Implements: [TC-4530](https://redhat.atlassian.net/browse/TC-4530)

## Test plan
- [x] New unit tests for workspace license inheritance (stack + component analysis)
- [x] New unit tests for CycloneDX license validation (filter non-CycloneDX objects, preserve valid, wrap strings)
- [x] All 69 existing Rust Cargo tests pass
- [x] All 11 CycloneDX SBOM hash/license tests pass
- [x] Lint passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4528]: https://redhat.atlassian.net/browse/TC-4528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4530]: https://redhat.atlassian.net/browse/TC-4530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Handle Cargo workspace-inherited licenses and harden CycloneDX SBOM license handling.

New Features:
- Resolve member crate licenses that inherit from the Cargo workspace root using cargo metadata workspace_root information.

Bug Fixes:
- Prevent invalid CycloneDX SBOM output by filtering out non-CycloneDX license objects while preserving valid objects and wrapping string licenses.

Tests:
- Add Cargo workspace fixture and SBOM expectations to verify workspace license inheritance in both stack and component analyses.
- Add CycloneDX SBOM tests to ensure correct handling of non-object, object, and string license values.