### PR TITLE
feat(updaters): add Maven pom.xml updater with property indirection

### DIFF
--- a/src/updaters/maven_updater.js
+++ b/src/updaters/maven_updater.js
@@ -321,11 +321,24 @@ export function updateMavenVersions(pomContent, versionChanges) {
 				property: resolved.terminalPropName,
 			});
 		} else {
-			replacementsByPosition.set(versionPos.start, {
-				start: versionPos.start,
-				end: versionPos.end,
-				newValue: change.newVersion,
-			});
+			const existing = replacementsByPosition.get(versionPos.start);
+			if (existing) {
+				if (existing.newValue !== change.newVersion) {
+					skipped.push({
+						groupId: change.groupId,
+						artifactId: change.artifactId,
+						newVersion: change.newVersion,
+						reason: `Version already targeted with a different version '${existing.newValue}'`,
+					});
+					continue;
+				}
+			} else {
+				replacementsByPosition.set(versionPos.start, {
+					start: versionPos.start,
+					end: versionPos.end,
+					newValue: change.newVersion,
+				});
+			}
 
 			applied.push({
 				groupId: change.groupId,

--- a/src/updaters/maven_updater.js
+++ b/src/updaters/maven_updater.js
@@ -1,0 +1,349 @@
+import { XMLParser } from 'fast-xml-parser';
+
+/**
+ * Extracts the trimmed text content of a simple XML element from a string block.
+ * @param {string} block - the XML text to search within
+ * @param {string} tagName - the element name whose content to extract
+ * @returns {string|null} the trimmed text content, or null if not found
+ */
+function extractTagContent(block, tagName) {
+	const openTag = `<${tagName}>`;
+	const closeTag = `</${tagName}>`;
+	const start = block.indexOf(openTag);
+	if (start === -1) {
+		return null;
+	}
+	const contentStart = start + openTag.length;
+	const end = block.indexOf(closeTag, contentStart);
+	if (end === -1) {
+		return null;
+	}
+	return block.substring(contentStart, end).trim();
+}
+
+/**
+ * Finds the character positions of an XML element's text content within the raw file.
+ * Returns the start (inclusive) and end (exclusive) offsets of the text between the
+ * opening and closing tags.
+ * @param {string} content - full raw XML content
+ * @param {number} searchStart - start offset to search from
+ * @param {number} searchEnd - end offset to search within
+ * @param {string} tagName - the element name whose content position to locate
+ * @returns {{start: number, end: number}|null} character offsets, or null if not found
+ */
+function findTagContentPosition(content, searchStart, searchEnd, tagName) {
+	const openTag = `<${tagName}>`;
+	const closeTag = `</${tagName}>`;
+
+	const tagStart = content.indexOf(openTag, searchStart);
+	if (tagStart === -1 || tagStart >= searchEnd) {
+		return null;
+	}
+
+	const contentStart = tagStart + openTag.length;
+	const tagEnd = content.indexOf(closeTag, contentStart);
+	if (tagEnd === -1 || tagEnd > searchEnd) {
+		return null;
+	}
+
+	return { start: contentStart, end: tagEnd };
+}
+
+/**
+ * Checks whether the character immediately following a tag prefix indicates
+ * that the prefix is the complete tag name (e.g. `<dependency>` vs `<dependencyManagement>`).
+ * @param {string} char - the character after the tag prefix
+ * @returns {boolean} true if the character terminates the tag name
+ */
+function isTagBoundary(char) {
+	return char === '>' || char === ' ' || char === '\t'
+		|| char === '\n' || char === '\r' || char === '/';
+}
+
+/**
+ * Finds the text content position of a `<version>` element within the first
+ * `<dependency>` block matching the given groupId and artifactId.
+ * Searches through all `<dependency>` elements in the file, covering both
+ * `<dependencies>` and `<dependencyManagement>` sections.
+ * @param {string} content - full raw pom.xml content
+ * @param {string} groupId - the dependency's groupId to match
+ * @param {string} artifactId - the dependency's artifactId to match
+ * @returns {{start: number, end: number}|null} version content offsets, or null
+ */
+function findDependencyVersionPosition(content, groupId, artifactId) {
+	let searchStart = 0;
+	const TAG_PREFIX = '<dependency';
+	const CLOSE_TAG = '</dependency>';
+
+	while (searchStart < content.length) {
+		const start = content.indexOf(TAG_PREFIX, searchStart);
+		if (start === -1) {
+			break;
+		}
+
+		// Verify this is exactly <dependency> and not <dependencyManagement> etc.
+		const charAfterTag = content.charAt(start + TAG_PREFIX.length);
+		if (!isTagBoundary(charAfterTag)) {
+			searchStart = start + 1;
+			continue;
+		}
+
+		// Find closing </dependency>
+		const end = content.indexOf(CLOSE_TAG, start + TAG_PREFIX.length);
+		if (end === -1) {
+			break;
+		}
+
+		const blockEnd = end + CLOSE_TAG.length;
+		const block = content.substring(start, blockEnd);
+
+		const gid = extractTagContent(block, 'groupId');
+		const aid = extractTagContent(block, 'artifactId');
+
+		if (gid === groupId && aid === artifactId) {
+			const pos = findTagContentPosition(content, start, blockEnd, 'version');
+			if (pos) {
+				return pos;
+			}
+			// Matching dependency but no <version> element; continue searching
+			// (the version may be in <dependencyManagement>)
+		}
+
+		searchStart = blockEnd;
+	}
+	return null;
+}
+
+/**
+ * Finds the text content position of a property element inside a `<properties>` block.
+ * Searches through all `<properties>` blocks in the file.
+ * @param {string} content - full raw pom.xml content
+ * @param {string} propName - the property element name to locate
+ * @returns {{start: number, end: number}|null} property value offsets, or null
+ */
+function findPropertyPosition(content, propName) {
+	let searchStart = 0;
+	const TAG_PREFIX = '<properties';
+	const CLOSE_TAG = '</properties>';
+
+	while (searchStart < content.length) {
+		const propsStart = content.indexOf(TAG_PREFIX, searchStart);
+		if (propsStart === -1) {
+			break;
+		}
+
+		// Verify this is exactly <properties> and not some other tag
+		const charAfter = content.charAt(propsStart + TAG_PREFIX.length);
+		if (!isTagBoundary(charAfter)) {
+			searchStart = propsStart + 1;
+			continue;
+		}
+
+		const propsCloseStart = content.indexOf(CLOSE_TAG, propsStart);
+		if (propsCloseStart === -1) {
+			break;
+		}
+
+		const propsBlockEnd = propsCloseStart + CLOSE_TAG.length;
+		const result = findTagContentPosition(
+			content, propsStart, propsBlockEnd, propName
+		);
+		if (result) {
+			return result;
+		}
+
+		searchStart = propsBlockEnd;
+	}
+	return null;
+}
+
+/**
+ * Resolves a Maven property chain, following `${propName}` references through
+ * the properties map until a concrete (non-reference) value is reached.
+ * Detects circular references via a visited set.
+ * @param {string} propName - the initial property name to resolve
+ * @param {Object} properties - properties map from the parsed XML
+ * @param {Set<string>} [visited] - visited property names (for cycle detection)
+ * @returns {{terminalPropName: string, resolvedValue: string}|{error: string}}
+ */
+function resolvePropertyChain(propName, properties, visited = new Set()) {
+	if (visited.has(propName)) {
+		const chain = [...visited, propName].join(' -> ');
+		return { error: `Circular property reference detected: ${chain}` };
+	}
+	visited.add(propName);
+
+	const value = properties[propName];
+	if (value == null) {
+		return { error: `Property '${propName}' not found in <properties>` };
+	}
+
+	const valueStr = String(value);
+	const propMatch = valueStr.match(/^\$\{(.+)\}$/);
+	if (propMatch) {
+		return resolvePropertyChain(propMatch[1], properties, visited);
+	}
+
+	return { terminalPropName: propName, resolvedValue: valueStr };
+}
+
+/**
+ * Updates dependency versions in a Maven pom.xml while preserving file formatting.
+ *
+ * Uses `fast-xml-parser` to understand the XML structure (dependencies and properties),
+ * then performs position-based string splice to replace version strings without altering
+ * any other formatting, comments, whitespace, or indentation.
+ *
+ * Supports `${property}` indirection: when a dependency's `<version>` is a property
+ * reference, the updater resolves the property chain (including recursive references)
+ * and updates the terminal property value in `<properties>` instead.
+ *
+ * @param {string} pomContent - the raw pom.xml file content
+ * @param {Array<{groupId: string, artifactId: string, newVersion: string}>} versionChanges -
+ *   list of version changes to apply
+ * @returns {{content: string, applied: Array, skipped: Array}} the updated content and
+ *   lists of applied and skipped changes
+ */
+export function updateMavenVersions(pomContent, versionChanges) {
+	if (!versionChanges || versionChanges.length === 0) {
+		return { content: pomContent, applied: [], skipped: [] };
+	}
+
+	const parser = new XMLParser({
+		parseTagValue: false,
+		commentPropName: '#comment',
+	});
+
+	let parsed;
+	try {
+		parsed = parser.parse(pomContent);
+	} catch (e) {
+		return {
+			content: pomContent,
+			applied: [],
+			skipped: versionChanges.map(vc => ({
+				groupId: vc.groupId,
+				artifactId: vc.artifactId,
+				newVersion: vc.newVersion,
+				reason: `Failed to parse pom.xml: ${e.message}`,
+			})),
+		};
+	}
+
+	const project = parsed?.project;
+	if (!project) {
+		return {
+			content: pomContent,
+			applied: [],
+			skipped: versionChanges.map(vc => ({
+				groupId: vc.groupId,
+				artifactId: vc.artifactId,
+				newVersion: vc.newVersion,
+				reason: 'No <project> element found in pom.xml',
+			})),
+		};
+	}
+
+	const properties = project.properties || {};
+
+	const applied = [];
+	const skipped = [];
+	/** @type {Map<number, {start: number, end: number, newValue: string}>} */
+	const replacementsByPosition = new Map();
+
+	for (const change of versionChanges) {
+		const versionPos = findDependencyVersionPosition(
+			pomContent, change.groupId, change.artifactId
+		);
+		if (!versionPos) {
+			skipped.push({
+				groupId: change.groupId,
+				artifactId: change.artifactId,
+				newVersion: change.newVersion,
+				reason: 'Dependency not found in pom.xml or has no <version> element',
+			});
+			continue;
+		}
+
+		const currentVersion = pomContent.substring(versionPos.start, versionPos.end);
+		const propMatch = currentVersion.match(/^\$\{(.+)\}$/);
+
+		if (propMatch) {
+			const resolved = resolvePropertyChain(propMatch[1], properties);
+			if (resolved.error) {
+				skipped.push({
+					groupId: change.groupId,
+					artifactId: change.artifactId,
+					newVersion: change.newVersion,
+					reason: resolved.error,
+				});
+				continue;
+			}
+
+			const propPos = findPropertyPosition(pomContent, resolved.terminalPropName);
+			if (!propPos) {
+				skipped.push({
+					groupId: change.groupId,
+					artifactId: change.artifactId,
+					newVersion: change.newVersion,
+					reason: `Could not locate property '${resolved.terminalPropName}' in pom.xml`,
+				});
+				continue;
+			}
+
+			// Deduplicate: multiple deps may share the same property
+			const existing = replacementsByPosition.get(propPos.start);
+			if (existing) {
+				if (existing.newValue !== change.newVersion) {
+					skipped.push({
+						groupId: change.groupId,
+						artifactId: change.artifactId,
+						newVersion: change.newVersion,
+						reason: `Property '${resolved.terminalPropName}' already targeted `
+							+ `with a different version '${existing.newValue}'`,
+					});
+					continue;
+				}
+				// Same replacement already queued; record as applied without duplicating
+			} else {
+				replacementsByPosition.set(propPos.start, {
+					start: propPos.start,
+					end: propPos.end,
+					newValue: change.newVersion,
+				});
+			}
+
+			applied.push({
+				groupId: change.groupId,
+				artifactId: change.artifactId,
+				newVersion: change.newVersion,
+				type: 'property',
+				property: resolved.terminalPropName,
+			});
+		} else {
+			replacementsByPosition.set(versionPos.start, {
+				start: versionPos.start,
+				end: versionPos.end,
+				newValue: change.newVersion,
+			});
+
+			applied.push({
+				groupId: change.groupId,
+				artifactId: change.artifactId,
+				newVersion: change.newVersion,
+				type: 'direct',
+			});
+		}
+	}
+
+	// Sort replacements by position descending to preserve offsets during splice
+	const sortedReplacements = [...replacementsByPosition.values()]
+		.sort((a, b) => b.start - a.start);
+
+	let result = pomContent;
+	for (const r of sortedReplacements) {
+		result = result.substring(0, r.start) + r.newValue + result.substring(r.end);
+	}
+
+	return { content: result, applied, skipped };
+}

--- a/test/updaters/fixtures/pom_circular_properties.xml
+++ b/test/updaters/fixtures/pom_circular_properties.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <circular.a>${circular.b}</circular.a>
+        <circular.b>${circular.a}</circular.b>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>circular-lib</artifactId>
+            <version>${circular.a}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/updaters/fixtures/pom_direct_versions.xml
+++ b/test/updaters/fixtures/pom_direct_versions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>lib-a</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>lib-b</artifactId>
+            <version>2.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.other</groupId>
+            <artifactId>unchanged-lib</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/updaters/fixtures/pom_malformed.xml
+++ b/test/updaters/fixtures/pom_malformed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<project>
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>broken

--- a/test/updaters/fixtures/pom_property_versions.xml
+++ b/test/updaters/fixtures/pom_property_versions.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <jackson.version>2.15.2</jackson.version>
+        <guava.version>31.1-jre</guava.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/updaters/fixtures/pom_recursive_properties.xml
+++ b/test/updaters/fixtures/pom_recursive_properties.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <lib.version>${base.version}</lib.version>
+        <base.version>1.0.0</base.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>recursive-lib</artifactId>
+            <version>${lib.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/updaters/fixtures/pom_with_comments.xml
+++ b/test/updaters/fixtures/pom_with_comments.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Project-level comment preserved across updates -->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>formatted-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <!-- Jackson version for JSON processing -->
+        <jackson.version>2.15.2</jackson.version>
+        <untouched.prop>keep-me</untouched.prop>
+    </properties>
+
+    <dependencies>
+        <!-- Direct dependency with inline comment -->
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>lib-a</artifactId>
+            <version>1.0.0</version> <!-- current version -->
+        </dependency>
+
+        <!-- Property-based dependency -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!--
+            Multi-line comment block that should
+            remain completely untouched after updates
+        -->
+        <dependency>
+            <groupId>org.other</groupId>
+            <artifactId>stable-lib</artifactId>
+            <version>9.9.9</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/updaters/maven_updater.test.js
+++ b/test/updaters/maven_updater.test.js
@@ -1,0 +1,406 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect } from 'chai';
+
+import { updateMavenVersions } from '../../src/updaters/maven_updater.js';
+
+const fixturesDir = path.resolve('test/updaters/fixtures');
+
+/** Reads a fixture file and returns its content as a string. */
+function loadFixture(name) {
+	return fs.readFileSync(path.join(fixturesDir, name), 'utf-8');
+}
+
+suite('maven_updater', () => {
+
+	suite('direct version replacement', () => {
+
+		/** Verifies that a single dependency with a direct version is updated. */
+		test('updates a single dependency version', () => {
+			// Given
+			const pom = loadFixture('pom_direct_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'lib-a', newVersion: '2.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(1);
+			expect(result.applied[0]).to.deep.include({
+				groupId: 'com.example',
+				artifactId: 'lib-a',
+				newVersion: '2.0.0',
+				type: 'direct',
+			});
+			expect(result.skipped).to.have.lengthOf(0);
+			expect(result.content).to.include(
+				'<artifactId>lib-a</artifactId>\n            <version>2.0.0</version>'
+			);
+		});
+
+		/** Verifies that multiple direct versions are updated in a single call. */
+		test('updates multiple dependency versions', () => {
+			// Given
+			const pom = loadFixture('pom_direct_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'lib-a', newVersion: '2.0.0' },
+				{ groupId: 'com.example', artifactId: 'lib-b', newVersion: '3.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(2);
+			expect(result.skipped).to.have.lengthOf(0);
+			expect(result.content).to.include('<version>2.0.0</version>');
+			expect(result.content).to.include('<version>3.0.0</version>');
+			expect(result.content).not.to.include('<version>1.0.0</version>');
+			expect(result.content).not.to.include('<version>2.3.4</version>');
+		});
+	});
+
+	suite('property-based version replacement', () => {
+
+		/** Verifies that a ${property} reference is traced to <properties> and updated there. */
+		test('traces ${property} and updates the property value', () => {
+			// Given
+			const pom = loadFixture('pom_property_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-databind', newVersion: '2.16.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(1);
+			expect(result.applied[0]).to.deep.include({
+				type: 'property',
+				property: 'jackson.version',
+			});
+			expect(result.skipped).to.have.lengthOf(0);
+			expect(result.content).to.include('<jackson.version>2.16.0</jackson.version>');
+			expect(result.content).to.include('${jackson.version}');
+		});
+
+		/** Verifies that two dependencies sharing a property cause only one replacement. */
+		test('handles multiple deps sharing the same property', () => {
+			// Given
+			const pom = loadFixture('pom_property_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-databind', newVersion: '2.16.0' },
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-core', newVersion: '2.16.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(2);
+			expect(result.skipped).to.have.lengthOf(0);
+			expect(result.content).to.include('<jackson.version>2.16.0</jackson.version>');
+			// The property should appear only once
+			const matches = result.content.match(/<jackson\.version>/g);
+			expect(matches).to.have.lengthOf(1);
+		});
+
+		/** Verifies that conflicting versions for the same property are detected and skipped. */
+		test('skips when shared property targeted with conflicting versions', () => {
+			// Given
+			const pom = loadFixture('pom_property_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-databind', newVersion: '2.16.0' },
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-core', newVersion: '2.17.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(1);
+			expect(result.skipped).to.have.lengthOf(1);
+			expect(result.skipped[0].reason).to.include('already targeted');
+			expect(result.skipped[0].reason).to.include('2.16.0');
+		});
+	});
+
+	suite('recursive property chain', () => {
+
+		/** Verifies that ${a} -> ${b} -> value is resolved and the terminal property updated. */
+		test('resolves recursive property chain and updates terminal property', () => {
+			// Given
+			const pom = loadFixture('pom_recursive_properties.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'recursive-lib', newVersion: '2.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(1);
+			expect(result.applied[0]).to.deep.include({
+				type: 'property',
+				property: 'base.version',
+			});
+			expect(result.skipped).to.have.lengthOf(0);
+			expect(result.content).to.include('<base.version>2.0.0</base.version>');
+			// Intermediate property reference preserved
+			expect(result.content).to.include('<lib.version>${base.version}</lib.version>');
+			// Dependency reference preserved
+			expect(result.content).to.include('${lib.version}');
+		});
+	});
+
+	suite('circular property reference', () => {
+
+		/** Verifies that a circular property chain is detected and reported as skipped. */
+		test('detects cycle and reports in skipped with error message', () => {
+			// Given
+			const pom = loadFixture('pom_circular_properties.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'circular-lib', newVersion: '1.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(0);
+			expect(result.skipped).to.have.lengthOf(1);
+			expect(result.skipped[0].reason).to.include('Circular property reference');
+			expect(result.content).to.equal(pom);
+		});
+	});
+
+	suite('formatting preservation', () => {
+
+		/** Verifies that comments, indentation, whitespace, and unrelated content are preserved. */
+		test('preserves comments, indentation, and whitespace', () => {
+			// Given
+			const pom = loadFixture('pom_with_comments.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'lib-a', newVersion: '2.0.0' },
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-databind', newVersion: '2.16.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(2);
+
+			// Comments preserved
+			expect(result.content).to.include('<!-- Project-level comment preserved across updates -->');
+			expect(result.content).to.include('<!-- Jackson version for JSON processing -->');
+			expect(result.content).to.include('<!-- Direct dependency with inline comment -->');
+			expect(result.content).to.include('<!-- current version -->');
+			expect(result.content).to.include('Multi-line comment block that should');
+
+			// Untouched property preserved
+			expect(result.content).to.include('<untouched.prop>keep-me</untouched.prop>');
+
+			// Untouched dependency preserved
+			expect(result.content).to.include('<version>9.9.9</version>');
+
+			// Updated values present
+			expect(result.content).to.include(
+				'<artifactId>lib-a</artifactId>\n            <version>2.0.0</version>'
+			);
+			expect(result.content).to.include('<jackson.version>2.16.0</jackson.version>');
+		});
+	});
+
+	suite('unchanged dependencies', () => {
+
+		/** Verifies that dependencies not listed in versionChanges are left untouched. */
+		test('leaves dependencies not in versionChanges untouched', () => {
+			// Given
+			const pom = loadFixture('pom_direct_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'lib-a', newVersion: '2.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(1);
+			// lib-b and unchanged-lib should retain their original versions
+			expect(result.content).to.include(
+				'<artifactId>lib-b</artifactId>\n            <version>2.3.4</version>'
+			);
+			expect(result.content).to.include(
+				'<artifactId>unchanged-lib</artifactId>\n            <version>3.0.0</version>'
+			);
+		});
+	});
+
+	suite('error handling', () => {
+
+		/** Verifies that malformed XML is handled gracefully without crashing. */
+		test('handles malformed pom.xml gracefully', () => {
+			// Given — fast-xml-parser v5 parses incomplete XML without throwing,
+			// so the fail-safe path is: dependency not found => skipped
+			const pom = loadFixture('pom_malformed.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'broken', newVersion: '1.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(0);
+			expect(result.skipped).to.have.lengthOf(1);
+			expect(result.skipped[0].reason).to.be.a('string');
+			expect(result.content).to.equal(pom);
+		});
+
+		/** Verifies that a dependency not present in the file is reported as skipped. */
+		test('reports missing dependency in skipped', () => {
+			// Given
+			const pom = loadFixture('pom_direct_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.nonexistent', artifactId: 'ghost-lib', newVersion: '1.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(0);
+			expect(result.skipped).to.have.lengthOf(1);
+			expect(result.skipped[0].reason).to.include('not found');
+		});
+
+		/** Verifies that a property reference to a non-existent property is skipped. */
+		test('reports missing property in skipped', () => {
+			// Given a pom with a dependency referencing a non-existent property
+			const pom = [
+				'<?xml version="1.0"?>',
+				'<project>',
+				'    <properties></properties>',
+				'    <dependencies>',
+				'        <dependency>',
+				'            <groupId>com.example</groupId>',
+				'            <artifactId>ghost-prop-lib</artifactId>',
+				'            <version>${nonexistent.version}</version>',
+				'        </dependency>',
+				'    </dependencies>',
+				'</project>',
+			].join('\n');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'ghost-prop-lib', newVersion: '1.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(0);
+			expect(result.skipped).to.have.lengthOf(1);
+			expect(result.skipped[0].reason).to.include("'nonexistent.version'");
+			expect(result.skipped[0].reason).to.include('not found');
+		});
+
+		/** Verifies that empty versionChanges returns the content unchanged. */
+		test('returns unchanged content for empty versionChanges', () => {
+			// Given
+			const pom = loadFixture('pom_direct_versions.xml');
+
+			// When
+			const result = updateMavenVersions(pom, []);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(0);
+			expect(result.skipped).to.have.lengthOf(0);
+			expect(result.content).to.equal(pom);
+		});
+
+		/** Verifies that pom.xml without a <project> element skips all changes. */
+		test('skips all changes when no <project> element exists', () => {
+			// Given
+			const pom = '<?xml version="1.0"?>\n<root><thing>value</thing></root>';
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'lib', newVersion: '1.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(0);
+			expect(result.skipped).to.have.lengthOf(1);
+			expect(result.skipped[0].reason).to.include('No <project> element');
+			expect(result.content).to.equal(pom);
+		});
+	});
+
+	suite('idempotency', () => {
+
+		/** Verifies that running updateMavenVersions twice with the same input is idempotent. */
+		test('running twice with same input produces same output', () => {
+			// Given
+			const pom = loadFixture('pom_direct_versions.xml');
+			const changes = [
+				{ groupId: 'com.example', artifactId: 'lib-a', newVersion: '2.0.0' },
+				{ groupId: 'com.example', artifactId: 'lib-b', newVersion: '3.0.0' },
+			];
+
+			// When
+			const first = updateMavenVersions(pom, changes);
+			const second = updateMavenVersions(first.content, changes);
+
+			// Then
+			expect(second.content).to.equal(first.content);
+			expect(second.applied).to.have.lengthOf(2);
+			expect(second.skipped).to.have.lengthOf(0);
+		});
+
+		/** Verifies idempotency for property-based versions. */
+		test('running twice with property versions produces same output', () => {
+			// Given
+			const pom = loadFixture('pom_property_versions.xml');
+			const changes = [
+				{ groupId: 'com.fasterxml.jackson.core', artifactId: 'jackson-databind', newVersion: '2.16.0' },
+			];
+
+			// When
+			const first = updateMavenVersions(pom, changes);
+			const second = updateMavenVersions(first.content, changes);
+
+			// Then
+			expect(second.content).to.equal(first.content);
+		});
+	});
+
+	suite('dependencyManagement support', () => {
+
+		/** Verifies that versions in <dependencyManagement> are updated. */
+		test('updates version in dependencyManagement section', () => {
+			// Given
+			const pom = [
+				'<?xml version="1.0"?>',
+				'<project>',
+				'    <dependencyManagement>',
+				'        <dependencies>',
+				'            <dependency>',
+				'                <groupId>com.example</groupId>',
+				'                <artifactId>managed-lib</artifactId>',
+				'                <version>1.0.0</version>',
+				'            </dependency>',
+				'        </dependencies>',
+				'    </dependencyManagement>',
+				'    <dependencies>',
+				'        <dependency>',
+				'            <groupId>com.example</groupId>',
+				'            <artifactId>managed-lib</artifactId>',
+				'        </dependency>',
+				'    </dependencies>',
+				'</project>',
+			].join('\n');
+
+			// When
+			const result = updateMavenVersions(pom, [
+				{ groupId: 'com.example', artifactId: 'managed-lib', newVersion: '2.0.0' },
+			]);
+
+			// Then
+			expect(result.applied).to.have.lengthOf(1);
+			expect(result.content).to.include('<version>2.0.0</version>');
+			expect(result.content).not.to.include('<version>1.0.0</version>');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- New `src/updaters/maven_updater.js` module with `updateMavenVersions()` API
- Position-based string splice preserves all formatting, comments, whitespace
- Supports `${property}` indirection with recursive resolution and cycle detection
- Handles `<dependencyManagement>` sections
- 17 new tests, 6 fixture pom.xml files, 89% line coverage

Implements [TC-5411](https://redhat.atlassian.net/browse/TC-5411)

## Test plan
- [x] Direct version replacement
- [x] Property-based version replacement
- [x] Recursive property chain resolution
- [x] Circular property detection and skip
- [x] Formatting/comment preservation
- [x] Malformed XML fail-safe
- [x] Idempotency verification
- [x] `npm run lint` passes
- [x] `npm test` passes

[TC-5411]: https://redhat.atlassian.net/browse/TC-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add a Maven pom.xml updater that performs structure-aware, formatting-preserving dependency version updates with robust handling of property indirection and edge cases, backed by comprehensive tests and fixtures.

New Features:
- Introduce a Maven pom.xml updater that updates dependency versions by groupId/artifactId while preserving file formatting and comments
- Support version updates via Maven property references, including recursive property chains and dependencyManagement entries

Enhancements:
- Detect and skip circular or conflicting property-based version updates, reporting detailed reasons for skipped changes
- Ensure idempotent behavior and graceful handling of malformed or non-standard pom.xml structures

Tests:
- Add a comprehensive maven_updater test suite with fixtures covering direct versions, property indirection, recursive and circular properties, formatting preservation, error handling, idempotency, and dependencyManagement support