### PR TITLE
docs: add CLI command authoring conventions to CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -73,6 +73,15 @@ test/
 - **Async errors**: Bubble up naturally via async/await (no blanket try-catch)
 - **Validation errors**: Thrown early with descriptive context (manifest type, lock file)
 
+## CLI Commands
+
+New yargs commands in `src/cli.js` must follow the patterns established by the existing commands (`component`, `stack`, `stack-batch`, `image`, `validate-token`, `license`, `sbom`). Read those commands before adding a new one.
+
+Two things that are not obvious from reading siblings:
+
+- **Mutually exclusive flags**: use yargs `conflicts` (e.g., `conflicts: 'summary'`). Do not set `default: false` on conflicting boolean options — yargs treats defaulted booleans as "present" and fires the conflict on every invocation.
+- **Provider/source option wording**: include the env var reference in the description: `'Comma-separated list of vulnerability providers (env: TRUSTIFY_DA_PROVIDERS)'`. This ensures `--help` output tells users about the env var alternative.
+
 ## Testing Conventions
 
 - **Framework**: Mocha with TDD UI (`suite()` / `test()`)


### PR DESCRIPTION
## Summary
- Document CLI command authoring conventions in CONVENTIONS.md
- Cover two non-obvious patterns: yargs `conflicts` for mutually exclusive flags (and why `default: false` breaks it), and provider/source option wording with env var references in `--help` output

Implements [TC-5560](https://redhat.atlassian.net/browse/TC-5560)

## Test plan
- [x] No code changes — documentation only
- [x] Conventions match the patterns used by existing CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-5560]: https://redhat.atlassian.net/browse/TC-5560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ