### PR TITLE
test: validate exhort-integration-tests TC-4813

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch'
-    uses: trustification/exhort-integration-tests/.github/workflows/integration.yml@main
+    uses: a-oren/exhort-integration-tests/.github/workflows/integration.yml@TC-4813
     with:
       language: javascript
       repo-url: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name || github.repository }}


### PR DESCRIPTION
## Summary

- Points integration workflow to `a-oren/exhort-integration-tests@TC-4813` to validate syft image analysis scenarios before merging

## Related

- exhort-integration-tests PR: https://github.com/trustification/exhort-integration-tests/pull/38

## Test plan

- [ ] Integration tests pass with the updated workflow reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Point integration workflow to use the exhort-integration-tests reusable workflow from the TC-4813 branch in the a-oren fork.