### PR TITLE
build(deps-dev): bump @trustify-da/trustify-da-api-model to ^2.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.23.2",
 				"@eslint/js": "^10.0.0",
-				"@trustify-da/trustify-da-api-model": "^2.0.8",
+				"@trustify-da/trustify-da-api-model": "^2.0.9",
 				"@types/node": "^25.9.1",
 				"@types/which": "^3.0.4",
 				"babel-plugin-rewire": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.23.2",
-		"@trustify-da/trustify-da-api-model": "^2.0.8",
+		"@trustify-da/trustify-da-api-model": "^2.0.9",
 		"@types/node": "^25.9.1",
 		"@types/which": "^3.0.4",
 		"babel-plugin-rewire": "^1.2.0",


### PR DESCRIPTION
## Summary

- Bump `@trustify-da/trustify-da-api-model` devDependency from `^2.0.8` to `^2.0.9` to pick up the new `unknown` field in `SourceSummary` and `UNKNOWN` value in `Severity` enum

## Test plan

- [x] `npm test` passes (463 passing; 19 pre-existing OCI image test failures unrelated to this change)
- [x] `npm run lint` passes (0 errors)
- [x] Verified `2.0.9` contains `unknown` field in `SourceSummary.ts` and `UNKNOWN` in `Severity.ts`

Implements [TC-4726](https://redhat.atlassian.net/browse/TC-4726)

[TC-4726]: https://redhat.atlassian.net/browse/TC-4726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Build:
- Bump @trustify-da/trustify-da-api-model devDependency from ^2.0.8 to ^2.0.9 in package.json and lockfile.