### PR TITLE
feat(report): add remediation and recommendation details to pipeline summary

### DIFF
--- a/docker-image/scripts/trustify-da.sh
+++ b/docker-image/scripts/trustify-da.sh
@@ -93,7 +93,7 @@ for provider in $providers; do
   code=$(echo $provider_status | jq -r '.code')
   if [ "$code" -eq 200 ]; then
     sources=$(jq -r --arg provider "$provider" '.providers[$provider].sources | keys[]' <<< "$report")
-    for source in $sources; do
+    while IFS= read -r source; do
       printf "  Source: %s\n" "${source^}"
       printf "    Vulnerabilities\n"
       printf "      Total          :  %s \n" "$(jq -r --arg provider "$provider" --arg source "$source" '.providers[$provider].sources[$source].summary.total' <<< $report)"
@@ -119,7 +119,7 @@ for provider in $providers; do
           "      \(.ref)\n        → \(.tc)\n        CVEs: \(.cves)"
         ' <<< "$report"
       fi
-    done
+    done <<< "$sources"
 
     rec_sources=$(jq -r --arg provider "$provider" '.providers[$provider].recommendations // {} | keys[]' <<< "$report" 2>/dev/null)
     for rec_source in $rec_sources; do

--- a/docker-image/scripts/trustify-da.sh
+++ b/docker-image/scripts/trustify-da.sh
@@ -115,14 +115,14 @@ for provider in $providers; do
               (.issues // [])[] | select(.remediation.trustedContent.ref != null) |
               {ref: $t.ref, tc: .remediation.trustedContent.ref, cves: ((.cves // [.id]) | join(", "))}
             ]
-          ] | flatten | unique_by(.ref + .tc) | .[] |
+          ] | flatten | unique_by({ref, tc}) | .[] |
           "      \(.ref)\n        → \(.tc)\n        CVEs: \(.cves)"
         ' <<< "$report"
       fi
     done <<< "$sources"
 
     rec_sources=$(jq -r --arg provider "$provider" '.providers[$provider].recommendations // {} | keys[]' <<< "$report" 2>/dev/null)
-    for rec_source in $rec_sources; do
+    while IFS= read -r rec_source; do
       rec_total=$(jq -r --arg provider "$provider" --arg rs "$rec_source" '.providers[$provider].recommendations[$rs].summary.total // 0' <<< "$report")
       printf "  Recommendations (%s): %s\n" "$rec_source" "$rec_total"
       if [ "$rec_total" -gt 0 ] 2>/dev/null; then
@@ -131,7 +131,7 @@ for provider in $providers; do
           "    \(.ref)\n      → \(.recommendation)"
         ' <<< "$report"
       fi
-    done
+    done <<< "$rec_sources"
   fi
 done
 printf "=%.0s" {1..50}

--- a/docker-image/scripts/trustify-da.sh
+++ b/docker-image/scripts/trustify-da.sh
@@ -103,6 +103,34 @@ for provider in $providers; do
       printf "      High           :  %s \n" "$(jq -r --arg provider "$provider" --arg source "$source" '.providers[$provider].sources[$source].summary.high' <<< $report)"
       printf "      Medium         :  %s \n" "$(jq -r --arg provider "$provider" --arg source "$source" '.providers[$provider].sources[$source].summary.medium' <<< $report)"
       printf "      Low            :  %s \n" "$(jq -r --arg provider "$provider" --arg source "$source" '.providers[$provider].sources[$source].summary.low' <<< $report)"
+      remediations_count=$(jq -r --arg provider "$provider" --arg source "$source" '.providers[$provider].sources[$source].summary.remediations' <<< $report)
+      printf "    Remediations     :  %s \n" "$remediations_count"
+      if [ "$remediations_count" -gt 0 ] 2>/dev/null; then
+        jq -r --arg provider "$provider" --arg source "$source" '
+          [.providers[$provider].sources[$source].dependencies[] |
+            . as $dep |
+            [(.issues // [])[] | select(.remediation.trustedContent.ref != null) |
+              {ref: $dep.ref, tc: .remediation.trustedContent.ref, cves: ((.cves // [.id]) | join(", "))}
+            ] + [(.transitive // [])[] | . as $t |
+              (.issues // [])[] | select(.remediation.trustedContent.ref != null) |
+              {ref: $t.ref, tc: .remediation.trustedContent.ref, cves: ((.cves // [.id]) | join(", "))}
+            ]
+          ] | flatten | unique_by(.ref + .tc) | .[] |
+          "      \(.ref)\n        → \(.tc)\n        CVEs: \(.cves)"
+        ' <<< "$report"
+      fi
+    done
+
+    rec_sources=$(jq -r --arg provider "$provider" '.providers[$provider].recommendations // {} | keys[]' <<< "$report" 2>/dev/null)
+    for rec_source in $rec_sources; do
+      rec_total=$(jq -r --arg provider "$provider" --arg rs "$rec_source" '.providers[$provider].recommendations[$rs].summary.total // 0' <<< "$report")
+      printf "  Recommendations (%s): %s\n" "$rec_source" "$rec_total"
+      if [ "$rec_total" -gt 0 ] 2>/dev/null; then
+        jq -r --arg provider "$provider" --arg rs "$rec_source" '
+          .providers[$provider].recommendations[$rs].dependencies[]? |
+          "    \(.ref)\n      → \(.recommendation)"
+        ' <<< "$report"
+      fi
     done
   fi
 done


### PR DESCRIPTION
## Summary
- Surfaces trusted-content remediations and recommendations in the Tekton task console output
- Previously this data was only available in the saved JSON report file; now it appears inline after the vulnerability counts
- Supports the Lightwell demo (Act 2: build-time guardrail) by showing which vulnerable dependencies have trusted-content replacements

## Changes
- **`docker-image/scripts/trustify-da.sh`**: Added two new sections to the console summary:
  - **Remediations** (per source): count + list of dependencies with `trustedContent` replacements and their CVEs
  - **Recommendations** (per provider): count + list of dependencies with trusted-content alternatives

## Test plan
- [x] Verified jq queries against `trustify-dependency-analytics` test data (`report.json`) — correct output with remediations and recommendations
- [x] Verified against `trustify-da-java-client` test data (`analysis-report.json`) — handles empty remediations gracefully
- [x] No output produced when no remediations/recommendations exist (empty case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface trusted-content remediation and recommendation details in the Trustify dependency analytics pipeline summary output.

New Features:
- Display per-source remediation counts and lists of dependencies with trusted-content replacements and associated CVEs in the Tekton task console summary.
- Display per-provider recommendation counts and lists of dependencies with trusted-content alternative suggestions in the console summary when available.