### PR TITLE
feat: add Codecov integration for unit test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Lint and test project
+    permissions:
+      id-token: write
     strategy:
       matrix:
         node: ['22', '24']
@@ -110,4 +112,13 @@ jobs:
         with:
           name: coverage
           path: ./coverage/coverage-final.json
+
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.node == env.MAIN_NODE_VER }}
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: ./coverage/lcov.info
+          slug: guacsec/trustify-da-javascript-client
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,5 +120,4 @@ jobs:
           use_oidc: true
           flags: unit-tests
           files: ./coverage/lcov.info
-          slug: guacsec/trustify-da-javascript-client
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+ignore:
+  - "node_modules/**"
+  - "dist/**"
+  - "coverage/**"
+
+flags:
+  unit-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"reporter": [
 			"html",
 			"json",
+			"lcov",
 			"text"
 		]
 	},


### PR DESCRIPTION
## Summary

- Add `lcov` reporter to c8 config so Codecov can parse coverage output
- Add **Codecov upload** step to test workflow using OIDC authentication (no secret needed)
- Upload only from the Node 24 matrix run (matches `MAIN_NODE_VER`)
- Add `codecov.yml` with informational status checks, `unit-tests` flag with carryforward

## Changes

| File | Change |
|------|--------|
| `package.json` | Add `lcov` to c8 reporter list |
| `.github/workflows/test.yml` | Add `permissions: id-token: write` + Codecov upload step |
| `codecov.yml` | Coverage config: informational checks, flag setup, ignore patterns |

## Manual follow-up

After merging:
1. Go to https://app.codecov.io/gh/guacsec/trustify-da-javascript-client
2. Click the **Flags** tab
3. Click **Enable flag analytics**

Ref: [COVERPORT-254](https://redhat.atlassian.net/browse/COVERPORT-254)

[COVERPORT-254]: https://redhat.atlassian.net/browse/COVERPORT-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate Codecov coverage reporting into the project’s CI test workflow and configuration.

New Features:
- Enable Codecov uploads from the CI test workflow using OIDC authentication and unit-test coverage flags.
- Add Codecov configuration to control coverage status checks, flags, and comment layout.

Enhancements:
- Extend test coverage reporting to generate lcov output consumable by external coverage tooling.

CI:
- Grant OIDC token permissions and add a Codecov upload step to the test workflow, restricted to the main Node.js version matrix run.