### PR TITLE
build(deps-dev): bump @trustify-da/trustify-da-api-model to ^2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.23.2",
 				"@eslint/js": "^10.0.0",
-				"@trustify-da/trustify-da-api-model": "^2.0.7",
+				"@trustify-da/trustify-da-api-model": "^2.0.8",
 				"@types/node": "^25.9.1",
 				"@types/which": "^3.0.4",
 				"babel-plugin-rewire": "^1.2.0",
@@ -935,9 +935,9 @@
 			}
 		},
 		"node_modules/@trustify-da/trustify-da-api-model": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.7.tgz",
-			"integrity": "sha512-42ApYWE4LYiCXD86AzPdLHSxFY7t2P9PhR+BwwFKBwHlcnJE2fPVELI0e8vbf+2Lxz0CpzU1g4WPHXOCp2K1oQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.8.tgz",
+			"integrity": "sha512-i4wVuNzWg8ASPOKpeiuuMD9SJaYDlqWCDApknMRuskP9QBSMnAORtbzoFXBNoMXWPVYGI8SrSpfF3J7fAPvzIw==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -2309,7 +2309,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.2",
-		"@trustify-da/trustify-da-api-model": "^2.0.7",
+		"@trustify-da/trustify-da-api-model": "^2.0.8",
 		"@types/node": "^25.9.1",
 		"@types/which": "^3.0.4",
 		"babel-plugin-rewire": "^1.2.0",


### PR DESCRIPTION
## Summary

- Bump `@trustify-da/trustify-da-api-model` devDependency from `^2.0.7` to `^2.0.8`
- The new version includes recommendation schemas (`RecommendationSource`, `RecommendationReport`, `RecommendationSummary`) added in the v5.2.0 API spec
- No source code changes needed — the JS client passes through the API response to consumers (IDE extensions)

Implements [TC-4694](https://redhat.atlassian.net/browse/TC-4694)

## Test plan

- [x] Verified new TypeScript types are available from the model package
- [x] Full test suite passes (463 passing; 19 pre-existing failures unrelated to this change)

[TC-4694]: https://redhat.atlassian.net/browse/TC-4694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Build:
- Bump @trustify-da/trustify-da-api-model devDependency from ^2.0.7 to ^2.0.8 in package.json and lockfile.