### PR TITLE
build(deps): bump @trustify-da/trustify-da-api-model from 2.0.9 to 2.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 			"devDependencies": {
 				"@babel/core": "^7.23.2",
 				"@eslint/js": "^10.0.0",
-				"@trustify-da/trustify-da-api-model": "^2.0.9",
+				"@trustify-da/trustify-da-api-model": "^2.0.12",
 				"@types/node": "^25.9.1",
 				"@types/which": "^3.0.4",
 				"babel-plugin-rewire": "^1.2.0",
@@ -929,9 +929,9 @@
 			}
 		},
 		"node_modules/@trustify-da/trustify-da-api-model": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.10.tgz",
-			"integrity": "sha512-QGJP4fmu+dKm8BIsuEVCwEQAli7ED9QT/8Xz7XScv81etxJNXivHjIKXPz/5e5xz1vS2zpkYELE32QwywYc6hQ==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@trustify-da/trustify-da-api-model/-/trustify-da-api-model-2.0.12.tgz",
+			"integrity": "sha512-NnXHhlusj66OKKgBFbA1VV3jRouOIBPnn375dTmaL6bW0KL/RHQaq3tr3umxTWz0NBssJbuskz+mHERthE/d2A==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -1377,16 +1377,17 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-			"devOptional": true,
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -2226,6 +2227,30 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/eslint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/esmock": {
 			"version": "2.7.6",
 			"resolved": "https://registry.npmjs.org/esmock/-/esmock-2.7.6.tgz",
@@ -2345,7 +2370,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-levenshtein": {
@@ -2371,6 +2396,24 @@
 			"dependencies": {
 				"fast-string-truncated-width": "^3.0.2"
 			}
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/fast-wrap-ansi": {
 			"version": "0.2.2",
@@ -3003,11 +3046,12 @@
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"devOptional": true,
-			"license": "MIT"
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -3911,7 +3955,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3967,6 +4011,17 @@
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
 			"dev": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4747,7 +4802,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 	"devDependencies": {
 		"@babel/core": "^7.23.2",
 		"@eslint/js": "^10.0.0",
-		"@trustify-da/trustify-da-api-model": "^2.0.9",
+		"@trustify-da/trustify-da-api-model": "^2.0.12",
 		"@types/node": "^25.9.1",
 		"@types/which": "^3.0.4",
 		"babel-plugin-rewire": "^1.2.0",


### PR DESCRIPTION
## Summary

Bumps `@trustify-da/trustify-da-api-model` from `^2.0.9` to `^2.0.12` to pick up v3 migration schema changes:

- `AdvisoryInfo` schema — advisory id, title, and URL on each remediation
- `RemediationInfo` schema — category (`RemediationCategory` enum), details, and URL
- `AdvisoryRemediation` schema — groups remediations by source advisory
- `URI format` added to URL properties in `RemediationInfo` and `AdvisoryInfo`

No source code changes — the JS client is a pure pass-through; new TypeScript types flow in via the model package.

Implements [TC-5021](https://redhat.atlassian.net/browse/TC-5021)

[TC-5021]: https://redhat.atlassian.net/browse/TC-5021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Build:
- Update @trustify-da/trustify-da-api-model devDependency from 2.0.9 to 2.0.12.