### PR TITLE
fix(poetry): add ENOENT error handling for missing poetry binary

### DIFF
--- a/src/providers/python_poetry.js
+++ b/src/providers/python_poetry.js
@@ -52,7 +52,7 @@ export default class Python_poetry extends Base_pyproject {
 			invokeCommand(poetryBin, ['--version'])
 		} catch (error) {
 			if (error.code === 'ENOENT') {
-				throw new Error(`poetry is not accessible at "${poetryBin}"`)
+				throw new Error(`poetry is not accessible at "${poetryBin}"`, { cause: error })
 			}
 			throw new Error('failed to check for poetry binary', { cause: error })
 		}
@@ -63,8 +63,8 @@ export default class Python_poetry extends Base_pyproject {
 		let poetryBin = getCustomPath('poetry', opts)
 		this._verifyPoetryAccessible(poetryBin)
 		let hasDevGroup = !!(parsed.tool?.poetry?.group?.dev || parsed.tool?.poetry?.['dev-dependencies'])
-		let treeOutput = this._getPoetryShowTreeOutput(manifestDir, hasDevGroup, opts)
-		let showAllOutput = this._getPoetryShowAllOutput(manifestDir, opts)
+		let treeOutput = this._getPoetryShowTreeOutput(manifestDir, hasDevGroup, poetryBin)
+		let showAllOutput = this._getPoetryShowAllOutput(manifestDir, poetryBin)
 		let versionMap = this._parsePoetryShowAll(showAllOutput)
 		let lockDir = this._findLockFileDir(manifestDir, opts)
 		let markerData = this._extractMarkerData(lockDir, parsed)
@@ -75,14 +75,13 @@ export default class Python_poetry extends Base_pyproject {
 	 * Get poetry show --tree output.
 	 * @param {string} manifestDir
 	 * @param {boolean} hasDevGroup
-	 * @param {Object} opts
+	 * @param {string} poetryBin
 	 * @returns {string}
 	 */
-	_getPoetryShowTreeOutput(manifestDir, hasDevGroup, opts) {
+	_getPoetryShowTreeOutput(manifestDir, hasDevGroup, poetryBin) {
 		if (environmentVariableIsPopulated('TRUSTIFY_DA_POETRY_SHOW_TREE')) {
 			return Buffer.from(process.env['TRUSTIFY_DA_POETRY_SHOW_TREE'], 'base64').toString('utf-8')
 		}
-		let poetryBin = getCustomPath('poetry', opts)
 		let args = ['show', '--tree', '--no-ansi']
 		if (hasDevGroup) {
 			args.push('--without', 'dev')
@@ -93,14 +92,13 @@ export default class Python_poetry extends Base_pyproject {
 	/**
 	 * Get poetry show --all output (flat list with resolved versions).
 	 * @param {string} manifestDir
-	 * @param {Object} opts
+	 * @param {string} poetryBin
 	 * @returns {string}
 	 */
-	_getPoetryShowAllOutput(manifestDir, opts) {
+	_getPoetryShowAllOutput(manifestDir, poetryBin) {
 		if (environmentVariableIsPopulated('TRUSTIFY_DA_POETRY_SHOW_ALL')) {
 			return Buffer.from(process.env['TRUSTIFY_DA_POETRY_SHOW_ALL'], 'base64').toString('utf-8')
 		}
-		let poetryBin = getCustomPath('poetry', opts)
 		return invokeCommand(poetryBin, ['show', '--no-ansi', '--all'], { cwd: manifestDir }).toString()
 	}
 

--- a/src/providers/python_poetry.js
+++ b/src/providers/python_poetry.js
@@ -40,13 +40,6 @@ export default class Python_poetry extends Base_pyproject {
 		return 'poetry'
 	}
 
-	/**
-	 * @param {string} manifestDir
-	 * @param {string} _workspaceDir - unused (poetry has no workspace support)
-	 * @param {object} parsed - parsed pyproject.toml
-	 * @param {Object} opts
-	 * @returns {Promise<{directDeps: string[], graph: Map<string, {name: string, version: string, children: string[]}>}>}
-	 */
 	_verifyPoetryAccessible(poetryBin) {
 		try {
 			invokeCommand(poetryBin, ['--version'])
@@ -58,6 +51,13 @@ export default class Python_poetry extends Base_pyproject {
 		}
 	}
 
+	/**
+	 * @param {string} manifestDir
+	 * @param {string} _workspaceDir - unused (poetry has no workspace support)
+	 * @param {object} parsed - parsed pyproject.toml
+	 * @param {Object} opts
+	 * @returns {Promise<{directDeps: string[], graph: Map<string, {name: string, version: string, children: string[]}>}>}
+	 */
 	// eslint-disable-next-line no-unused-vars
 	async _getDependencyData(manifestDir, _workspaceDir, parsed, opts) {
 		let poetryBin = getCustomPath('poetry', opts)

--- a/src/providers/python_poetry.js
+++ b/src/providers/python_poetry.js
@@ -47,8 +47,21 @@ export default class Python_poetry extends Base_pyproject {
 	 * @param {Object} opts
 	 * @returns {Promise<{directDeps: string[], graph: Map<string, {name: string, version: string, children: string[]}>}>}
 	 */
+	_verifyPoetryAccessible(poetryBin) {
+		try {
+			invokeCommand(poetryBin, ['--version'])
+		} catch (error) {
+			if (error.code === 'ENOENT') {
+				throw new Error(`poetry is not accessible at "${poetryBin}"`)
+			}
+			throw new Error('failed to check for poetry binary', { cause: error })
+		}
+	}
+
 	// eslint-disable-next-line no-unused-vars
 	async _getDependencyData(manifestDir, _workspaceDir, parsed, opts) {
+		let poetryBin = getCustomPath('poetry', opts)
+		this._verifyPoetryAccessible(poetryBin)
 		let hasDevGroup = !!(parsed.tool?.poetry?.group?.dev || parsed.tool?.poetry?.['dev-dependencies'])
 		let treeOutput = this._getPoetryShowTreeOutput(manifestDir, hasDevGroup, opts)
 		let showAllOutput = this._getPoetryShowAllOutput(manifestDir, opts)

--- a/src/providers/python_poetry.js
+++ b/src/providers/python_poetry.js
@@ -61,7 +61,11 @@ export default class Python_poetry extends Base_pyproject {
 	// eslint-disable-next-line no-unused-vars
 	async _getDependencyData(manifestDir, _workspaceDir, parsed, opts) {
 		let poetryBin = getCustomPath('poetry', opts)
-		this._verifyPoetryAccessible(poetryBin)
+		let envBypass = environmentVariableIsPopulated('TRUSTIFY_DA_POETRY_SHOW_TREE')
+			&& environmentVariableIsPopulated('TRUSTIFY_DA_POETRY_SHOW_ALL')
+		if (!envBypass) {
+			this._verifyPoetryAccessible(poetryBin)
+		}
 		let hasDevGroup = !!(parsed.tool?.poetry?.group?.dev || parsed.tool?.poetry?.['dev-dependencies'])
 		let treeOutput = this._getPoetryShowTreeOutput(manifestDir, hasDevGroup, poetryBin)
 		let showAllOutput = this._getPoetryShowAllOutput(manifestDir, poetryBin)

--- a/test/providers/python_pyproject.test.js
+++ b/test/providers/python_pyproject.test.js
@@ -666,6 +666,19 @@ suite('testing python-poetry error handling', () => {
 			.to.throw('poetry is not accessible at "/nonexistent/poetry"')
 	}).timeout(TIMEOUT)
 
+	/** Verifies that an accessible poetry binary does not throw. */
+	test('verify no error when poetry binary is accessible', async () => {
+		let provider = await esmock('../../src/providers/python_poetry.js', {
+			'../../src/tools.js': {
+				getCustomPath: () => 'poetry',
+				invokeCommand: () => Buffer.from('Poetry (version 1.8.0)')
+			}
+		})
+
+		let instance = new provider.default()
+		expect(() => instance._verifyPoetryAccessible('poetry')).to.not.throw()
+	}).timeout(TIMEOUT)
+
 	/** Verifies that non-ENOENT errors are re-thrown with cause chain preserved. */
 	test('verify non-ENOENT errors are re-thrown with cause', async () => {
 		let originalError = new Error('permission denied')

--- a/test/providers/python_pyproject.test.js
+++ b/test/providers/python_pyproject.test.js
@@ -697,4 +697,54 @@ suite('testing python-poetry error handling', () => {
 		expect(() => instance._verifyPoetryAccessible('poetry'))
 			.to.throw('failed to check for poetry binary')
 	}).timeout(TIMEOUT)
+
+	/** Verifies that _getDependencyData skips binary verification when both env vars bypass poetry. */
+	test('verify _getDependencyData skips binary check when both env vars are set', async () => {
+		let provider = await esmock('../../src/providers/python_poetry.js', {
+			'../../src/tools.js': {
+				getCustomPath: () => '/nonexistent/poetry',
+				environmentVariableIsPopulated: (name) => {
+					return name === 'TRUSTIFY_DA_POETRY_SHOW_TREE' || name === 'TRUSTIFY_DA_POETRY_SHOW_ALL'
+				},
+				invokeCommand: () => {
+					let err = new Error('spawn /nonexistent/poetry ENOENT')
+					err.code = 'ENOENT'
+					throw err
+				}
+			}
+		})
+
+		let instance = new provider.default()
+		instance._getPoetryShowTreeOutput = () => ''
+		instance._getPoetryShowAllOutput = () => ''
+		instance._parsePoetryShowAll = () => new Map()
+		instance._findLockFileDir = () => '/tmp'
+		instance._extractMarkerData = () => ({})
+		instance._parsePoetryTree = () => ({ directDeps: [], graph: new Map() })
+
+		await instance._getDependencyData('/tmp', '/tmp', { tool: {} }, {})
+	}).timeout(TIMEOUT)
+
+	/** Verifies that _getDependencyData runs binary verification when env vars are not set. */
+	test('verify _getDependencyData runs binary check when env vars are not set', async () => {
+		let provider = await esmock('../../src/providers/python_poetry.js', {
+			'../../src/tools.js': {
+				getCustomPath: () => '/nonexistent/poetry',
+				environmentVariableIsPopulated: () => false,
+				invokeCommand: () => {
+					let err = new Error('spawn /nonexistent/poetry ENOENT')
+					err.code = 'ENOENT'
+					throw err
+				}
+			}
+		})
+
+		let instance = new provider.default()
+		try {
+			await instance._getDependencyData('/tmp', '/tmp', { tool: {} }, {})
+			expect.fail('Expected error to be thrown')
+		} catch (e) {
+			expect(e.message).to.include('poetry is not accessible')
+		}
+	}).timeout(TIMEOUT)
 })

--- a/test/providers/python_pyproject.test.js
+++ b/test/providers/python_pyproject.test.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { expect } from 'chai'
+import esmock from 'esmock'
 import { useFakeTimers } from 'sinon'
 
 import Python_pip_pyproject from '../../src/providers/python_pip_pyproject.js'
@@ -644,4 +645,43 @@ suite('testing the python-pyproject data provider', () => {
 }).afterAll(() => {
 	Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
 	clock.restore()
+})
+
+suite('testing python-poetry error handling', () => {
+	/** Verifies that a missing poetry binary produces a clear error message. */
+	test('verify error when poetry binary is not accessible', async () => {
+		let provider = await esmock('../../src/providers/python_poetry.js', {
+			'../../src/tools.js': {
+				getCustomPath: () => '/nonexistent/poetry',
+				invokeCommand: () => {
+					let err = new Error('spawn /nonexistent/poetry ENOENT')
+					err.code = 'ENOENT'
+					throw err
+				}
+			}
+		})
+
+		let instance = new provider.default()
+		expect(() => instance._verifyPoetryAccessible('/nonexistent/poetry'))
+			.to.throw('poetry is not accessible at "/nonexistent/poetry"')
+	}).timeout(TIMEOUT)
+
+	/** Verifies that non-ENOENT errors are re-thrown with cause chain preserved. */
+	test('verify non-ENOENT errors are re-thrown with cause', async () => {
+		let originalError = new Error('permission denied')
+		originalError.code = 'EACCES'
+
+		let provider = await esmock('../../src/providers/python_poetry.js', {
+			'../../src/tools.js': {
+				getCustomPath: () => 'poetry',
+				invokeCommand: () => {
+					throw originalError
+				}
+			}
+		})
+
+		let instance = new provider.default()
+		expect(() => instance._verifyPoetryAccessible('poetry'))
+			.to.throw('failed to check for poetry binary')
+	}).timeout(TIMEOUT)
 })


### PR DESCRIPTION
## Summary
- Add `_verifyPoetryAccessible()` method to the Poetry provider that checks if the `poetry` binary is accessible before attempting to run dependency analysis
- Throw a clear `"poetry is not accessible at "<path>"` error instead of the raw `"spawnSync poetry ENOENT"` when poetry is not installed
- Follow the established binary verification pattern from the Cargo provider (`verifyCargoAccessible`)
- Skip binary verification when both `TRUSTIFY_DA_POETRY_SHOW_TREE` and `TRUSTIFY_DA_POETRY_SHOW_ALL` env vars are set, since poetry is not actually invoked in that case ([TC-4660](https://redhat.atlassian.net/browse/TC-4660))

Implements [TC-4563](https://redhat.atlassian.net/browse/TC-4563)

## Test plan
- [x] New test: ENOENT throws user-friendly error mentioning the poetry binary path
- [x] New test: non-ENOENT errors (e.g., EACCES) are re-thrown with cause chain preserved
- [x] New test: binary check skipped when both env vars are set
- [x] New test: binary check runs when env vars are not set
- [x] All existing poetry tests pass unchanged
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4660]: https://redhat.atlassian.net/browse/TC-4660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4563]: https://redhat.atlassian.net/browse/TC-4563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ